### PR TITLE
feat(brooks): add Signal/Decision/Order Pydantic schemas (QUA-38)

### DIFF
--- a/src/brooks/__init__.py
+++ b/src/brooks/__init__.py
@@ -1,0 +1,9 @@
+"""Brooks price-action trading primitives.
+
+Top-level package for the Brooks-style multi-stage trading pipeline
+(detector → analyst → aggregator → TE → risk → execution).
+"""
+
+from src.brooks.schema import Decision, Order, Signal
+
+__all__ = ["Signal", "Decision", "Order"]

--- a/src/brooks/schema.py
+++ b/src/brooks/schema.py
@@ -1,0 +1,69 @@
+"""Unified Pydantic schemas for the Brooks pipeline.
+
+These models form the single data contract shared by detectors, analysts,
+aggregators, the Trader's Equation evaluator, the risk layer, and the
+execution engine.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class Signal(BaseModel):
+    """A pattern-detection signal produced by a rule/LLM/VLM detector."""
+
+    pattern: str
+    side: Literal["long", "short"]
+    signal_bar_idx: int
+    entry_px: float = Field(gt=0)
+    stop_px: float = Field(gt=0)
+    target_px: Optional[float] = None
+    probability: float = Field(ge=0, le=1)
+    quality: float = Field(ge=0, le=1)
+    reasoning: str = ""
+    source: str
+    meta: dict = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _entry_differs_from_stop(self) -> "Signal":
+        if self.entry_px == self.stop_px:
+            raise ValueError("entry_px must differ from stop_px")
+        return self
+
+    @property
+    def one_r(self) -> float:
+        """Absolute per-share risk (|entry − stop|)."""
+        return abs(self.entry_px - self.stop_px)
+
+
+class Decision(BaseModel):
+    """An analyst's trading decision derived from one or more Signals."""
+
+    symbol: str
+    side: Literal["long", "short"]
+    entry_px: float
+    stop_px: float
+    target_px: float
+    quantity: float = 0.0
+    probability: float = Field(ge=0, le=1)
+    expected_r: float
+    regime: str
+    htf_aligned: bool
+    signals: list[Signal] = Field(default_factory=list)
+    source: str
+    reasoning: str = ""
+
+
+class Order(BaseModel):
+    """A concrete broker order ready for execution."""
+
+    symbol: str
+    side: Literal["buy", "sell", "sell_short", "buy_to_cover"]
+    quantity: float = Field(gt=0)
+    type: Literal["market", "stop", "limit"]
+    price: Optional[float] = None
+    reason: str = ""
+    decision_ref: Optional[str] = None

