### PR TITLE
feat(brooks): copy L1/L2 features + structure to src/brooks/ (Phase 2.1)

### DIFF
--- a/src/brooks/__init__.py
+++ b/src/brooks/__init__.py
@@ -4,6 +4,26 @@ Top-level package for the Brooks-style multi-stage trading pipeline
 (detector → analyst → aggregator → TE → risk → execution).
 """
 
+from src.brooks.features import (
+    BarFeatureExtractor,
+    ExtendedBarFeatures,
+    SwingPoint,
+)
 from src.brooks.schema import Decision, Order, Signal
+from src.brooks.structure import (
+    ChannelFit,
+    MarketStructure,
+    MarketStructureTracker,
+)
 
-__all__ = ["Signal", "Decision", "Order"]
+__all__ = [
+    "BarFeatureExtractor",
+    "ChannelFit",
+    "Decision",
+    "ExtendedBarFeatures",
+    "MarketStructure",
+    "MarketStructureTracker",
+    "Order",
+    "Signal",
+    "SwingPoint",
+]

--- a/src/brooks/features.py
+++ b/src/brooks/features.py
@@ -1,0 +1,351 @@
+"""L1 — Extended bar features for Brooks price action.
+
+Builds on `src.analysis.bar_features` (`BarFeatures`) by adding time-series features
+required by the higher layers:
+
+- K-bar fractal swing detection (with ``confirmed_as_of_idx`` to prevent look-ahead)
+- Breakout flags (N-bar high/low)
+- Consecutive bull/bear bar counters
+- EMA/ATR distance
+- Current leg length
+- Gap up / down
+
+Design notes
+------------
+* Features are computed with a *streaming* ``BarFeatureExtractor`` — internal state is
+  an append-only bar buffer; ``on_bar(bar)`` returns the ``ExtendedBarFeatures`` for
+  the latest bar plus any newly *confirmed* swing points.
+* Swing confirmation lags ``K`` bars by definition: we only know bar ``i`` is a swing
+  high once we've seen ``K`` bars after it without exceeding ``high[i]``. Consumers
+  (L2/L3) must only use swings whose ``confirmed_at_idx <= current_idx``.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Deque, List, Literal, Optional
+
+
+@dataclass
+class ExtendedBarFeatures:
+    """Per-bar numeric features (no look-ahead)."""
+
+    bar_idx: int
+    timestamp_ns: int  # unix ns — avoid datetime serialization
+
+    open: float
+    high: float
+    low: float
+    close: float
+
+    body_pct: int  # 0..100 — fraction of range taken by body
+    is_bull: bool
+    is_trend: bool  # body_pct > 50
+    is_doji: bool  # body_pct <= 10
+    is_inside_bar: bool
+    is_outside_bar: bool
+    is_reversal_bar: bool  # >= 40% wick
+    close_position: Literal["high", "mid", "low"]
+
+    ema20: float
+    atr14: float
+    ema_atr_distance: float  # (close - ema) / atr
+    ema_relation: Literal["above", "at", "below"]
+
+    is_breakout_up_20: bool
+    is_breakout_down_20: bool
+    consecutive_bull_bars: int
+    consecutive_bear_bars: int
+
+    leg_length: int  # # of bars in current same-direction leg
+    leg_dir: Literal["up", "down", "flat"]
+
+    gap_up: bool
+    gap_down: bool
+
+    def to_dict(self) -> dict:
+        return {
+            "bar_idx": self.bar_idx,
+            "timestamp_ns": self.timestamp_ns,
+            "open": self.open,
+            "high": self.high,
+            "low": self.low,
+            "close": self.close,
+            "body_pct": self.body_pct,
+            "is_bull": self.is_bull,
+            "is_trend": self.is_trend,
+            "is_doji": self.is_doji,
+            "is_inside_bar": self.is_inside_bar,
+            "is_outside_bar": self.is_outside_bar,
+            "is_reversal_bar": self.is_reversal_bar,
+            "close_position": self.close_position,
+            "ema20": round(self.ema20, 6),
+            "atr14": round(self.atr14, 6),
+            "ema_atr_distance": round(self.ema_atr_distance, 4),
+            "ema_relation": self.ema_relation,
+            "is_breakout_up_20": self.is_breakout_up_20,
+            "is_breakout_down_20": self.is_breakout_down_20,
+            "consecutive_bull_bars": self.consecutive_bull_bars,
+            "consecutive_bear_bars": self.consecutive_bear_bars,
+            "leg_length": self.leg_length,
+            "leg_dir": self.leg_dir,
+            "gap_up": self.gap_up,
+            "gap_down": self.gap_down,
+        }
+
+
+@dataclass
+class SwingPoint:
+    """A confirmed (past) swing high or low.
+
+    ``bar_idx`` is the index of the actual pivot bar; ``confirmed_at_idx`` is the
+    index of the bar at which this swing became confirmed (always bar_idx + K).
+    """
+
+    bar_idx: int
+    price: float
+    kind: Literal["high", "low"]
+    confirmed_at_idx: int
+    timestamp_ns: int = 0
+
+    def to_dict(self) -> dict:
+        return {
+            "bar_idx": self.bar_idx,
+            "price": round(self.price, 6),
+            "kind": self.kind,
+            "confirmed_at_idx": self.confirmed_at_idx,
+            "timestamp_ns": self.timestamp_ns,
+        }
+
+
+@dataclass
+class _BarCache:
+    """Minimal bar record held in the streaming buffer."""
+
+    idx: int
+    ts_ns: int
+    open: float
+    high: float
+    low: float
+    close: float
+
+
+class BarFeatureExtractor:
+    """Stream features bar-by-bar.
+
+    Call :meth:`on_bar` once per completed bar (never on an in-progress bar).
+    """
+
+    def __init__(
+        self,
+        swing_k: int = 3,
+        ema_period: int = 20,
+        atr_period: int = 14,
+        breakout_lookback: int = 20,
+    ):
+        if swing_k < 1:
+            raise ValueError("swing_k must be >= 1")
+        self.swing_k = swing_k
+        self.ema_period = ema_period
+        self.atr_period = atr_period
+        self.breakout_lookback = breakout_lookback
+
+        self._bars: List[_BarCache] = []
+        self._ema: Optional[float] = None
+        self._atr: Optional[float] = None
+        self._atr_warm: Deque[float] = deque(maxlen=atr_period)
+
+        self._consec_bull = 0
+        self._consec_bear = 0
+        self._leg_dir: Literal["up", "down", "flat"] = "flat"
+        self._leg_start_idx = 0
+
+        self.confirmed_swings: List[SwingPoint] = []
+        self._last_confirmed_swing_high: Optional[SwingPoint] = None
+        self._last_confirmed_swing_low: Optional[SwingPoint] = None
+
+    # ---- public API -----------------------------------------------------
+
+    @property
+    def bar_count(self) -> int:
+        return len(self._bars)
+
+    def on_bar(self, ts_ns: int, o: float, h: float, l: float, c: float) -> ExtendedBarFeatures:
+        """Ingest a bar, return features. Look-ahead free."""
+        idx = len(self._bars)
+        prev = self._bars[-1] if self._bars else None
+
+        self._update_ema(c)
+        self._update_atr(h, l, prev.close if prev else c)
+
+        is_bull = c >= o
+        rng = h - l
+        body = abs(c - o)
+        body_pct = int(body / rng * 100) if rng > 0 else 0
+        is_trend = body_pct > 50
+        is_doji = body_pct <= 10
+
+        if rng > 0:
+            pos = (c - l) / rng
+            close_position: Literal["high", "mid", "low"] = "high" if pos >= 0.67 else "low" if pos <= 0.33 else "mid"
+        else:
+            close_position = "mid"
+
+        is_inside = prev is not None and h <= prev.high and l >= prev.low
+        is_outside = prev is not None and h > prev.high and l < prev.low
+        if rng > 0:
+            upper_wick = h - max(o, c)
+            lower_wick = min(o, c) - l
+            is_reversal = upper_wick >= 0.4 * rng or lower_wick >= 0.4 * rng
+        else:
+            is_reversal = False
+
+        ema = self._ema if self._ema is not None else c
+        atr = self._atr if self._atr is not None else max(rng, 1e-9)
+        ema_atr_dist = (c - ema) / atr if atr > 0 else 0.0
+        ema_rel: Literal["above", "at", "below"] = (
+            "above" if ema_atr_dist > 0.3 else "below" if ema_atr_dist < -0.3 else "at"
+        )
+
+        lookback_start = max(0, idx - self.breakout_lookback)
+        window = self._bars[lookback_start:idx]  # excludes current bar
+        if window:
+            prior_high = max(b.high for b in window)
+            prior_low = min(b.low for b in window)
+            is_breakout_up = h > prior_high
+            is_breakout_down = l < prior_low
+        else:
+            is_breakout_up = False
+            is_breakout_down = False
+
+        if is_bull:
+            self._consec_bull += 1
+            self._consec_bear = 0
+        else:
+            self._consec_bear += 1
+            self._consec_bull = 0
+
+        leg_dir, leg_length = self._update_leg(idx, h, l, prev)
+
+        gap_up = prev is not None and o > prev.high
+        gap_down = prev is not None and o < prev.low
+
+        self._bars.append(_BarCache(idx=idx, ts_ns=ts_ns, open=o, high=h, low=l, close=c))
+        self._confirm_swings()
+
+        return ExtendedBarFeatures(
+            bar_idx=idx,
+            timestamp_ns=ts_ns,
+            open=o,
+            high=h,
+            low=l,
+            close=c,
+            body_pct=body_pct,
+            is_bull=is_bull,
+            is_trend=is_trend,
+            is_doji=is_doji,
+            is_inside_bar=is_inside,
+            is_outside_bar=is_outside,
+            is_reversal_bar=is_reversal,
+            close_position=close_position,
+            ema20=ema,
+            atr14=atr,
+            ema_atr_distance=ema_atr_dist,
+            ema_relation=ema_rel,
+            is_breakout_up_20=is_breakout_up,
+            is_breakout_down_20=is_breakout_down,
+            consecutive_bull_bars=self._consec_bull,
+            consecutive_bear_bars=self._consec_bear,
+            leg_length=leg_length,
+            leg_dir=leg_dir,
+            gap_up=gap_up,
+            gap_down=gap_down,
+        )
+
+    def bars_since_last_swing(self, kind: Literal["high", "low"], current_idx: int) -> Optional[int]:
+        swing = self._last_confirmed_swing_high if kind == "high" else self._last_confirmed_swing_low
+        if swing is None or swing.confirmed_at_idx > current_idx:
+            return None
+        return current_idx - swing.bar_idx
+
+    def last_confirmed_swings(
+        self, current_idx: int, n: int = 10, kind: Optional[Literal["high", "low"]] = None
+    ) -> List[SwingPoint]:
+        out = [s for s in self.confirmed_swings if s.confirmed_at_idx <= current_idx]
+        if kind is not None:
+            out = [s for s in out if s.kind == kind]
+        return out[-n:]
+
+    # ---- internals ------------------------------------------------------
+
+    def _update_ema(self, close: float) -> None:
+        alpha = 2.0 / (self.ema_period + 1)
+        if self._ema is None:
+            self._ema = close
+        else:
+            self._ema = alpha * close + (1 - alpha) * self._ema
+
+    def _update_atr(self, high: float, low: float, prev_close: float) -> None:
+        tr = max(high - low, abs(high - prev_close), abs(low - prev_close))
+        self._atr_warm.append(tr)
+        if self._atr is None:
+            if len(self._atr_warm) >= self.atr_period:
+                self._atr = sum(self._atr_warm) / self.atr_period
+        else:
+            self._atr = (self._atr * (self.atr_period - 1) + tr) / self.atr_period
+
+    def _update_leg(
+        self, idx: int, h: float, l: float, prev: Optional[_BarCache]
+    ) -> tuple[Literal["up", "down", "flat"], int]:
+        if prev is None:
+            self._leg_dir = "flat"
+            self._leg_start_idx = idx
+            return "flat", 1
+
+        going_up = h > prev.high and l >= prev.low
+        going_down = l < prev.low and h <= prev.high
+
+        if going_up and self._leg_dir != "up":
+            self._leg_dir = "up"
+            self._leg_start_idx = idx
+        elif going_down and self._leg_dir != "down":
+            self._leg_dir = "down"
+            self._leg_start_idx = idx
+        elif not going_up and not going_down:
+            pass  # inside / outside bar — preserve leg direction but don't extend length
+
+        return self._leg_dir, max(1, idx - self._leg_start_idx + 1)
+
+    def _confirm_swings(self) -> None:
+        """Promote fractal pivots to confirmed swings once K bars have passed."""
+        K = self.swing_k
+        if len(self._bars) < 2 * K + 1:
+            return
+        # Candidate pivot = bar at position (len - K - 1); we now have K bars on both sides.
+        pivot_idx = len(self._bars) - K - 1
+        pivot = self._bars[pivot_idx]
+        left = self._bars[pivot_idx - K : pivot_idx]
+        right = self._bars[pivot_idx + 1 : pivot_idx + 1 + K]
+
+        if all(pivot.high >= b.high for b in left) and all(pivot.high > b.high for b in right):
+            sp = SwingPoint(
+                bar_idx=pivot.idx,
+                price=pivot.high,
+                kind="high",
+                confirmed_at_idx=pivot.idx + K,
+                timestamp_ns=pivot.ts_ns,
+            )
+            self.confirmed_swings.append(sp)
+            self._last_confirmed_swing_high = sp
+
+        if all(pivot.low <= b.low for b in left) and all(pivot.low < b.low for b in right):
+            sp = SwingPoint(
+                bar_idx=pivot.idx,
+                price=pivot.low,
+                kind="low",
+                confirmed_at_idx=pivot.idx + K,
+                timestamp_ns=pivot.ts_ns,
+            )
+            self.confirmed_swings.append(sp)
+            self._last_confirmed_swing_low = sp

