### PR TITLE
feat(alpha/llm): Anthropic / OpenAI / Gemini providers + model registry (QUA-40)

### DIFF
--- a/config/llm/registry.yaml
+++ b/config/llm/registry.yaml
@@ -1,0 +1,109 @@
+# Frontier-model registry for `src/alpha/llm/registry.py::ModelRegistry.from_yaml()`.
+# Each entry: id (local handle), provider (anthropic|openai|gemini), api_id (vendor model id),
+# capability flags, and USD pricing per 1M tokens.
+
+models:
+  # ---- Anthropic ----------------------------------------------------------
+  - id: claude-opus-4-7
+    provider: anthropic
+    api_id: claude-opus-4-7
+    context_window: 200000
+    max_output: 32000
+    supports_image: true
+    supports_tool_use: true
+    supports_cache: true
+    cache_min_tokens: 1024
+    pricing:
+      input_per_1m: 15.00
+      output_per_1m: 75.00
+      cache_write_per_1m: 18.75
+      cache_read_per_1m: 1.50
+    notes: "Frontier reasoning / long-horizon planning."
+
+  - id: claude-sonnet-4-6
+    provider: anthropic
+    api_id: claude-sonnet-4-6
+    context_window: 200000
+    max_output: 32000
+    supports_image: true
+    supports_tool_use: true
+    supports_cache: true
+    cache_min_tokens: 1024
+    pricing:
+      input_per_1m: 3.00
+      output_per_1m: 15.00
+      cache_write_per_1m: 3.75
+      cache_read_per_1m: 0.30
+    notes: "Workhorse; best cost/quality balance for most analyst prompts."
+
+  - id: claude-haiku-4-5
+    provider: anthropic
+    api_id: claude-haiku-4-5
+    context_window: 200000
+    max_output: 16000
+    supports_image: true
+    supports_tool_use: true
+    supports_cache: true
+    cache_min_tokens: 2048
+    pricing:
+      input_per_1m: 1.00
+      output_per_1m: 5.00
+      cache_write_per_1m: 1.25
+      cache_read_per_1m: 0.10
+    notes: "Low-latency tier for high-QPS structured classification."
+
+  # ---- OpenAI -------------------------------------------------------------
+  - id: gpt-4.1
+    provider: openai
+    api_id: gpt-4.1
+    context_window: 1000000
+    max_output: 32000
+    supports_image: true
+    supports_tool_use: true
+    supports_cache: true
+    pricing:
+      input_per_1m: 2.00
+      output_per_1m: 8.00
+      cache_read_per_1m: 0.50
+    notes: "1M context; caching is automatic via prompt_tokens_details.cached_tokens."
+
+  - id: gpt-4.1-mini
+    provider: openai
+    api_id: gpt-4.1-mini
+    context_window: 1000000
+    max_output: 32000
+    supports_image: true
+    supports_tool_use: true
+    supports_cache: true
+    pricing:
+      input_per_1m: 0.40
+      output_per_1m: 1.60
+      cache_read_per_1m: 0.10
+
+  # ---- Gemini -------------------------------------------------------------
+  - id: gemini-2.5-pro
+    provider: gemini
+    api_id: gemini-2.5-pro
+    context_window: 2000000
+    max_output: 65536
+    supports_image: true
+    supports_tool_use: true
+    supports_cache: true
+    pricing:
+      input_per_1m: 1.25
+      output_per_1m: 10.00
+      cache_read_per_1m: 0.3125
+    notes: "2M context; explicit cached_content API recommended for reused prefixes."
+
+  - id: gemini-2.5-flash
+    provider: gemini
+    api_id: gemini-2.5-flash
+    context_window: 1000000
+    max_output: 65536
+    supports_image: true
+    supports_tool_use: true
+    supports_cache: true
+    pricing:
+      input_per_1m: 0.30
+      output_per_1m: 2.50
+      cache_read_per_1m: 0.075

--- a/src/alpha/llm/__init__.py
+++ b/src/alpha/llm/__init__.py
@@ -12,3 +12,4 @@ from .provider import (
     TextPart,
     Usage,
 )
+from .registry import ModelRegistry, ModelSpec, Pricing

--- a/src/alpha/llm/providers/__init__.py
+++ b/src/alpha/llm/providers/__init__.py
@@ -1,0 +1,15 @@
+"""Concrete LLM/VLM providers behind the unified `Provider` protocol.
+
+Anthropic / OpenAI / Gemini providers each implement `complete()` with structured
+output (schema-enforced), prompt caching metadata, and multimodal (text+image)
+input. SDK imports are deferred to provider `__init__` so the vendor packages are
+only required when the corresponding provider is actually instantiated.
+"""
+
+from __future__ import annotations
+
+from .anthropic import AnthropicProvider
+from .gemini import GeminiProvider
+from .openai import OpenAIProvider
+
+__all__ = ["AnthropicProvider", "OpenAIProvider", "GeminiProvider"]

--- a/src/alpha/llm/providers/_common.py
+++ b/src/alpha/llm/providers/_common.py
@@ -1,0 +1,89 @@
+"""Shared helpers for provider implementations."""
+
+from __future__ import annotations
+
+import base64
+import time
+from typing import Any
+
+from pydantic import BaseModel
+
+
+def pydantic_json_schema(schema: type[BaseModel]) -> dict[str, Any]:
+    """Return the plain JSON schema for a Pydantic v2 model."""
+    return schema.model_json_schema()
+
+
+def strict_openai_schema(schema: type[BaseModel]) -> dict[str, Any]:
+    """JSON schema shape accepted by OpenAI strict mode.
+
+    OpenAI's `response_format={"type": "json_schema", "strict": true}` requires
+    every object to declare `additionalProperties: false` and list every property
+    in `required`. Pydantic v2 emits `required` only for non-default fields, so
+    we tighten the schema recursively (including `$defs`).
+    """
+    js = schema.model_json_schema()
+    _tighten_objects(js)
+    for defn in (js.get("$defs") or {}).values():
+        _tighten_objects(defn)
+    return js
+
+
+def _tighten_objects(node: Any) -> None:
+    if not isinstance(node, dict):
+        return
+    if node.get("type") == "object" and isinstance(node.get("properties"), dict):
+        node["additionalProperties"] = False
+        node["required"] = list(node["properties"].keys())
+    for value in node.values():
+        if isinstance(value, dict):
+            _tighten_objects(value)
+        elif isinstance(value, list):
+            for item in value:
+                _tighten_objects(item)
+
+
+def encode_image_base64(data: bytes) -> str:
+    return base64.b64encode(data).decode("ascii")
+
+
+def get_attr(obj: Any, name: str, default: Any = None) -> Any:
+    """Uniform attribute / mapping accessor: works on dicts and SDK response objects."""
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+def raw_to_dict(raw: Any) -> dict[str, Any]:
+    """Best-effort conversion of a vendor SDK response to a plain dict."""
+    if isinstance(raw, dict):
+        return dict(raw)
+    for method_name in ("model_dump", "to_dict", "dict"):
+        method = getattr(raw, method_name, None)
+        if callable(method):
+            try:
+                dumped = method()
+            except Exception:
+                continue
+            if isinstance(dumped, dict):
+                return dumped
+    return {"repr": repr(raw)}
+
+
+class Timer:
+    """Context manager that captures wall-clock elapsed milliseconds."""
+
+    def __enter__(self) -> "Timer":
+        self._start = time.perf_counter()
+        self._end: float | None = None
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self._end = time.perf_counter()
+
+    @property
+    def elapsed_ms(self) -> float:
+        end = self._end if self._end is not None else time.perf_counter()
+        return (end - self._start) * 1000.0