--- a/tests/brooks/test_schema.py
+++ b/tests/brooks/test_schema.py
@@ -1,0 +1,164 @@
+"""Tests for src/brooks/schema.py — Signal, Decision, Order contracts."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from src.brooks.schema import Decision, Order, Signal
+
+
+def _valid_signal(**overrides) -> Signal:
+    base = dict(
+        pattern="h2",
+        side="long",
+        signal_bar_idx=42,
+        entry_px=100.0,
+        stop_px=98.0,
+        target_px=104.0,
+        probability=0.6,
+        quality=0.8,
+        reasoning="pullback to EMA20",
+        source="rule:h2",
+        meta={"latency_ms": 3},
+    )
+    base.update(overrides)
+    return Signal(**base)
+
+
+def test_signal_valid_and_one_r():
+    sig = _valid_signal()
+    assert sig.one_r == pytest.approx(2.0)
+    assert sig.side == "long"
+    assert sig.source == "rule:h2"
+    assert sig.meta["latency_ms"] == 3
+
+
+@pytest.mark.parametrize(
+    "field, value, err_fragment",
+    [
+        ("entry_px", 0.0, "greater than 0"),
+        ("entry_px", -1.0, "greater than 0"),
+        ("stop_px", 0.0, "greater than 0"),
+        ("probability", 1.5, "less than or equal to 1"),
+        ("probability", -0.1, "greater than or equal to 0"),
+        ("quality", 2.0, "less than or equal to 1"),
+        ("side", "flat", "Input should be"),
+    ],
+)
+def test_signal_invalid_field_values(field, value, err_fragment):
+    with pytest.raises(ValidationError) as exc:
+        _valid_signal(**{field: value})
+    assert err_fragment in str(exc.value)
+
+
+def test_signal_entry_must_differ_from_stop():
+    with pytest.raises(ValidationError) as exc:
+        _valid_signal(entry_px=100.0, stop_px=100.0)
+    assert "entry_px must differ from stop_px" in str(exc.value)
+
+
+def test_signal_round_trip():
+    sig = _valid_signal()
+    dumped = sig.model_dump()
+    restored = Signal(**dumped)
+    assert restored == sig
+    json_bytes = sig.model_dump_json()
+    restored_json = Signal.model_validate_json(json_bytes)
+    assert restored_json == sig
+
+
+def test_signal_json_schema_export():
+    schema = Signal.model_json_schema()
+    assert schema["title"] == "Signal"
+    props = schema["properties"]
+    for key in (
+        "pattern",
+        "side",
+        "signal_bar_idx",
+        "entry_px",
+        "stop_px",
+        "target_px",
+        "probability",
+        "quality",
+        "source",
+        "meta",
+    ):
+        assert key in props
+    assert props["entry_px"]["exclusiveMinimum"] == 0
+    assert props["probability"]["minimum"] == 0
+    assert props["probability"]["maximum"] == 1
+
+
+def test_decision_valid_with_nested_signals_round_trip():
+    sig = _valid_signal()
+    dec = Decision(
+        symbol="BTCUSDT",
+        side="long",
+        entry_px=100.0,
+        stop_px=98.0,
+        target_px=106.0,
+        quantity=1.5,
+        probability=0.55,
+        expected_r=1.2,
+        regime="bull_trend",
+        htf_aligned=True,
+        signals=[sig],
+        source="analyst.trend_follower",
+        reasoning="aligned H2 with HTF uptrend",
+    )
+    dumped = dec.model_dump()
+    restored = Decision(**dumped)
+    assert restored == dec
+    assert restored.signals[0].one_r == pytest.approx(2.0)
+
+
+def test_decision_probability_bounds():
+    with pytest.raises(ValidationError):
+        Decision(
+            symbol="BTCUSDT",
+            side="long",
+            entry_px=100.0,
+            stop_px=98.0,
+            target_px=106.0,
+            probability=1.01,
+            expected_r=1.0,
+            regime="bull_trend",
+            htf_aligned=True,
+            source="analyst.trend_follower",
+        )
+
+
+def test_order_valid_round_trip_and_defaults():
+    order = Order(
+        symbol="AAPL",
+        side="buy",
+        quantity=10.0,
+        type="limit",
+        price=150.0,
+        reason="decision entry",
+        decision_ref="7b3f1e62-5d4e-4f56-9a8d-2e9e4a3b1c77",
+    )
+    dumped = order.model_dump()
+    assert Order(**dumped) == order
+
+    market_order = Order(symbol="AAPL", side="sell", quantity=1.0, type="market")
+    assert market_order.price is None
+    assert market_order.reason == ""
+    assert market_order.decision_ref is None
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("quantity", 0.0),
+        ("quantity", -5.0),
+        ("side", "hold"),
+        ("type", "twap"),
+    ],
+)
+def test_order_invalid_field_values(field, value):
+    kwargs = dict(symbol="AAPL", side="buy", quantity=1.0, type="market")
+    kwargs[field] = value
+    with pytest.raises(ValidationError):
+        Order(**kwargs)


### PR DESCRIPTION
## Summary
- Introduces `src/brooks/schema.py` — the unified Pydantic data contract shared across the Brooks pipeline (detector / analyst / aggregator / TE / risk / execution).
- Defines `Signal` (with `one_r` property and `entry_px != stop_px` validator), `Decision`, and `Order` models matching the interface spec in QUA-38.
- Adds `tests/brooks/test_schema.py` with 18 tests covering construction, bounds, round-trip, JSON-schema export, and validator edge cases.

Closes QUA-38.

## Test plan
- [x] `pytest tests/brooks/test_schema.py` — 18 passed
- [x] `ruff check src/brooks tests/brooks` — clean
- [x] `ruff format --check src/brooks tests/brooks` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)