--- a/src/brooks/structure.py
+++ b/src/brooks/structure.py
@@ -1,0 +1,190 @@
+"""L2 — Market structure built on top of confirmed swings.
+
+Tracks the Brooks-style *structural* state of the market:
+
+- Always-in long/short/neutral (bull/bear breakout of prior N-bar extremes)
+- Current leg direction and start index
+- Latest confirmed swing-high and swing-low (for stop-placement, trailing)
+- Micro-channel fit on the most recent leg (least-squares on extremes)
+
+All state is *confirmed-as-of now*: only swings whose ``confirmed_at_idx <= now``
+are consulted, eliminating look-ahead.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Literal, Optional
+
+from .features import BarFeatureExtractor, ExtendedBarFeatures, SwingPoint
+
+
+@dataclass
+class ChannelFit:
+    """Linear channel slope/intercept on a leg."""
+
+    slope: float
+    intercept: float
+    start_idx: int
+    end_idx: int
+    kind: Literal["top", "bottom"]
+
+    def project(self, idx: int) -> float:
+        return self.slope * idx + self.intercept
+
+    def to_dict(self) -> dict:
+        return {
+            "slope": round(self.slope, 8),
+            "intercept": round(self.intercept, 6),
+            "start_idx": self.start_idx,
+            "end_idx": self.end_idx,
+            "kind": self.kind,
+        }
+
+
+@dataclass
+class MarketStructure:
+    """Structural view updated once per bar."""
+
+    current_idx: int = -1
+    ema20: float = 0.0
+    atr14: float = 0.0
+
+    confirmed_swing_highs: List[SwingPoint] = field(default_factory=list)
+    confirmed_swing_lows: List[SwingPoint] = field(default_factory=list)
+
+    always_in: Literal["long", "short", "neutral"] = "neutral"
+    breakout_state: Literal["bull_breakout", "bear_breakout", "none"] = "none"
+
+    current_leg_dir: Literal["up", "down", "flat"] = "flat"
+    current_leg_start_idx: int = 0
+    current_leg_length: int = 0
+
+    micro_channel_top: Optional[ChannelFit] = None
+    micro_channel_bot: Optional[ChannelFit] = None
+
+    last_close: float = 0.0
+    last_high: float = 0.0
+    last_low: float = 0.0
+    last_breakout_lookback_high: float = 0.0
+    last_breakout_lookback_low: float = 0.0
+
+    def to_dict(self) -> dict:
+        return {
+            "current_idx": self.current_idx,
+            "ema20": round(self.ema20, 6),
+            "atr14": round(self.atr14, 6),
+            "always_in": self.always_in,
+            "breakout_state": self.breakout_state,
+            "current_leg_dir": self.current_leg_dir,
+            "current_leg_start_idx": self.current_leg_start_idx,
+            "current_leg_length": self.current_leg_length,
+            "last_swing_high": self.confirmed_swing_highs[-1].to_dict() if self.confirmed_swing_highs else None,
+            "last_swing_low": self.confirmed_swing_lows[-1].to_dict() if self.confirmed_swing_lows else None,
+            "micro_channel_top": self.micro_channel_top.to_dict() if self.micro_channel_top else None,
+            "micro_channel_bot": self.micro_channel_bot.to_dict() if self.micro_channel_bot else None,
+        }
+
+
+class MarketStructureTracker:
+    """Consumes ``ExtendedBarFeatures`` output from ``BarFeatureExtractor``.
+
+    Responsibilities:
+      * maintain ``MarketStructure`` snapshot
+      * compute always-in via N-bar breakout (:attr:`breakout_lookback`)
+      * fit micro-channels on the current leg
+    """
+
+    def __init__(self, extractor: BarFeatureExtractor, breakout_lookback: int = 20):
+        self._ext = extractor
+        self.breakout_lookback = breakout_lookback
+        self.state = MarketStructure()
+        self._high_history: List[float] = []
+        self._low_history: List[float] = []
+
+    def on_features(self, feat: ExtendedBarFeatures) -> MarketStructure:
+        self.state.current_idx = feat.bar_idx
+        self.state.ema20 = feat.ema20
+        self.state.atr14 = feat.atr14
+        self.state.last_close = feat.close
+        self.state.last_high = feat.high
+        self.state.last_low = feat.low
+
+        self._high_history.append(feat.high)
+        self._low_history.append(feat.low)
+        if len(self._high_history) > self.breakout_lookback * 4:
+            # keep the working window a bit larger than lookback
+            self._high_history = self._high_history[-self.breakout_lookback * 2 :]
+            self._low_history = self._low_history[-self.breakout_lookback * 2 :]
+
+        self.state.current_leg_dir = feat.leg_dir
+        self.state.current_leg_length = feat.leg_length
+        self.state.current_leg_start_idx = feat.bar_idx - feat.leg_length + 1
+
+        # Snapshot confirmed swings visible as of this bar.
+        current = feat.bar_idx
+        confirmed = [s for s in self._ext.confirmed_swings if s.confirmed_at_idx <= current]
+        self.state.confirmed_swing_highs = [s for s in confirmed if s.kind == "high"]
+        self.state.confirmed_swing_lows = [s for s in confirmed if s.kind == "low"]
+
+        self._update_always_in(feat)
+        self._fit_micro_channels(feat)
+        return self.state
+
+    # ---- always-in resolver --------------------------------------------
+
+    def _update_always_in(self, feat: ExtendedBarFeatures) -> None:
+        N = self.breakout_lookback
+        if len(self._high_history) <= N:
+            return
+        prior_high = max(self._high_history[-N - 1 : -1])
+        prior_low = min(self._low_history[-N - 1 : -1])
+        self.state.last_breakout_lookback_high = prior_high
+        self.state.last_breakout_lookback_low = prior_low
+
+        if feat.close > prior_high:
+            self.state.always_in = "long"
+            self.state.breakout_state = "bull_breakout"
+        elif feat.close < prior_low:
+            self.state.always_in = "short"
+            self.state.breakout_state = "bear_breakout"
+        else:
+            # Don't flip on chop — hold prior always_in decision.
+            self.state.breakout_state = "none"
+
+    # ---- channel fit ---------------------------------------------------
+
+    def _fit_micro_channels(self, feat: ExtendedBarFeatures) -> None:
+        start = self.state.current_leg_start_idx
+        end = feat.bar_idx
+        if end - start < 3:
+            self.state.micro_channel_top = None
+            self.state.micro_channel_bot = None
+            return
+
+        n = end - start + 1
+        xs = list(range(start, end + 1))
+        tail = n
+        highs = self._high_history[-tail:]
+        lows = self._low_history[-tail:]
+
+        self.state.micro_channel_top = _least_squares(xs, highs, start, end, "top")
+        self.state.micro_channel_bot = _least_squares(xs, lows, start, end, "bottom")
+
+
+def _least_squares(
+    xs: List[int], ys: List[float], start: int, end: int, kind: Literal["top", "bottom"]
+) -> Optional[ChannelFit]:
+    n = len(xs)
+    if n < 2 or n != len(ys):
+        return None
+    sx = sum(xs)
+    sy = sum(ys)
+    sxx = sum(x * x for x in xs)
+    sxy = sum(x * y for x, y in zip(xs, ys))
+    denom = n * sxx - sx * sx
+    if denom == 0:
+        return None
+    slope = (n * sxy - sx * sy) / denom
+    intercept = (sy - slope * sx) / n
+    return ChannelFit(slope=slope, intercept=intercept, start_idx=start, end_idx=end, kind=kind)

--- a/tests/brooks/test_features.py
+++ b/tests/brooks/test_features.py
@@ -1,0 +1,55 @@
+"""L1 BarFeatureExtractor tests — focus on look-ahead free swings."""
+
+from __future__ import annotations
+
+from src.brooks.features import BarFeatureExtractor
+
+
+def test_swing_confirmed_after_k_bars_only():
+    ext = BarFeatureExtractor(swing_k=2, atr_period=3, breakout_lookback=3)
+    # a simple peak at idx 3
+    bars = [
+        (1, 1.0, 1.1, 0.9, 1.0),
+        (2, 1.05, 1.2, 1.0, 1.15),
+        (3, 1.15, 1.3, 1.1, 1.25),
+        (4, 1.25, 1.6, 1.15, 1.4),  # pivot: high = 1.6
+        (5, 1.35, 1.45, 1.2, 1.25),
+        (6, 1.2, 1.3, 1.05, 1.1),
+    ]
+    for ts, o, h, l, c in bars:
+        ext.on_bar(ts, o, h, l, c)
+    # Only the swing at idx 3 should be confirmed, confirmed_at_idx == 5
+    highs = [s for s in ext.confirmed_swings if s.kind == "high"]
+    assert len(highs) == 1
+    assert highs[0].bar_idx == 3
+    assert highs[0].confirmed_at_idx == 5
+    assert abs(highs[0].price - 1.6) < 1e-9
+
+
+def test_no_swing_before_k_bars_lag():
+    ext = BarFeatureExtractor(swing_k=3)
+    # 5 bars shouldn't produce any swing (2*K+1 = 7 minimum needed)
+    for i in range(5):
+        ext.on_bar(i, 100.0 + i, 100.5 + i, 99.5 + i, 100.0 + i)
+    assert ext.confirmed_swings == []
+
+
+def test_breakout_flags():
+    ext = BarFeatureExtractor(swing_k=2, atr_period=3, breakout_lookback=5)
+    # 5 bars around 100, then a break-up
+    for i in range(5):
+        ext.on_bar(i, 100.0, 100.5, 99.5, 100.0)
+    feat = ext.on_bar(5, 100.5, 102.0, 100.2, 101.9)
+    assert feat.is_breakout_up_20 is True
+    assert feat.is_breakout_down_20 is False
+
+
+def test_consecutive_bars_counter():
+    ext = BarFeatureExtractor(swing_k=2, atr_period=3, breakout_lookback=5)
+    for i in range(3):
+        ext.on_bar(i, 100.0, 101.0, 99.9, 100.5)  # bull
+    f = ext.on_bar(3, 100.5, 101.5, 100.4, 101.0)
+    assert f.consecutive_bull_bars == 4
+    f2 = ext.on_bar(4, 101.0, 101.2, 100.0, 100.1)  # bear
+    assert f2.consecutive_bear_bars == 1
+    assert f2.consecutive_bull_bars == 0

--- a/tests/brooks/test_structure.py
+++ b/tests/brooks/test_structure.py
@@ -1,0 +1,47 @@
+"""L2 MarketStructure tests."""
+
+from __future__ import annotations
+
+from src.brooks.features import BarFeatureExtractor
+from src.brooks.structure import MarketStructureTracker
+
+
+def test_always_in_long_on_breakout():
+    ext = BarFeatureExtractor(swing_k=2, breakout_lookback=5)
+    tr = MarketStructureTracker(ext, breakout_lookback=5)
+    # 5 bars hugging 100
+    for i in range(5):
+        f = ext.on_bar(i, 100.0, 100.5, 99.5, 100.0)
+        tr.on_features(f)
+    # break out above
+    f = ext.on_bar(5, 100.5, 102.5, 100.4, 102.3)
+    s = tr.on_features(f)
+    assert s.always_in == "long"
+    assert s.breakout_state == "bull_breakout"
+
+
+def test_always_in_short_on_breakdown():
+    ext = BarFeatureExtractor(swing_k=2, breakout_lookback=5)
+    tr = MarketStructureTracker(ext, breakout_lookback=5)
+    for i in range(5):
+        f = ext.on_bar(i, 100.0, 100.5, 99.5, 100.0)
+        tr.on_features(f)
+    f = ext.on_bar(5, 99.5, 99.6, 97.5, 97.7)
+    s = tr.on_features(f)
+    assert s.always_in == "short"
+    assert s.breakout_state == "bear_breakout"
+
+
+def test_always_in_sticky_during_chop():
+    """Once always-in is set, chop should not flip it."""
+    ext = BarFeatureExtractor(swing_k=2, breakout_lookback=5)
+    tr = MarketStructureTracker(ext, breakout_lookback=5)
+    for i in range(5):
+        f = ext.on_bar(i, 100.0, 100.5, 99.5, 100.0)
+        tr.on_features(f)
+    f = ext.on_bar(5, 100.5, 102.5, 100.4, 102.3)
+    tr.on_features(f)  # long
+    # a neutral bar
+    f = ext.on_bar(6, 102.0, 102.3, 101.5, 101.8)
+    s = tr.on_features(f)
+    assert s.always_in == "long"  # unchanged


### PR DESCRIPTION
## Summary
- Copy `ExtendedBarFeatures` / `SwingPoint` / `BarFeatureExtractor` from `src/analysis/brooks/features.py` → `src/brooks/features.py` (byte-identical)
- Copy `MarketStructure` / `MarketStructureTracker` / `ChannelFit` from `src/analysis/brooks/structure.py` → `src/brooks/structure.py` (byte-identical; relative `from .features import ...` stays valid)
- Re-export the new symbols from `src/brooks/__init__.py`
- Add parallel tests under `tests/brooks/test_features.py` and `tests/brooks/test_structure.py` (migrated from `tests/strategies/brooks_v2/`, only `src.analysis.brooks.*` → `src.brooks.*` import path change)
- Old files under `src/analysis/brooks/` are intentionally kept so `src/strategies/brooks_v2/` keeps working; they'll be deleted in the Phase 3 cutover.

Closes QUA-42.

## Test plan
- [x] `pytest tests/brooks/test_features.py tests/brooks/test_structure.py` → 7 passed
- [x] `pytest tests/strategies/brooks_v2/` → 17 passed (legacy path untouched)
- [x] `diff` between old and new `features.py` / `structure.py` shows no content changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)