--- a/src/alpha/llm/providers/anthropic.py
+++ b/src/alpha/llm/providers/anthropic.py
@@ -113,11 +113,7 @@ class AnthropicProvider:
             rendered_parts: list[dict[str, Any]] = []
             for pi, part in enumerate(message.content):
                 block = self._render_part(part)
-                if (
-                    part.cache is not None
-                    and part.cache in cache_blocks
-                    and last_for_block.get(part.cache) == (mi, pi)
-                ):
+                if part.cache is not None and part.cache in cache_blocks and last_for_block.get(part.cache) == (mi, pi):
                     block["cache_control"] = _cache_control(ttl_seconds)
                 rendered_parts.append(block)
 
@@ -128,9 +124,7 @@ class AnthropicProvider:
         return system_blocks, chat_messages
 
     @staticmethod
-    def _last_part_per_block(
-        messages: list[Message], cache_blocks: set[str]
-    ) -> dict[str, tuple[int, int]]:
+    def _last_part_per_block(messages: list[Message], cache_blocks: set[str]) -> dict[str, tuple[int, int]]:
         last: dict[str, tuple[int, int]] = {}
         for mi, msg in enumerate(messages):
             for pi, part in enumerate(msg.content):
@@ -161,9 +155,7 @@ class AnthropicProvider:
             if get_attr(block, "type") == "tool_use" and get_attr(block, "name") == _STRUCTURED_TOOL_NAME:
                 payload = get_attr(block, "input", {}) or {}
                 return schema.model_validate(payload)
-        raise ValueError(
-            f"Anthropic response contained no tool_use block named {_STRUCTURED_TOOL_NAME!r}"
-        )
+        raise ValueError(f"Anthropic response contained no tool_use block named {_STRUCTURED_TOOL_NAME!r}")
 
     @staticmethod
     def _extract_usage(raw: Any) -> Usage:

--- a/src/alpha/llm/providers/anthropic.py
+++ b/src/alpha/llm/providers/anthropic.py
@@ -1,0 +1,185 @@
+"""Anthropic Claude provider — Messages API + tool-use structured output + cache_control."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional, TypeVar
+
+from pydantic import BaseModel
+
+from ..cache import CacheSpec
+from ..provider import ImagePart, Message, Response, TextPart, Usage
+from ._common import (
+    Timer,
+    encode_image_base64,
+    get_attr,
+    pydantic_json_schema,
+    raw_to_dict,
+)
+
+T = TypeVar("T", bound=BaseModel)
+
+_STRUCTURED_TOOL_NAME = "respond"
+
+
+class AnthropicProvider:
+    """Anthropic Claude provider.
+
+    * Structured output: declares a single `respond` tool whose `input_schema`
+      mirrors the Pydantic class, and forces `tool_choice` to that tool so the
+      model returns a JSON object in `tool_use.input`.
+    * Prompt caching: for each `CacheSpec.blocks` name, the *last* content part
+      carrying that cache name is decorated with `cache_control={"type":
+      "ephemeral"}`. A 1-hour TTL is requested when `ttl_seconds >= 3600`.
+    * Images: rendered as `image` content blocks with base64 `source`.
+    """
+
+    name = "anthropic"
+
+    def __init__(
+        self,
+        model: str,
+        api_key: Optional[str] = None,
+        client: Any = None,
+    ) -> None:
+        self.model = model
+        self._api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
+        if client is not None:
+            self._client = client
+            return
+        if not self._api_key:
+            raise ValueError("ANTHROPIC_API_KEY missing for AnthropicProvider")
+        import anthropic
+
+        self._client = anthropic.AsyncAnthropic(api_key=self._api_key)
+
+    async def complete(
+        self,
+        messages: list[Message],
+        schema: type[T],
+        cache: Optional[CacheSpec] = None,
+        seed: Optional[int] = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.0,
+    ) -> Response[T]:
+        system_blocks, chat_messages = self._render(messages, cache)
+
+        tools = [
+            {
+                "name": _STRUCTURED_TOOL_NAME,
+                "description": f"Return the final response as an instance of {schema.__name__}.",
+                "input_schema": pydantic_json_schema(schema),
+            }
+        ]
+        request: dict[str, Any] = {
+            "model": self.model,
+            "messages": chat_messages,
+            "tools": tools,
+            "tool_choice": {"type": "tool", "name": _STRUCTURED_TOOL_NAME},
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+        }
+        if system_blocks:
+            request["system"] = system_blocks
+
+        with Timer() as timer:
+            raw = await self._client.messages.create(**request)
+
+        parsed = self._parse_tool_output(raw, schema)
+        usage = self._extract_usage(raw)
+        return Response(
+            parsed=parsed,
+            raw=raw_to_dict(raw),
+            usage=usage,
+            latency_ms=timer.elapsed_ms,
+            model=get_attr(raw, "model", self.model),
+            cache_hit=usage.cache_read_tokens > 0,
+        )
+
+    # ---- rendering --------------------------------------------------------
+
+    def _render(
+        self,
+        messages: list[Message],
+        cache: Optional[CacheSpec],
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        cache_blocks = set(cache.blocks) if cache else set()
+        ttl_seconds = cache.ttl_seconds if cache else 300
+        last_for_block = self._last_part_per_block(messages, cache_blocks)
+
+        system_blocks: list[dict[str, Any]] = []
+        chat_messages: list[dict[str, Any]] = []
+        for mi, message in enumerate(messages):
+            rendered_parts: list[dict[str, Any]] = []
+            for pi, part in enumerate(message.content):
+                block = self._render_part(part)
+                if (
+                    part.cache is not None
+                    and part.cache in cache_blocks
+                    and last_for_block.get(part.cache) == (mi, pi)
+                ):
+                    block["cache_control"] = _cache_control(ttl_seconds)
+                rendered_parts.append(block)
+
+            if message.role == "system":
+                system_blocks.extend(rendered_parts)
+            else:
+                chat_messages.append({"role": message.role, "content": rendered_parts})
+        return system_blocks, chat_messages
+
+    @staticmethod
+    def _last_part_per_block(
+        messages: list[Message], cache_blocks: set[str]
+    ) -> dict[str, tuple[int, int]]:
+        last: dict[str, tuple[int, int]] = {}
+        for mi, msg in enumerate(messages):
+            for pi, part in enumerate(msg.content):
+                if part.cache is not None and part.cache in cache_blocks:
+                    last[part.cache] = (mi, pi)
+        return last
+
+    @staticmethod
+    def _render_part(part: TextPart | ImagePart) -> dict[str, Any]:
+        if isinstance(part, TextPart):
+            return {"type": "text", "text": part.text}
+        if isinstance(part, ImagePart):
+            return {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": part.media_type,
+                    "data": encode_image_base64(part.data),
+                },
+            }
+        raise TypeError(f"Unsupported content part: {type(part).__name__}")
+
+    # ---- response parsing -------------------------------------------------
+
+    @staticmethod
+    def _parse_tool_output(raw: Any, schema: type[T]) -> T:
+        for block in get_attr(raw, "content", []) or []:
+            if get_attr(block, "type") == "tool_use" and get_attr(block, "name") == _STRUCTURED_TOOL_NAME:
+                payload = get_attr(block, "input", {}) or {}
+                return schema.model_validate(payload)
+        raise ValueError(
+            f"Anthropic response contained no tool_use block named {_STRUCTURED_TOOL_NAME!r}"
+        )
+
+    @staticmethod
+    def _extract_usage(raw: Any) -> Usage:
+        u = get_attr(raw, "usage")
+        if u is None:
+            return Usage(input_tokens=0, output_tokens=0)
+        return Usage(
+            input_tokens=int(get_attr(u, "input_tokens", 0) or 0),
+            output_tokens=int(get_attr(u, "output_tokens", 0) or 0),
+            cache_creation_tokens=int(get_attr(u, "cache_creation_input_tokens", 0) or 0),
+            cache_read_tokens=int(get_attr(u, "cache_read_input_tokens", 0) or 0),
+        )
+
+
+def _cache_control(ttl_seconds: int) -> dict[str, Any]:
+    cc: dict[str, Any] = {"type": "ephemeral"}
+    if ttl_seconds >= 3600:
+        cc["ttl"] = "1h"
+    return cc

--- a/src/alpha/llm/providers/gemini.py
+++ b/src/alpha/llm/providers/gemini.py
@@ -1,0 +1,154 @@
+"""Google Gemini provider (google-genai SDK)."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional, TypeVar
+
+from pydantic import BaseModel
+
+from ..cache import CacheSpec
+from ..provider import ImagePart, Message, Response, TextPart, Usage
+from ._common import Timer, get_attr, raw_to_dict
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class GeminiProvider:
+    """Google Gemini provider backed by the async surface of `google-genai`.
+
+    * Structured output: passes the Pydantic class directly as
+      `response_schema` with `response_mime_type="application/json"`; the SDK
+      populates `response.parsed` with a validated instance.
+    * Prompt caching: the Gemini explicit `cached_content` API is not yet wired
+      here (tracked as a follow-up). The `cache` argument is accepted for
+      Protocol compatibility and the API-reported cache-read tokens are
+      surfaced via `Usage.cache_read_tokens`.
+    * Images: rendered as `inline_data` parts carrying raw bytes.
+    """
+
+    name = "gemini"
+
+    def __init__(
+        self,
+        model: str,
+        api_key: Optional[str] = None,
+        client: Any = None,
+    ) -> None:
+        self.model = model
+        self._api_key = (
+            api_key or os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")
+        )
+        if client is not None:
+            self._client = client
+            return
+        if not self._api_key:
+            raise ValueError("GOOGLE_API_KEY missing for GeminiProvider")
+        from google import genai
+
+        self._client = genai.Client(api_key=self._api_key)
+
+    async def complete(
+        self,
+        messages: list[Message],
+        schema: type[T],
+        cache: Optional[CacheSpec] = None,
+        seed: Optional[int] = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.0,
+    ) -> Response[T]:
+        system_instruction, contents = self._split(messages)
+
+        config: dict[str, Any] = {
+            "response_mime_type": "application/json",
+            "response_schema": schema,
+            "temperature": temperature,
+            "max_output_tokens": max_tokens,
+        }
+        if seed is not None:
+            config["seed"] = seed
+        if system_instruction:
+            config["system_instruction"] = system_instruction
+
+        with Timer() as timer:
+            raw = await self._client.aio.models.generate_content(
+                model=self.model,
+                contents=contents,
+                config=config,
+            )
+
+        parsed = self._extract_parsed(raw, schema)
+        usage = self._extract_usage(raw)
+        return Response(
+            parsed=parsed,
+            raw=raw_to_dict(raw),
+            usage=usage,
+            latency_ms=timer.elapsed_ms,
+            model=get_attr(raw, "model_version", self.model),
+            cache_hit=usage.cache_read_tokens > 0,
+        )
+
+    # ---- rendering --------------------------------------------------------
+
+    def _split(
+        self, messages: list[Message]
+    ) -> tuple[str, list[dict[str, Any]]]:
+        system_fragments: list[str] = []
+        contents: list[dict[str, Any]] = []
+        for message in messages:
+            if message.role == "system":
+                for part in message.content:
+                    if isinstance(part, TextPart):
+                        system_fragments.append(part.text)
+                continue
+            role = "user" if message.role == "user" else "model"
+            contents.append(
+                {
+                    "role": role,
+                    "parts": [self._render_part(p) for p in message.content],
+                }
+            )
+        return "\n\n".join(system_fragments), contents
+
+    @staticmethod
+    def _render_part(part: TextPart | ImagePart) -> dict[str, Any]:
+        if isinstance(part, TextPart):
+            return {"text": part.text}
+        if isinstance(part, ImagePart):
+            return {
+                "inline_data": {
+                    "mime_type": part.media_type,
+                    "data": part.data,
+                }
+            }
+        raise TypeError(f"Unsupported content part: {type(part).__name__}")
+
+    # ---- response parsing -------------------------------------------------
+
+    @staticmethod
+    def _extract_parsed(raw: Any, schema: type[T]) -> T:
+        parsed = get_attr(raw, "parsed")
+        if isinstance(parsed, schema):
+            return parsed
+        text = get_attr(raw, "text")
+        if isinstance(text, str) and text:
+            return schema.model_validate_json(text)
+        for candidate in get_attr(raw, "candidates", []) or []:
+            content = get_attr(candidate, "content")
+            for part in get_attr(content, "parts", []) or []:
+                pt = get_attr(part, "text")
+                if pt:
+                    return schema.model_validate_json(pt)
+        raise ValueError("Gemini response contained no parsed output or text content")
+
+    @staticmethod
+    def _extract_usage(raw: Any) -> Usage:
+        u = get_attr(raw, "usage_metadata")
+        if u is None:
+            return Usage(input_tokens=0, output_tokens=0)
+        return Usage(
+            input_tokens=int(get_attr(u, "prompt_token_count", 0) or 0),
+            output_tokens=int(get_attr(u, "candidates_token_count", 0) or 0),
+            cache_creation_tokens=0,
+            cache_read_tokens=int(get_attr(u, "cached_content_token_count", 0) or 0),
+        )

--- a/src/alpha/llm/providers/gemini.py
+++ b/src/alpha/llm/providers/gemini.py
@@ -36,9 +36,7 @@ class GeminiProvider:
         client: Any = None,
     ) -> None:
         self.model = model
-        self._api_key = (
-            api_key or os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")
-        )
+        self._api_key = api_key or os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")
         if client is not None:
             self._client = client
             return
@@ -90,9 +88,7 @@ class GeminiProvider:
 
     # ---- rendering --------------------------------------------------------
 
-    def _split(
-        self, messages: list[Message]
-    ) -> tuple[str, list[dict[str, Any]]]:
+    def _split(self, messages: list[Message]) -> tuple[str, list[dict[str, Any]]]:
         system_fragments: list[str] = []
         contents: list[dict[str, Any]] = []
         for message in messages:

