### PR TITLE
fix: cap requires-python <3.14 to resolve mootdx/httpx dependency con…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "quent"
 version = "3.0.0"
 description = "AI-Powered Quantitative Trading Platform"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.14"
 dependencies = [
     # Core dependencies
     "akshare>=1.18.12",


### PR DESCRIPTION
…flict

mootdx pins httpx<0.26.0 which conflicts with httpx>=0.28.0 on Python 3.14. Cap the supported range until mootdx releases a compatible version.