--- a/src/alpha/llm/providers/openai.py
+++ b/src/alpha/llm/providers/openai.py
@@ -144,9 +144,5 @@ def _first_choice_text(raw: Any) -> str:
     content = get_attr(msg, "content", "") or ""
     if isinstance(content, list):
         # Some OpenAI-compatible backends return structured parts instead of a string.
-        content = "".join(
-            get_attr(p, "text", "") or ""
-            for p in content
-            if get_attr(p, "type") == "text"
-        )
+        content = "".join(get_attr(p, "text", "") or "" for p in content if get_attr(p, "type") == "text")
     return content

--- a/src/alpha/llm/providers/openai.py
+++ b/src/alpha/llm/providers/openai.py
@@ -1,0 +1,152 @@
+"""OpenAI provider — Chat Completions + strict json_schema response_format."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional, TypeVar
+
+from pydantic import BaseModel
+
+from ..cache import CacheSpec
+from ..provider import ImagePart, Message, Response, TextPart, Usage
+from ._common import (
+    Timer,
+    encode_image_base64,
+    get_attr,
+    raw_to_dict,
+    strict_openai_schema,
+)
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class OpenAIProvider:
+    """OpenAI (or OpenAI-compatible) Chat Completions provider.
+
+    * Structured output: `response_format={"type": "json_schema", "strict":
+      true, ...}` with the Pydantic JSON schema, then validated client-side via
+      `BaseModel.model_validate_json`.
+    * Prompt caching: automatic at the OpenAI platform; the
+      `usage.prompt_tokens_details.cached_tokens` field populates
+      `Usage.cache_read_tokens` and `Response.cache_hit`.
+    * Images: rendered as `image_url` content parts with a `data:` URL.
+    """
+
+    name = "openai"
+
+    def __init__(
+        self,
+        model: str,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        client: Any = None,
+    ) -> None:
+        self.model = model
+        self._api_key = api_key or os.getenv("OPENAI_API_KEY")
+        self._base_url = base_url or os.getenv("OPENAI_BASE_URL")
+        if client is not None:
+            self._client = client
+            return
+        if not self._api_key:
+            raise ValueError("OPENAI_API_KEY missing for OpenAIProvider")
+        import openai
+
+        kwargs: dict[str, Any] = {"api_key": self._api_key}
+        if self._base_url:
+            kwargs["base_url"] = self._base_url
+        self._client = openai.AsyncOpenAI(**kwargs)
+
+    async def complete(
+        self,
+        messages: list[Message],
+        schema: type[T],
+        cache: Optional[CacheSpec] = None,
+        seed: Optional[int] = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.0,
+    ) -> Response[T]:
+        rendered = [self._render_message(m) for m in messages]
+        request: dict[str, Any] = {
+            "model": self.model,
+            "messages": rendered,
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": schema.__name__,
+                    "schema": strict_openai_schema(schema),
+                    "strict": True,
+                },
+            },
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+        }
+        if seed is not None:
+            request["seed"] = seed
+
+        with Timer() as timer:
+            raw = await self._client.chat.completions.create(**request)
+
+        parsed = schema.model_validate_json(_first_choice_text(raw))
+        usage = self._extract_usage(raw)
+        return Response(
+            parsed=parsed,
+            raw=raw_to_dict(raw),
+            usage=usage,
+            latency_ms=timer.elapsed_ms,
+            model=get_attr(raw, "model", self.model),
+            cache_hit=usage.cache_read_tokens > 0,
+        )
+
+    # ---- rendering --------------------------------------------------------
+
+    @staticmethod
+    def _render_message(message: Message) -> dict[str, Any]:
+        parts: list[dict[str, Any]] = []
+        for part in message.content:
+            if isinstance(part, TextPart):
+                parts.append({"type": "text", "text": part.text})
+            elif isinstance(part, ImagePart):
+                b64 = encode_image_base64(part.data)
+                parts.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:{part.media_type};base64,{b64}"},
+                    }
+                )
+            else:
+                raise TypeError(f"Unsupported content part: {type(part).__name__}")
+        return {"role": message.role, "content": parts}
+
+    # ---- response parsing -------------------------------------------------
+
+    @staticmethod
+    def _extract_usage(raw: Any) -> Usage:
+        u = get_attr(raw, "usage")
+        if u is None:
+            return Usage(input_tokens=0, output_tokens=0)
+        input_tokens = int(get_attr(u, "prompt_tokens", 0) or 0)
+        output_tokens = int(get_attr(u, "completion_tokens", 0) or 0)
+        details = get_attr(u, "prompt_tokens_details")
+        cached = int(get_attr(details, "cached_tokens", 0) or 0)
+        return Usage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_creation_tokens=0,
+            cache_read_tokens=cached,
+        )
+
+
+def _first_choice_text(raw: Any) -> str:
+    choices = get_attr(raw, "choices") or []
+    if not choices:
+        raise ValueError("OpenAI response contained no choices")
+    msg = get_attr(choices[0], "message")
+    content = get_attr(msg, "content", "") or ""
+    if isinstance(content, list):
+        # Some OpenAI-compatible backends return structured parts instead of a string.
+        content = "".join(
+            get_attr(p, "text", "") or ""
+            for p in content
+            if get_attr(p, "type") == "text"
+        )
+    return content

--- a/src/alpha/llm/registry.py
+++ b/src/alpha/llm/registry.py
@@ -1,0 +1,120 @@
+"""Model registry — loads `config/llm/registry.yaml` and builds Provider instances."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+import yaml
+
+from .provider import Provider
+
+_DEFAULT_REGISTRY_PATH = (
+    Path(__file__).resolve().parents[3] / "config" / "llm" / "registry.yaml"
+)
+
+
+@dataclass
+class Pricing:
+    input_per_1m: float = 0.0
+    output_per_1m: float = 0.0
+    cache_write_per_1m: float = 0.0
+    cache_read_per_1m: float = 0.0
+
+
+@dataclass
+class ModelSpec:
+    id: str
+    provider: str
+    api_id: str
+    context_window: int = 0
+    max_output: int = 0
+    supports_image: bool = False
+    supports_tool_use: bool = False
+    supports_cache: bool = False
+    cache_min_tokens: int = 0
+    pricing: Pricing = field(default_factory=Pricing)
+    notes: Optional[str] = None
+
+
+ProviderFactory = Callable[..., Provider]
+
+
+class ModelRegistry:
+    """Registry of `ModelSpec`s keyed by model id with per-provider factories."""
+
+    def __init__(self, models: dict[str, ModelSpec]) -> None:
+        self._models = models
+        self._factories: dict[str, ProviderFactory] = {
+            "anthropic": _build_anthropic,
+            "openai": _build_openai,
+            "gemini": _build_gemini,
+        }
+
+    # ---- loading ----------------------------------------------------------
+
+    @classmethod
+    def from_yaml(cls, path: Optional[os.PathLike[str] | str] = None) -> "ModelRegistry":
+        yaml_path = Path(path) if path else _DEFAULT_REGISTRY_PATH
+        with open(yaml_path, "r", encoding="utf-8") as f:
+            raw = yaml.safe_load(f) or {}
+        models: dict[str, ModelSpec] = {}
+        for item in raw.get("models", []) or []:
+            pricing_kwargs = dict(item.get("pricing") or {})
+            remaining = {k: v for k, v in item.items() if k != "pricing"}
+            spec = ModelSpec(pricing=Pricing(**pricing_kwargs), **remaining)
+            if spec.id in models:
+                raise ValueError(f"Duplicate model id in registry: {spec.id!r}")
+            models[spec.id] = spec
+        return cls(models)
+
+    # ---- introspection ----------------------------------------------------
+
+    def list(self, provider: Optional[str] = None) -> list[ModelSpec]:
+        specs = list(self._models.values())
+        if provider is not None:
+            specs = [s for s in specs if s.provider == provider]
+        return specs
+
+    def ids(self) -> list[str]:
+        return list(self._models.keys())
+
+    def get(self, model_id: str) -> ModelSpec:
+        if model_id not in self._models:
+            raise KeyError(f"Unknown model id: {model_id!r}")
+        return self._models[model_id]
+
+    # ---- factory wiring ---------------------------------------------------
+
+    def register_factory(self, provider: str, factory: ProviderFactory) -> None:
+        self._factories[provider] = factory
+
+    def build(self, model_id: str, **overrides: Any) -> Provider:
+        spec = self.get(model_id)
+        factory = self._factories.get(spec.provider)
+        if factory is None:
+            raise ValueError(f"No factory registered for provider {spec.provider!r}")
+        return factory(spec, **overrides)
+
+
+def _build_anthropic(spec: ModelSpec, **overrides: Any) -> Provider:
+    from .providers.anthropic import AnthropicProvider
+
+    return AnthropicProvider(model=spec.api_id, **overrides)
+
+
+def _build_openai(spec: ModelSpec, **overrides: Any) -> Provider:
+    from .providers.openai import OpenAIProvider
+
+    return OpenAIProvider(model=spec.api_id, **overrides)
+
+
+def _build_gemini(spec: ModelSpec, **overrides: Any) -> Provider:
+    from .providers.gemini import GeminiProvider
+
+    return GeminiProvider(model=spec.api_id, **overrides)
+
+
+__all__ = ["Pricing", "ModelSpec", "ModelRegistry"]

--- a/src/alpha/llm/registry.py
+++ b/src/alpha/llm/registry.py
@@ -11,9 +11,7 @@ import yaml
 
 from .provider import Provider
 
-_DEFAULT_REGISTRY_PATH = (
-    Path(__file__).resolve().parents[3] / "config" / "llm" / "registry.yaml"
-)
+_DEFAULT_REGISTRY_PATH = Path(__file__).resolve().parents[3] / "config" / "llm" / "registry.yaml"
 
 
 @dataclass

--- a/tests/alpha/llm/providers/conftest.py
+++ b/tests/alpha/llm/providers/conftest.py
@@ -1,0 +1,11 @@
+"""Shared fixtures for provider integration tests."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class HelloOut(BaseModel):
+    """Minimal schema used for round-trip structured-output tests."""
+
+    greeting: str

--- a/tests/alpha/llm/providers/test_anthropic.py
+++ b/tests/alpha/llm/providers/test_anthropic.py
@@ -15,7 +15,6 @@ from src.alpha.llm.providers.anthropic import AnthropicProvider
 
 from .conftest import HelloOut
 
-
 # ----------------------------- fake Anthropic SDK --------------------------------
 
 

--- a/tests/alpha/llm/providers/test_anthropic.py
+++ b/tests/alpha/llm/providers/test_anthropic.py
@@ -1,0 +1,204 @@
+"""Tests for `AnthropicProvider` — schema-backed tool use, cache_control, image blocks."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from src.alpha.llm.provider import CacheSpec, ImagePart, Message, TextPart
+from src.alpha.llm.providers.anthropic import AnthropicProvider
+
+from .conftest import HelloOut
+
+
+# ----------------------------- fake Anthropic SDK --------------------------------
+
+
+@dataclass
+class _ToolUseBlock:
+    type: str
+    name: str
+    input: dict
+
+
+@dataclass
+class _AnthropicUsage:
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    cache_read_input_tokens: int = 0
+
+
+@dataclass
+class _AnthropicResponse:
+    content: list
+    usage: _AnthropicUsage = field(default_factory=_AnthropicUsage)
+    model: str = "claude-opus-4-7"
+
+
+class _FakeMessages:
+    def __init__(self, response: _AnthropicResponse) -> None:
+        self.response = response
+        self.last_kwargs: dict[str, Any] | None = None
+
+    async def create(self, **kwargs: Any) -> _AnthropicResponse:
+        self.last_kwargs = kwargs
+        return self.response
+
+
+class _FakeAnthropicClient:
+    def __init__(self, response: _AnthropicResponse) -> None:
+        self.messages = _FakeMessages(response)
+
+
+def _fake(greeting: str, **usage_kwargs: Any) -> _FakeAnthropicClient:
+    resp = _AnthropicResponse(
+        content=[_ToolUseBlock(type="tool_use", name="respond", input={"greeting": greeting})],
+        usage=_AnthropicUsage(**usage_kwargs),
+    )
+    return _FakeAnthropicClient(resp)
+
+
+# ----------------------------- mock round-trip -----------------------------------
+
+
+def test_roundtrip_parses_tool_use_and_extracts_cache_usage():
+    fake = _fake(
+        "hi",
+        input_tokens=11,
+        output_tokens=3,
+        cache_creation_input_tokens=200,
+        cache_read_input_tokens=999,
+    )
+    provider = AnthropicProvider(model="claude-haiku-4-5", client=fake)
+    messages = [
+        Message(role="system", content=[TextPart(text="You are helpful.", cache="system")]),
+        Message(role="user", content=[TextPart(text="Say hi.")]),
+    ]
+    result = asyncio.run(
+        provider.complete(
+            messages=messages,
+            schema=HelloOut,
+            cache=CacheSpec(blocks=["system"], ttl_seconds=3600),
+            max_tokens=128,
+        )
+    )
+
+    assert isinstance(result.parsed, HelloOut)
+    assert result.parsed.greeting == "hi"
+    assert result.usage.input_tokens == 11
+    assert result.usage.output_tokens == 3
+    assert result.usage.cache_creation_tokens == 200
+    assert result.usage.cache_read_tokens == 999
+    assert result.cache_hit is True
+    assert result.latency_ms >= 0.0
+    assert result.model == "claude-opus-4-7"
+
+
+def test_tool_schema_and_cache_control_are_applied():
+    fake = _fake("hi")
+    provider = AnthropicProvider(model="claude-haiku-4-5", client=fake)
+    messages = [
+        Message(
+            role="system",
+            content=[
+                TextPart(text="Always answer briefly.", cache="system"),
+                TextPart(text="JSON only.", cache="system"),
+            ],
+        ),
+        Message(role="user", content=[TextPart(text="Say hi.")]),
+    ]
+    asyncio.run(
+        provider.complete(
+            messages=messages,
+            schema=HelloOut,
+            cache=CacheSpec(blocks=["system"], ttl_seconds=3600),
+        )
+    )
+
+    kwargs = fake.messages.last_kwargs
+    assert kwargs is not None
+
+    # The tool mirrors the Pydantic schema and is forced via tool_choice.
+    tool = kwargs["tools"][0]
+    assert tool["name"] == "respond"
+    assert tool["input_schema"]["properties"]["greeting"]["type"] == "string"
+    assert kwargs["tool_choice"] == {"type": "tool", "name": "respond"}
+
+    # Only the last text part in the "system" block carries cache_control (1h TTL).
+    system = kwargs["system"]
+    assert "cache_control" not in system[0]
+    assert system[1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+
+def test_image_part_renders_as_base64_image_block():
+    fake = _fake("ok")
+    provider = AnthropicProvider(model="claude-haiku-4-5", client=fake)
+    img = b"\x89PNG\r\n\x1a\nmini"
+    asyncio.run(
+        provider.complete(
+            messages=[
+                Message(
+                    role="user",
+                    content=[
+                        ImagePart(data=img, media_type="image/png"),
+                        TextPart(text="Describe the image."),
+                    ],
+                )
+            ],
+            schema=HelloOut,
+        )
+    )
+
+    user_msg = fake.messages.last_kwargs["messages"][0]
+    assert user_msg["role"] == "user"
+    assert user_msg["content"][0]["type"] == "image"
+    assert user_msg["content"][0]["source"]["media_type"] == "image/png"
+    assert user_msg["content"][0]["source"]["data"] == base64.b64encode(img).decode()
+
+
+def test_missing_tool_use_block_raises():
+    @dataclass
+    class _TextBlock:
+        type: str
+        text: str
+
+    resp = _AnthropicResponse(content=[_TextBlock(type="text", text="sorry")])
+    provider = AnthropicProvider(model="claude-haiku-4-5", client=_FakeAnthropicClient(resp))
+    with pytest.raises(ValueError):
+        asyncio.run(
+            provider.complete(
+                messages=[Message(role="user", content=[TextPart(text="hi")])],
+                schema=HelloOut,
+            )
+        )
+
+
+# ----------------------------- live round-trip -----------------------------------
+
+
+@pytest.mark.skipif(not os.getenv("ANTHROPIC_API_KEY"), reason="no ANTHROPIC_API_KEY")
+def test_live_roundtrip_hello_schema():
+    provider = AnthropicProvider(model="claude-haiku-4-5")
+    result = asyncio.run(
+        provider.complete(
+            messages=[
+                Message(
+                    role="user",
+                    content=[TextPart(text='Respond with the JSON object {"greeting":"hi"}.')],
+                )
+            ],
+            schema=HelloOut,
+            max_tokens=256,
+        )
+    )
+    assert isinstance(result.parsed, HelloOut)
+    assert result.parsed.greeting  # non-empty
+    assert result.usage.input_tokens > 0
+    assert result.usage.output_tokens > 0
+    assert result.latency_ms > 0

--- a/tests/alpha/llm/providers/test_gemini.py
+++ b/tests/alpha/llm/providers/test_gemini.py
@@ -1,0 +1,191 @@
+"""Tests for `GeminiProvider` — response_schema parse, inline_data image, usage_metadata."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from src.alpha.llm.provider import ImagePart, Message, TextPart
+from src.alpha.llm.providers.gemini import GeminiProvider
+
+from .conftest import HelloOut
+
+
+# ----------------------------- fake google-genai ---------------------------------
+
+
+@dataclass
+class _GeminiUsage:
+    prompt_token_count: int = 0
+    candidates_token_count: int = 0
+    cached_content_token_count: int = 0
+
+
+@dataclass
+class _GeminiResponse:
+    parsed: Any = None
+    text: str = ""
+    usage_metadata: _GeminiUsage = field(default_factory=_GeminiUsage)
+    model_version: str = "gemini-2.5-flash"
+
+
+class _FakeModels:
+    def __init__(self, response: _GeminiResponse) -> None:
+        self.response = response
+        self.last_kwargs: dict[str, Any] | None = None
+
+    async def generate_content(self, **kwargs: Any) -> _GeminiResponse:
+        self.last_kwargs = kwargs
+        return self.response
+
+
+class _FakeAio:
+    def __init__(self, response: _GeminiResponse) -> None:
+        self.models = _FakeModels(response)
+
+
+class _FakeGeminiClient:
+    def __init__(self, response: _GeminiResponse) -> None:
+        self.aio = _FakeAio(response)
+
+
+# ----------------------------- mock round-trip -----------------------------------
+
+
+def test_roundtrip_uses_parsed_and_usage_metadata():
+    resp = _GeminiResponse(
+        parsed=HelloOut(greeting="hi"),
+        usage_metadata=_GeminiUsage(
+            prompt_token_count=8,
+            candidates_token_count=2,
+            cached_content_token_count=5,
+        ),
+    )
+    fake = _FakeGeminiClient(resp)
+    provider = GeminiProvider(model="gemini-2.5-flash", client=fake)
+    result = asyncio.run(
+        provider.complete(
+            messages=[Message(role="user", content=[TextPart(text="Say hi")])],
+            schema=HelloOut,
+            seed=123,
+        )
+    )
+    assert isinstance(result.parsed, HelloOut)
+    assert result.parsed.greeting == "hi"
+    assert result.usage.input_tokens == 8
+    assert result.usage.output_tokens == 2
+    assert result.usage.cache_read_tokens == 5
+    assert result.cache_hit is True
+    assert result.model == "gemini-2.5-flash"
+    assert result.latency_ms >= 0.0
+
+
+def test_config_forwards_schema_and_seed_and_system_instruction():
+    fake = _FakeGeminiClient(_GeminiResponse(parsed=HelloOut(greeting="ok")))
+    provider = GeminiProvider(model="gemini-2.5-flash", client=fake)
+    asyncio.run(
+        provider.complete(
+            messages=[
+                Message(role="system", content=[TextPart(text="Answer briefly.")]),
+                Message(role="user", content=[TextPart(text="Hi")]),
+            ],
+            schema=HelloOut,
+            seed=99,
+            max_tokens=64,
+            temperature=0.2,
+        )
+    )
+    cfg = fake.aio.models.last_kwargs["config"]
+    assert cfg["response_mime_type"] == "application/json"
+    assert cfg["response_schema"] is HelloOut
+    assert cfg["seed"] == 99
+    assert cfg["max_output_tokens"] == 64
+    assert cfg["temperature"] == pytest.approx(0.2)
+    assert cfg["system_instruction"] == "Answer briefly."
+
+    # System messages are split out of `contents`.
+    contents = fake.aio.models.last_kwargs["contents"]
+    assert len(contents) == 1
+    assert contents[0]["role"] == "user"
+
+
+def test_falls_back_to_text_when_parsed_is_missing():
+    resp = _GeminiResponse(
+        parsed=None,
+        text='{"greeting":"hey"}',
+        usage_metadata=_GeminiUsage(prompt_token_count=3, candidates_token_count=2),
+    )
+    provider = GeminiProvider(model="gemini-2.5-flash", client=_FakeGeminiClient(resp))
+    result = asyncio.run(
+        provider.complete(
+            messages=[Message(role="user", content=[TextPart(text="Hi")])],
+            schema=HelloOut,
+        )
+    )
+    assert result.parsed.greeting == "hey"
+
+
+def test_image_part_uses_inline_data_with_raw_bytes():
+    fake = _FakeGeminiClient(_GeminiResponse(parsed=HelloOut(greeting="ok")))
+    provider = GeminiProvider(model="gemini-2.5-flash", client=fake)
+    img = b"\x89PNG\r\n"
+    asyncio.run(
+        provider.complete(
+            messages=[
+                Message(
+                    role="user",
+                    content=[
+                        ImagePart(data=img, media_type="image/png"),
+                        TextPart(text="What is this?"),
+                    ],
+                )
+            ],
+            schema=HelloOut,
+        )
+    )
+    parts = fake.aio.models.last_kwargs["contents"][0]["parts"]
+    assert parts[0]["inline_data"]["mime_type"] == "image/png"
+    assert parts[0]["inline_data"]["data"] == img
+    assert parts[1]["text"] == "What is this?"
+
+
+def test_missing_parsed_and_text_raises():
+    resp = _GeminiResponse(parsed=None, text="", usage_metadata=_GeminiUsage())
+    provider = GeminiProvider(model="gemini-2.5-flash", client=_FakeGeminiClient(resp))
+    with pytest.raises(ValueError):
+        asyncio.run(
+            provider.complete(
+                messages=[Message(role="user", content=[TextPart(text="hi")])],
+                schema=HelloOut,
+            )
+        )
+
+
+# ----------------------------- live round-trip -----------------------------------
+
+
+@pytest.mark.skipif(
+    not (os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")),
+    reason="no GOOGLE_API_KEY / GEMINI_API_KEY",
+)
+def test_live_roundtrip_hello_schema():
+    provider = GeminiProvider(model="gemini-2.5-flash")
+    result = asyncio.run(
+        provider.complete(
+            messages=[
+                Message(
+                    role="user",
+                    content=[TextPart(text='Respond with JSON {"greeting":"hi"}.')],
+                )
+            ],
+            schema=HelloOut,
+            max_tokens=64,
+        )
+    )
+    assert result.parsed.greeting  # non-empty string
+    assert result.usage.input_tokens > 0
+    assert result.latency_ms > 0

--- a/tests/alpha/llm/providers/test_gemini.py
+++ b/tests/alpha/llm/providers/test_gemini.py
@@ -14,7 +14,6 @@ from src.alpha.llm.providers.gemini import GeminiProvider
 
 from .conftest import HelloOut
 
-
 # ----------------------------- fake google-genai ---------------------------------
 
 

--- a/tests/alpha/llm/providers/test_openai.py
+++ b/tests/alpha/llm/providers/test_openai.py
@@ -15,7 +15,6 @@ from src.alpha.llm.providers.openai import OpenAIProvider
 
 from .conftest import HelloOut
 
-
 # ------------------------------- fake OpenAI SDK ---------------------------------
 
 
@@ -163,10 +162,16 @@ def test_list_content_response_is_concatenated():
         content: list
 
     resp = _OpenAIResponse(
-        choices=[_Choice(message=_MessageWithParts(content=[
-            _TextPart(type="text", text='{"greeting":'),
-            _TextPart(type="text", text='"yo"}'),
-        ]))],
+        choices=[
+            _Choice(
+                message=_MessageWithParts(
+                    content=[
+                        _TextPart(type="text", text='{"greeting":'),
+                        _TextPart(type="text", text='"yo"}'),
+                    ]
+                )
+            )
+        ],
         usage=_OpenAIUsage(prompt_tokens=1, completion_tokens=2),
     )
     provider = OpenAIProvider(model="gpt-4.1-mini", client=_FakeOpenAIClient(resp))
@@ -187,9 +192,7 @@ def test_live_roundtrip_hello_schema():
     provider = OpenAIProvider(model="gpt-4.1-mini")
     result = asyncio.run(
         provider.complete(
-            messages=[
-                Message(role="user", content=[TextPart(text='Return JSON {"greeting":"hi"}.')])
-            ],
+            messages=[Message(role="user", content=[TextPart(text='Return JSON {"greeting":"hi"}.')])],
             schema=HelloOut,
             max_tokens=64,
         )

--- a/tests/alpha/llm/providers/test_openai.py
+++ b/tests/alpha/llm/providers/test_openai.py
@@ -1,0 +1,200 @@
+"""Tests for `OpenAIProvider` — strict json_schema response_format, cached_tokens, images."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from src.alpha.llm.provider import ImagePart, Message, TextPart
+from src.alpha.llm.providers.openai import OpenAIProvider
+
+from .conftest import HelloOut
+
+
+# ------------------------------- fake OpenAI SDK ---------------------------------
+
+
+@dataclass
+class _Message:
+    content: str = ""
+
+
+@dataclass
+class _Choice:
+    message: _Message
+
+
+@dataclass
+class _PromptDetails:
+    cached_tokens: int = 0
+
+
+@dataclass
+class _OpenAIUsage:
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    prompt_tokens_details: _PromptDetails = field(default_factory=_PromptDetails)
+
+
+@dataclass
+class _OpenAIResponse:
+    choices: list
+    usage: _OpenAIUsage = field(default_factory=_OpenAIUsage)
+    model: str = "gpt-4.1-mini"
+
+
+class _FakeCompletions:
+    def __init__(self, response: _OpenAIResponse) -> None:
+        self.response = response
+        self.last_kwargs: dict[str, Any] | None = None
+
+    async def create(self, **kwargs: Any) -> _OpenAIResponse:
+        self.last_kwargs = kwargs
+        return self.response
+
+
+class _FakeChat:
+    def __init__(self, response: _OpenAIResponse) -> None:
+        self.completions = _FakeCompletions(response)
+
+
+class _FakeOpenAIClient:
+    def __init__(self, response: _OpenAIResponse) -> None:
+        self.chat = _FakeChat(response)
+
+
+def _fake(greeting: str, **usage_kwargs: Any) -> _FakeOpenAIClient:
+    cached = usage_kwargs.pop("cached_tokens", 0)
+    resp = _OpenAIResponse(
+        choices=[_Choice(message=_Message(content=json.dumps({"greeting": greeting})))],
+        usage=_OpenAIUsage(
+            prompt_tokens=usage_kwargs.pop("prompt_tokens", 0),
+            completion_tokens=usage_kwargs.pop("completion_tokens", 0),
+            prompt_tokens_details=_PromptDetails(cached_tokens=cached),
+        ),
+    )
+    return _FakeOpenAIClient(resp)
+
+
+# ------------------------------- mock round-trip ---------------------------------
+
+
+def test_roundtrip_parses_json_schema_and_cached_tokens():
+    fake = _fake("hi", prompt_tokens=50, completion_tokens=3, cached_tokens=40)
+    provider = OpenAIProvider(model="gpt-4.1-mini", client=fake)
+    result = asyncio.run(
+        provider.complete(
+            messages=[Message(role="user", content=[TextPart(text='Output {"greeting":"hi"}.')])],
+            schema=HelloOut,
+            seed=42,
+            max_tokens=128,
+        )
+    )
+    assert result.parsed.greeting == "hi"
+    assert result.usage.input_tokens == 50
+    assert result.usage.output_tokens == 3
+    assert result.usage.cache_read_tokens == 40
+    assert result.cache_hit is True
+    assert result.model == "gpt-4.1-mini"
+    assert result.latency_ms >= 0.0
+
+
+def test_response_format_is_strict_json_schema_and_seed_forwarded():
+    fake = _fake("hi")
+    provider = OpenAIProvider(model="gpt-4.1-mini", client=fake)
+    asyncio.run(
+        provider.complete(
+            messages=[Message(role="user", content=[TextPart(text="hi")])],
+            schema=HelloOut,
+            seed=7,
+        )
+    )
+    kwargs = fake.chat.completions.last_kwargs
+    assert kwargs is not None
+    assert kwargs["seed"] == 7
+
+    rf = kwargs["response_format"]
+    assert rf["type"] == "json_schema"
+    assert rf["json_schema"]["name"] == "HelloOut"
+    assert rf["json_schema"]["strict"] is True
+
+    schema = rf["json_schema"]["schema"]
+    assert schema["additionalProperties"] is False
+    assert schema["required"] == ["greeting"]
+
+
+def test_image_part_renders_as_data_url():
+    fake = _fake("ok")
+    provider = OpenAIProvider(model="gpt-4.1-mini", client=fake)
+    img = b"\xff\xd8\xff"
+    asyncio.run(
+        provider.complete(
+            messages=[
+                Message(
+                    role="user",
+                    content=[
+                        TextPart(text="Describe:"),
+                        ImagePart(data=img, media_type="image/jpeg"),
+                    ],
+                )
+            ],
+            schema=HelloOut,
+        )
+    )
+    msg = fake.chat.completions.last_kwargs["messages"][0]
+    image_block = msg["content"][1]
+    assert image_block["type"] == "image_url"
+    assert image_block["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+
+def test_list_content_response_is_concatenated():
+    @dataclass
+    class _TextPart:
+        type: str
+        text: str
+
+    @dataclass
+    class _MessageWithParts:
+        content: list
+
+    resp = _OpenAIResponse(
+        choices=[_Choice(message=_MessageWithParts(content=[
+            _TextPart(type="text", text='{"greeting":'),
+            _TextPart(type="text", text='"yo"}'),
+        ]))],
+        usage=_OpenAIUsage(prompt_tokens=1, completion_tokens=2),
+    )
+    provider = OpenAIProvider(model="gpt-4.1-mini", client=_FakeOpenAIClient(resp))
+    result = asyncio.run(
+        provider.complete(
+            messages=[Message(role="user", content=[TextPart(text="hi")])],
+            schema=HelloOut,
+        )
+    )
+    assert result.parsed.greeting == "yo"
+
+
+# ------------------------------- live round-trip ---------------------------------
+
+
+@pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="no OPENAI_API_KEY")
+def test_live_roundtrip_hello_schema():
+    provider = OpenAIProvider(model="gpt-4.1-mini")
+    result = asyncio.run(
+        provider.complete(
+            messages=[
+                Message(role="user", content=[TextPart(text='Return JSON {"greeting":"hi"}.')])
+            ],
+            schema=HelloOut,
+            max_tokens=64,
+        )
+    )
+    assert result.parsed.greeting  # non-empty string
+    assert result.usage.input_tokens > 0
+    assert result.usage.output_tokens > 0
+    assert result.latency_ms > 0

--- a/tests/alpha/llm/test_registry.py
+++ b/tests/alpha/llm/test_registry.py
@@ -1,0 +1,79 @@
+"""Tests for `ModelRegistry` — yaml loading, lookups, factory wiring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.alpha.llm.provider import Provider
+from src.alpha.llm.registry import ModelRegistry, ModelSpec
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_YAML = REPO_ROOT / "config" / "llm" / "registry.yaml"
+
+
+def test_default_registry_yaml_loads_all_models():
+    registry = ModelRegistry.from_yaml(DEFAULT_YAML)
+    ids = set(registry.ids())
+    # At minimum: the three hero models per provider exist.
+    assert {"claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"} <= ids
+    assert {"gpt-4.1", "gpt-4.1-mini"} <= ids
+    assert {"gemini-2.5-pro", "gemini-2.5-flash"} <= ids
+
+
+def test_model_spec_pricing_roundtrip():
+    registry = ModelRegistry.from_yaml(DEFAULT_YAML)
+    opus = registry.get("claude-opus-4-7")
+    assert opus.provider == "anthropic"
+    assert opus.api_id == "claude-opus-4-7"
+    assert opus.context_window == 200000
+    assert opus.supports_cache is True
+    assert opus.pricing.input_per_1m == pytest.approx(15.00)
+    assert opus.pricing.cache_read_per_1m == pytest.approx(1.50)
+
+
+def test_list_filters_by_provider():
+    registry = ModelRegistry.from_yaml(DEFAULT_YAML)
+    anthropic_models = registry.list(provider="anthropic")
+    assert anthropic_models and all(m.provider == "anthropic" for m in anthropic_models)
+
+
+def test_registry_build_uses_registered_factory():
+    spec = ModelSpec(id="fake", provider="fake-provider", api_id="fake-api")
+    registry = ModelRegistry({"fake": spec})
+
+    built: dict[str, object] = {}
+
+    class _Stub:
+        name = "fake-provider"
+
+        def __init__(self, model: str, **_: object) -> None:
+            self.model = model
+
+        async def complete(self, *args, **kwargs):  # pragma: no cover - stub
+            raise NotImplementedError
+
+    def _factory(s: ModelSpec, **overrides) -> Provider:
+        instance = _Stub(model=s.api_id, **overrides)
+        built["instance"] = instance
+        return instance  # type: ignore[return-value]
+
+    registry.register_factory("fake-provider", _factory)
+    provider = registry.build("fake", extra="kw")
+    assert provider is built["instance"]
+    assert getattr(provider, "model") == "fake-api"
+
+
+def test_unknown_model_id_raises():
+    registry = ModelRegistry.from_yaml(DEFAULT_YAML)
+    with pytest.raises(KeyError):
+        registry.get("does-not-exist")
+
+
+def test_unknown_provider_factory_raises():
+    spec = ModelSpec(id="rogue", provider="unregistered", api_id="x")
+    registry = ModelRegistry({"rogue": spec})
+    with pytest.raises(ValueError):
+        registry.build("rogue")

--- a/tests/alpha/llm/test_registry.py
+++ b/tests/alpha/llm/test_registry.py
@@ -9,7 +9,6 @@ import pytest
 from src.alpha.llm.provider import Provider
 from src.alpha.llm.registry import ModelRegistry, ModelSpec
 
-
 REPO_ROOT = Path(__file__).resolve().parents[3]
 DEFAULT_YAML = REPO_ROOT / "config" / "llm" / "registry.yaml"
 


### PR DESCRIPTION
## Summary
- Implements the three frontier providers (Anthropic / OpenAI / Gemini) against the `Provider` protocol from QUA-39, each with structured output, prompt-cache reporting, and multimodal (text + image) input.
- Adds `ModelRegistry` + `config/llm/registry.yaml` with per-provider factories so upstream analysts can resolve a model id to a ready-to-call `Provider` instance.
- Adds provider tests (mocked round-trips + skipif-gated live API checks) plus a registry test.

## Files
- `src/alpha/llm/providers/{__init__,_common,anthropic,openai,gemini}.py`
- `src/alpha/llm/registry.py`
- `config/llm/registry.yaml`
- `tests/alpha/llm/providers/{conftest,test_anthropic,test_openai,test_gemini}.py`
- `tests/alpha/llm/test_registry.py`

## Test plan
- [x] `pytest tests/alpha/llm/` — 27 passed, 3 skipped (no live API keys in CI)
- [ ] Live round-trip: set `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GOOGLE_API_KEY` locally and re-run to exercise the skipped tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)