### PR TITLE
feat(brooks): patterns/ plugin layer — ABC + registry + 5 detectors (Phase 2.3)

### DIFF
--- a/src/brooks/patterns/__init__.py
+++ b/src/brooks/patterns/__init__.py
@@ -1,0 +1,35 @@
+"""L3 pattern detectors.
+
+Importing this module triggers registration of all built-in detectors
+with :class:`PatternRegistry`.
+"""
+
+from src.brooks.patterns import (  # noqa: F401 — imported for side-effect
+    double_tb,
+    final_flag,
+    h2_l2,
+    measured_move,
+    wedge,
+)
+from src.brooks.patterns.base import DetectorContext, PatternDetector, PatternSignal
+from src.brooks.patterns.double_tb import DoubleBottomDetector, DoubleTopDetector
+from src.brooks.patterns.final_flag import FinalFlagDetector
+from src.brooks.patterns.h2_l2 import H2Detector, L2Detector
+from src.brooks.patterns.measured_move import MeasuredMoveTargeter
+from src.brooks.patterns.registry import PatternRegistry
+from src.brooks.patterns.wedge import WedgeLongDetector, WedgeShortDetector
+
+__all__ = [
+    "DetectorContext",
+    "DoubleBottomDetector",
+    "DoubleTopDetector",
+    "FinalFlagDetector",
+    "H2Detector",
+    "L2Detector",
+    "MeasuredMoveTargeter",
+    "PatternDetector",
+    "PatternRegistry",
+    "PatternSignal",
+    "WedgeLongDetector",
+    "WedgeShortDetector",
+]

--- a/src/brooks/patterns/base.py
+++ b/src/brooks/patterns/base.py
@@ -1,0 +1,74 @@
+"""Base ABC and shared dataclasses for Brooks pattern detectors.
+
+``PatternSignal`` is the **internal** detector output type. The
+``src/brooks/analyst/rule.py`` layer (Phase 2.5) is responsible for
+promoting it to the unified :class:`src.brooks.schema.Signal`.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Literal, Optional
+
+from src.brooks.features import ExtendedBarFeatures
+from src.brooks.structure import MarketStructure
+
+
+@dataclass
+class DetectorContext:
+    """Everything a detector needs from the outer layers."""
+
+    feat: ExtendedBarFeatures
+    structure: MarketStructure
+    recent_features: List[ExtendedBarFeatures]
+    params: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class PatternSignal:
+    """A single-bar buy/sell setup.
+
+    ``signal_bar_idx`` is the bar that *triggered* the setup. Entry
+    actually happens on the next bar via a stop-at-``entry_px`` working
+    order (Brooks' standard "1 tick above/below signal bar" convention).
+    """
+
+    detector: str
+    side: Literal["long", "short"]
+    signal_bar_idx: int
+    entry_px: float
+    stop_px: float
+    timestamp_ns: int
+    reason: str = ""
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "detector": self.detector,
+            "side": self.side,
+            "signal_bar_idx": self.signal_bar_idx,
+            "entry_px": round(self.entry_px, 6),
+            "stop_px": round(self.stop_px, 6),
+            "timestamp_ns": self.timestamp_ns,
+            "reason": self.reason,
+            "metadata": self.metadata,
+        }
+
+
+class PatternDetector(ABC):
+    """Stateful per-bar detector.
+
+    Subclasses register themselves via
+    :meth:`src.brooks.patterns.registry.PatternRegistry.register`;
+    the decorator assigns :attr:`name` to the registry key.
+    """
+
+    name: str = ""
+
+    @abstractmethod
+    def on_bar(self, ctx: DetectorContext) -> Optional[PatternSignal]:
+        """Ingest one bar; return a signal on the bar it forms, else None."""
+
+    def state_snapshot(self) -> Dict[str, Any]:
+        return {"name": self.name}

--- a/src/brooks/patterns/double_tb.py
+++ b/src/brooks/patterns/double_tb.py
@@ -1,0 +1,131 @@
+"""Double Top / Double Bottom Twin detectors.
+
+A "double bottom" in Brooks terms is a pair of confirmed swing lows close
+enough in price that the second retest forms a signal bar. Entry =
+second bottom's bar high + 1 tick, stop = min(lows) − 1 tick.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Literal, Optional
+
+from src.brooks.patterns.base import DetectorContext, PatternDetector, PatternSignal
+from src.brooks.patterns.registry import PatternRegistry
+
+_TICK = 1e-6
+
+
+@dataclass
+class _DoubleState:
+    last_signal_bar_idx: int = -1
+
+
+class _DoubleTwinBase(PatternDetector):
+    side: Literal["long", "short"]
+
+    def __init__(
+        self,
+        max_separation_atr: float = 0.5,
+        min_separation_bars: int = 3,
+        max_separation_bars: int = 30,
+    ):
+        self.max_separation_atr = max_separation_atr
+        self.min_separation_bars = min_separation_bars
+        self.max_separation_bars = max_separation_bars
+        self._state = _DoubleState()
+
+    def state_snapshot(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "last_signal_bar_idx": self._state.last_signal_bar_idx,
+        }
+
+    def reset(self) -> None:
+        self._state = _DoubleState()
+
+
+@PatternRegistry.register("double_bottom")
+class DoubleBottomDetector(_DoubleTwinBase):
+    side: Literal["long", "short"] = "long"
+
+    def on_bar(self, ctx: DetectorContext) -> Optional[PatternSignal]:
+        lows = [
+            s for s in ctx.structure.confirmed_swing_lows if s.confirmed_at_idx <= ctx.feat.bar_idx
+        ]
+        if len(lows) < 2:
+            return None
+        a, b = lows[-2], lows[-1]
+        sep = b.bar_idx - a.bar_idx
+        if sep < self.min_separation_bars or sep > self.max_separation_bars:
+            return None
+        atr = ctx.feat.atr14
+        if atr <= 0:
+            return None
+        if abs(a.price - b.price) > self.max_separation_atr * atr:
+            return None
+        if not (ctx.feat.is_bull and ctx.feat.close > ctx.feat.open):
+            return None
+        if b.bar_idx == self._state.last_signal_bar_idx:
+            return None
+        self._state.last_signal_bar_idx = b.bar_idx
+        entry = ctx.feat.high + _TICK
+        stop = min(a.price, b.price) - _TICK
+        return PatternSignal(
+            detector=self.name,
+            side="long",
+            signal_bar_idx=ctx.feat.bar_idx,
+            entry_px=entry,
+            stop_px=stop,
+            timestamp_ns=ctx.feat.timestamp_ns,
+            reason=f"double-bottom: swings at {a.bar_idx}={a.price:.4f} & {b.bar_idx}={b.price:.4f}",
+            metadata={
+                "low1_idx": a.bar_idx,
+                "low1_px": a.price,
+                "low2_idx": b.bar_idx,
+                "low2_px": b.price,
+            },
+        )
+
+
+@PatternRegistry.register("double_top")
+class DoubleTopDetector(_DoubleTwinBase):
+    side: Literal["long", "short"] = "short"
+
+    def on_bar(self, ctx: DetectorContext) -> Optional[PatternSignal]:
+        highs = [
+            s for s in ctx.structure.confirmed_swing_highs if s.confirmed_at_idx <= ctx.feat.bar_idx
+        ]
+        if len(highs) < 2:
+            return None
+        a, b = highs[-2], highs[-1]
+        sep = b.bar_idx - a.bar_idx
+        if sep < self.min_separation_bars or sep > self.max_separation_bars:
+            return None
+        atr = ctx.feat.atr14
+        if atr <= 0:
+            return None
+        if abs(a.price - b.price) > self.max_separation_atr * atr:
+            return None
+        if not (not ctx.feat.is_bull and ctx.feat.close < ctx.feat.open):
+            return None
+        if b.bar_idx == self._state.last_signal_bar_idx:
+            return None
+        self._state.last_signal_bar_idx = b.bar_idx
+        entry = ctx.feat.low - _TICK
+        stop = max(a.price, b.price) + _TICK
+        return PatternSignal(
+            detector=self.name,
+            side="short",
+            signal_bar_idx=ctx.feat.bar_idx,
+            entry_px=entry,
+            stop_px=stop,
+            timestamp_ns=ctx.feat.timestamp_ns,
+            reason=f"double-top: swings at {a.bar_idx}={a.price:.4f} & {b.bar_idx}={b.price:.4f}",
+            metadata={
+                "high1_idx": a.bar_idx,
+                "high1_px": a.price,
+                "high2_idx": b.bar_idx,
+                "high2_px": b.price,
+            },
+        )

--- a/src/brooks/patterns/double_tb.py
+++ b/src/brooks/patterns/double_tb.py
@@ -50,9 +50,7 @@ class DoubleBottomDetector(_DoubleTwinBase):
     side: Literal["long", "short"] = "long"
 
     def on_bar(self, ctx: DetectorContext) -> Optional[PatternSignal]:
-        lows = [
-            s for s in ctx.structure.confirmed_swing_lows if s.confirmed_at_idx <= ctx.feat.bar_idx
-        ]
+        lows = [s for s in ctx.structure.confirmed_swing_lows if s.confirmed_at_idx <= ctx.feat.bar_idx]
         if len(lows) < 2:
             return None
         a, b = lows[-2], lows[-1]
@@ -93,9 +91,7 @@ class DoubleTopDetector(_DoubleTwinBase):
     side: Literal["long", "short"] = "short"
 
     def on_bar(self, ctx: DetectorContext) -> Optional[PatternSignal]:
-        highs = [
-            s for s in ctx.structure.confirmed_swing_highs if s.confirmed_at_idx <= ctx.feat.bar_idx
-        ]
+        highs = [s for s in ctx.structure.confirmed_swing_highs if s.confirmed_at_idx <= ctx.feat.bar_idx]
         if len(highs) < 2:
             return None
         a, b = highs[-2], highs[-1]

--- a/src/brooks/patterns/final_flag.py
+++ b/src/brooks/patterns/final_flag.py
@@ -1,0 +1,125 @@
+"""Final Flag detector — tight range after a strong trend leg, then break
+the *opposite* direction (trend exhaustion).
+
+Rules (simplified):
+  * Preceding strong leg: trend has ``leg_length >= leg_min`` bars
+  * Consolidation: ``flag_min_bars`` bars of tight range (range <
+    ``flag_atr_mult`` × ATR)
+  * Breakout: close breaks opposite extreme of the flag range
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from src.brooks.patterns.base import DetectorContext, PatternDetector, PatternSignal
+from src.brooks.patterns.registry import PatternRegistry
+
+_TICK = 1e-6
+
+
+@dataclass
+class _FlagState:
+    last_signal_bar_idx: int = -1
+
+
+@PatternRegistry.register("final_flag")
+class FinalFlagDetector(PatternDetector):
+    def __init__(
+        self,
+        leg_min: int = 6,
+        flag_min_bars: int = 5,
+        flag_max_bars: int = 15,
+        flag_atr_mult: float = 0.8,
+    ):
+        self.leg_min = leg_min
+        self.flag_min_bars = flag_min_bars
+        self.flag_max_bars = flag_max_bars
+        self.flag_atr_mult = flag_atr_mult
+        self._state = _FlagState()
+
+    def state_snapshot(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "last_signal_bar_idx": self._state.last_signal_bar_idx,
+        }
+
+    def reset(self) -> None:
+        self._state = _FlagState()
+
+    def on_bar(self, ctx: DetectorContext) -> Optional[PatternSignal]:
+        feat = ctx.feat
+        atr = feat.atr14
+        if atr <= 0:
+            return None
+        recent = ctx.recent_features
+        if len(recent) < self.flag_min_bars + self.leg_min + 1:
+            return None
+
+        for flag_len in range(
+            self.flag_min_bars,
+            min(self.flag_max_bars, len(recent) - self.leg_min - 1) + 1,
+        ):
+            flag_slice: List = recent[-flag_len - 1 : -1]
+            if len(flag_slice) < flag_len:
+                continue
+            flag_high = max(b.high for b in flag_slice)
+            flag_low = min(b.low for b in flag_slice)
+            flag_range = flag_high - flag_low
+            if flag_range > self.flag_atr_mult * atr * flag_len / self.flag_min_bars:
+                continue
+            if flag_range <= 0:
+                continue
+
+            pre_slice: List = recent[-flag_len - 1 - self.leg_min : -flag_len - 1]
+            if len(pre_slice) < self.leg_min:
+                continue
+            pre_high = max(b.high for b in pre_slice)
+            pre_low = min(b.low for b in pre_slice)
+            pre_range = pre_high - pre_low
+            if pre_range < 2 * flag_range:
+                continue
+
+            pre_trend_up = pre_slice[-1].close > pre_slice[0].close
+            if pre_trend_up and feat.close < flag_low:
+                if feat.bar_idx == self._state.last_signal_bar_idx:
+                    return None
+                self._state.last_signal_bar_idx = feat.bar_idx
+                entry = feat.low - _TICK
+                stop = flag_high + _TICK
+                return PatternSignal(
+                    detector=self.name,
+                    side="short",
+                    signal_bar_idx=feat.bar_idx,
+                    entry_px=entry,
+                    stop_px=stop,
+                    timestamp_ns=feat.timestamp_ns,
+                    reason=f"final flag top (len={flag_len}, range/ATR={flag_range / atr:.2f})",
+                    metadata={
+                        "flag_high": flag_high,
+                        "flag_low": flag_low,
+                        "flag_len": flag_len,
+                    },
+                )
+            if (not pre_trend_up) and feat.close > flag_high:
+                if feat.bar_idx == self._state.last_signal_bar_idx:
+                    return None
+                self._state.last_signal_bar_idx = feat.bar_idx
+                entry = feat.high + _TICK
+                stop = flag_low - _TICK
+                return PatternSignal(
+                    detector=self.name,
+                    side="long",
+                    signal_bar_idx=feat.bar_idx,
+                    entry_px=entry,
+                    stop_px=stop,
+                    timestamp_ns=feat.timestamp_ns,
+                    reason=f"final flag bottom (len={flag_len}, range/ATR={flag_range / atr:.2f})",
+                    metadata={
+                        "flag_high": flag_high,
+                        "flag_low": flag_low,
+                        "flag_len": flag_len,
+                    },
+                )
+        return None

--- a/src/brooks/patterns/h2_l2.py
+++ b/src/brooks/patterns/h2_l2.py
@@ -25,9 +25,7 @@ _TICK = 1e-6
 
 @dataclass
 class _PBState:
-    state: Literal[
-        "IDLE", "PB_LEG1", "PB_LEG1_RECOVERY", "PB_LEG2", "H2_FORMED", "TRIGGERED", "INVALID"
-    ] = "IDLE"
+    state: Literal["IDLE", "PB_LEG1", "PB_LEG1_RECOVERY", "PB_LEG2", "H2_FORMED", "TRIGGERED", "INVALID"] = "IDLE"
     pb_start_idx: int = -1
     leg1_extreme: float = 0.0
     recovery_extreme: float = 0.0

--- a/src/brooks/patterns/h2_l2.py
+++ b/src/brooks/patterns/h2_l2.py
@@ -1,0 +1,290 @@
+"""H2 / L2 pullback detectors.
+
+H2 ("high two"): in an always-in-long context, price pulls back twice against
+the trend before the bull pattern re-asserts. Textbook sequence:
+
+  1. Some bear bars (leg-1 down) make a low
+  2. One or more bull bars recover
+  3. Another bear push (leg-2 down) takes out (or matches) leg-1 low
+  4. A bull reversal bar forms — that's the *signal bar*
+  5. Entry = signal_bar.high + 1 tick (stop-buy), stop = signal_bar.low - 1 tick
+
+L2 is the bearish mirror.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Literal, Optional
+
+from src.brooks.patterns.base import DetectorContext, PatternDetector, PatternSignal
+from src.brooks.patterns.registry import PatternRegistry
+
+_TICK = 1e-6
+
+
+@dataclass
+class _PBState:
+    state: Literal[
+        "IDLE", "PB_LEG1", "PB_LEG1_RECOVERY", "PB_LEG2", "H2_FORMED", "TRIGGERED", "INVALID"
+    ] = "IDLE"
+    pb_start_idx: int = -1
+    leg1_extreme: float = 0.0
+    recovery_extreme: float = 0.0
+    signal_bar_idx: int = -1
+    signal_bar_high: float = 0.0
+    signal_bar_low: float = 0.0
+    leg2_start_idx: int = -1
+
+
+class _TwoLeggedPullbackBase(PatternDetector):
+    """Shared FSM for H2 and L2 — subclass picks direction-specific wiring."""
+
+    side: Literal["long", "short"]
+
+    def __init__(self, max_leg_bars: int = 10, invalidate_atr_mult: float = 2.0):
+        self._s = _PBState()
+        self.max_leg_bars = max_leg_bars
+        self.invalidate_atr_mult = invalidate_atr_mult
+
+    # ---- public --------------------------------------------------------
+
+    def on_bar(self, ctx: DetectorContext) -> Optional[PatternSignal]:
+        if not self._trend_ok(ctx):
+            self._s = _PBState()
+            return None
+
+        feat = ctx.feat
+        s = self._s
+
+        if s.state == "IDLE":
+            self._maybe_start_leg1(feat)
+            return None
+
+        if s.state == "PB_LEG1":
+            self._handle_leg1(ctx)
+            return None
+
+        if s.state == "PB_LEG1_RECOVERY":
+            self._handle_recovery(ctx)
+            return None
+
+        if s.state == "PB_LEG2":
+            return self._handle_leg2(ctx)
+
+        if s.state == "H2_FORMED":
+            if feat.bar_idx - s.signal_bar_idx > 3:
+                self._s = _PBState()
+            return None
+
+        return None
+
+    def state_snapshot(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "detector": self.name,
+            "state": self._s.state,
+            "pb_start_idx": self._s.pb_start_idx,
+            "leg1_extreme": round(self._s.leg1_extreme, 6),
+            "recovery_extreme": round(self._s.recovery_extreme, 6),
+            "signal_bar_idx": self._s.signal_bar_idx,
+        }
+
+    def mark_triggered(self, bar_idx: int) -> None:
+        if self._s.state == "H2_FORMED":
+            self._s = _PBState()
+
+    def reset(self) -> None:
+        self._s = _PBState()
+
+    # ---- direction-specific hooks (overridden) -------------------------
+
+    def _trend_ok(self, ctx: DetectorContext) -> bool:  # pragma: no cover
+        raise NotImplementedError
+
+    def _is_against(self, feat) -> bool:  # pragma: no cover
+        raise NotImplementedError
+
+    def _is_with(self, feat) -> bool:  # pragma: no cover
+        raise NotImplementedError
+
+    def _extreme_against(self, feat, current: float) -> float:  # pragma: no cover
+        raise NotImplementedError
+
+    def _recovery_extreme(self, feat, current: float) -> float:  # pragma: no cover
+        raise NotImplementedError
+
+    def _leg2_breaks_leg1(self, feat) -> bool:  # pragma: no cover
+        raise NotImplementedError
+
+    def _recovery_broken(self, feat) -> bool:  # pragma: no cover
+        raise NotImplementedError
+
+    def _make_signal(self, ctx: DetectorContext) -> PatternSignal:  # pragma: no cover
+        raise NotImplementedError
+
+    # ---- FSM step helpers ---------------------------------------------
+
+    def _maybe_start_leg1(self, feat) -> None:
+        if self._is_against(feat):
+            self._s.state = "PB_LEG1"
+            self._s.pb_start_idx = feat.bar_idx
+            self._s.leg1_extreme = feat.low if self.side == "long" else feat.high
+
+    def _handle_leg1(self, ctx: DetectorContext) -> None:
+        feat = ctx.feat
+        s = self._s
+        atr = ctx.feat.atr14
+        if self.side == "long":
+            start_close = (
+                ctx.recent_features[-(feat.bar_idx - s.pb_start_idx) - 1].close
+                if (feat.bar_idx - s.pb_start_idx) < len(ctx.recent_features)
+                else feat.close
+            )
+            if atr > 0 and start_close - feat.close > self.invalidate_atr_mult * atr:
+                self._s = _PBState()
+                return
+        else:
+            start_close = (
+                ctx.recent_features[-(feat.bar_idx - s.pb_start_idx) - 1].close
+                if (feat.bar_idx - s.pb_start_idx) < len(ctx.recent_features)
+                else feat.close
+            )
+            if atr > 0 and feat.close - start_close > self.invalidate_atr_mult * atr:
+                self._s = _PBState()
+                return
+
+        if feat.bar_idx - s.pb_start_idx > self.max_leg_bars:
+            self._s = _PBState()
+            return
+
+        if self._is_against(feat):
+            s.leg1_extreme = self._extreme_against(feat, s.leg1_extreme)
+        elif self._is_with(feat):
+            s.state = "PB_LEG1_RECOVERY"
+            s.recovery_extreme = feat.high if self.side == "long" else feat.low
+
+    def _handle_recovery(self, ctx: DetectorContext) -> None:
+        feat = ctx.feat
+        s = self._s
+        if self._recovery_broken(feat):
+            self._s = _PBState()
+            return
+        if self._is_with(feat):
+            s.recovery_extreme = self._recovery_extreme(feat, s.recovery_extreme)
+        elif self._is_against(feat):
+            s.state = "PB_LEG2"
+            s.leg2_start_idx = feat.bar_idx
+
+    def _handle_leg2(self, ctx: DetectorContext) -> Optional[PatternSignal]:
+        feat = ctx.feat
+        s = self._s
+
+        if feat.bar_idx - s.leg2_start_idx > self.max_leg_bars:
+            self._s = _PBState()
+            return None
+
+        if self._leg2_breaks_leg1(feat):
+            if self._is_with(feat) or feat.is_reversal_bar:
+                s.state = "H2_FORMED"
+                s.signal_bar_idx = feat.bar_idx
+                s.signal_bar_high = feat.high
+                s.signal_bar_low = feat.low
+                return self._make_signal(ctx)
+        return None
+
+
+@PatternRegistry.register("h2")
+class H2Detector(_TwoLeggedPullbackBase):
+    side: Literal["long", "short"] = "long"
+
+    def _trend_ok(self, ctx: DetectorContext) -> bool:
+        return ctx.structure.always_in == "long"
+
+    def _is_against(self, feat) -> bool:
+        return not feat.is_bull and feat.body_pct >= 30
+
+    def _is_with(self, feat) -> bool:
+        return feat.is_bull and feat.body_pct >= 30
+
+    def _extreme_against(self, feat, current: float) -> float:
+        return min(feat.low, current) if current > 0 else feat.low
+
+    def _recovery_extreme(self, feat, current: float) -> float:
+        return max(feat.high, current)
+
+    def _leg2_breaks_leg1(self, feat) -> bool:
+        return feat.low <= self._s.leg1_extreme
+
+    def _recovery_broken(self, feat) -> bool:
+        return False
+
+    def _make_signal(self, ctx: DetectorContext) -> PatternSignal:
+        s = self._s
+        entry = s.signal_bar_high + _TICK
+        stop = s.signal_bar_low - _TICK
+        return PatternSignal(
+            detector=self.name,
+            side="long",
+            signal_bar_idx=s.signal_bar_idx,
+            entry_px=entry,
+            stop_px=stop,
+            timestamp_ns=ctx.feat.timestamp_ns,
+            reason=(
+                f"H2 formed at bar {s.signal_bar_idx}: leg1_low={s.leg1_extreme:.4f} "
+                f"recovery_high={s.recovery_extreme:.4f} always_in=long"
+            ),
+            metadata={
+                "leg1_low": s.leg1_extreme,
+                "recovery_high": s.recovery_extreme,
+                "pb_start_idx": s.pb_start_idx,
+            },
+        )
+
+
+@PatternRegistry.register("l2")
+class L2Detector(_TwoLeggedPullbackBase):
+    side: Literal["long", "short"] = "short"
+
+    def _trend_ok(self, ctx: DetectorContext) -> bool:
+        return ctx.structure.always_in == "short"
+
+    def _is_against(self, feat) -> bool:
+        return feat.is_bull and feat.body_pct >= 30
+
+    def _is_with(self, feat) -> bool:
+        return not feat.is_bull and feat.body_pct >= 30
+
+    def _extreme_against(self, feat, current: float) -> float:
+        return max(feat.high, current)
+
+    def _recovery_extreme(self, feat, current: float) -> float:
+        return min(feat.low, current) if current > 0 else feat.low
+
+    def _leg2_breaks_leg1(self, feat) -> bool:
+        return feat.high >= self._s.leg1_extreme
+
+    def _recovery_broken(self, feat) -> bool:
+        return False
+
+    def _make_signal(self, ctx: DetectorContext) -> PatternSignal:
+        s = self._s
+        entry = s.signal_bar_low - _TICK
+        stop = s.signal_bar_high + _TICK
+        return PatternSignal(
+            detector=self.name,
+            side="short",
+            signal_bar_idx=s.signal_bar_idx,
+            entry_px=entry,
+            stop_px=stop,
+            timestamp_ns=ctx.feat.timestamp_ns,
+            reason=(
+                f"L2 formed at bar {s.signal_bar_idx}: leg1_high={s.leg1_extreme:.4f} "
+                f"recovery_low={s.recovery_extreme:.4f} always_in=short"
+            ),
+            metadata={
+                "leg1_high": s.leg1_extreme,
+                "recovery_low": s.recovery_extreme,
+                "pb_start_idx": s.pb_start_idx,
+            },
+        )

--- a/src/brooks/patterns/measured_move.py
+++ b/src/brooks/patterns/measured_move.py
@@ -1,0 +1,57 @@
+"""Measured Move target calculator.
+
+Not a signal generator — a helper that projects a target price from the
+most recent impulse leg, used by the risk model for optional TP
+placement. ``on_bar`` always returns ``None``; call :meth:`target`
+directly for a projected TP.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Literal, Optional
+
+from src.brooks.patterns.base import DetectorContext, PatternDetector, PatternSignal
+from src.brooks.patterns.registry import PatternRegistry
+
+
+@PatternRegistry.register("measured_move")
+class MeasuredMoveTargeter(PatternDetector):
+    def state_snapshot(self) -> Dict[str, Any]:
+        return {"name": self.name}
+
+    def reset(self) -> None:  # noqa: D401 — no state
+        pass
+
+    def on_bar(self, ctx: DetectorContext) -> Optional[PatternSignal]:
+        return None
+
+    def target(
+        self,
+        ctx: DetectorContext,
+        side: Literal["long", "short"],
+        entry_px: float,
+    ) -> Optional[float]:
+        """Return measured-move TP for the given side, or ``None`` if no impulse visible."""
+        recent = ctx.recent_features
+        if len(recent) < 6:
+            return None
+        if side == "long":
+            lows = [(b.bar_idx, b.low) for b in recent]
+            if not lows:
+                return None
+            low_idx = min(range(len(lows)), key=lambda i: lows[i][1])
+            high_after = max(b.high for b in recent[low_idx:])
+            leg = high_after - lows[low_idx][1]
+            if leg <= 0:
+                return None
+            return entry_px + leg
+        else:
+            highs = [(b.bar_idx, b.high) for b in recent]
+            if not highs:
+                return None
+            high_idx = max(range(len(highs)), key=lambda i: highs[i][1])
+            low_after = min(b.low for b in recent[high_idx:])
+            leg = highs[high_idx][1] - low_after
+            if leg <= 0:
+                return None
+            return entry_px - leg

--- a/src/brooks/patterns/registry.py
+++ b/src/brooks/patterns/registry.py
@@ -1,0 +1,54 @@
+"""Name → :class:`PatternDetector` registry.
+
+Use as a class decorator::
+
+    @PatternRegistry.register("h2")
+    class H2Detector(PatternDetector):
+        ...
+
+Then build instances with::
+
+    det = PatternRegistry.build("h2", max_leg_bars=12)
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Type
+
+from src.brooks.patterns.base import PatternDetector
+
+_REGISTRY: Dict[str, Type[PatternDetector]] = {}
+
+
+class PatternRegistry:
+    """Decorator + factory for :class:`PatternDetector` subclasses."""
+
+    @classmethod
+    def register(cls, name: str):
+        def decorator(klass: Type[PatternDetector]) -> Type[PatternDetector]:
+            if name in _REGISTRY and _REGISTRY[name] is not klass:
+                raise ValueError(
+                    f"PatternRegistry: name {name!r} already registered "
+                    f"to {_REGISTRY[name].__name__}"
+                )
+            _REGISTRY[name] = klass
+            klass.name = name
+            return klass
+
+        return decorator
+
+    @classmethod
+    def build(cls, name: str, **params) -> PatternDetector:
+        if name not in _REGISTRY:
+            raise KeyError(f"PatternRegistry: unknown detector {name!r}")
+        return _REGISTRY[name](**params)
+
+    @classmethod
+    def all(cls) -> List[str]:
+        return list(_REGISTRY.keys())
+
+    @classmethod
+    def get(cls, name: str) -> Type[PatternDetector]:
+        if name not in _REGISTRY:
+            raise KeyError(f"PatternRegistry: unknown detector {name!r}")
+        return _REGISTRY[name]

--- a/src/brooks/patterns/registry.py
+++ b/src/brooks/patterns/registry.py
@@ -27,10 +27,7 @@ class PatternRegistry:
     def register(cls, name: str):
         def decorator(klass: Type[PatternDetector]) -> Type[PatternDetector]:
             if name in _REGISTRY and _REGISTRY[name] is not klass:
-                raise ValueError(
-                    f"PatternRegistry: name {name!r} already registered "
-                    f"to {_REGISTRY[name].__name__}"
-                )
+                raise ValueError(f"PatternRegistry: name {name!r} already registered to {_REGISTRY[name].__name__}")
             _REGISTRY[name] = klass
             klass.name = name
             return klass

--- a/src/brooks/patterns/wedge.py
+++ b/src/brooks/patterns/wedge.py
@@ -1,0 +1,119 @@
+"""3-push wedge detectors.
+
+Bullish wedge (``wedge_long``): 3 sequential *lower* swing lows with
+contracting gaps between pushes; the third-push recovery forms the
+signal bar. ``wedge_short`` mirrors on swing highs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Literal, Optional
+
+from src.brooks.patterns.base import DetectorContext, PatternDetector, PatternSignal
+from src.brooks.patterns.registry import PatternRegistry
+
+_TICK = 1e-6
+
+
+@dataclass
+class _WedgeState:
+    last_signal_bar_idx: int = -1
+
+
+class _WedgeBase(PatternDetector):
+    side: Literal["long", "short"]
+
+    def __init__(self, min_separation_bars: int = 2, max_total_bars: int = 60):
+        self.min_separation_bars = min_separation_bars
+        self.max_total_bars = max_total_bars
+        self._state = _WedgeState()
+
+    def state_snapshot(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "last_signal_bar_idx": self._state.last_signal_bar_idx,
+        }
+
+    def reset(self) -> None:
+        self._state = _WedgeState()
+
+
+@PatternRegistry.register("wedge_long")
+class WedgeLongDetector(_WedgeBase):
+    side: Literal["long", "short"] = "long"
+
+    def on_bar(self, ctx: DetectorContext) -> Optional[PatternSignal]:
+        pivots = [
+            s for s in ctx.structure.confirmed_swing_lows if s.confirmed_at_idx <= ctx.feat.bar_idx
+        ]
+        if len(pivots) < 3:
+            return None
+        p1, p2, p3 = pivots[-3:]
+        if p3.bar_idx - p1.bar_idx > self.max_total_bars:
+            return None
+        if p2.bar_idx - p1.bar_idx < self.min_separation_bars:
+            return None
+        if p3.bar_idx - p2.bar_idx < self.min_separation_bars:
+            return None
+        if not (p1.price > p2.price > p3.price):
+            return None
+        if (p2.price - p3.price) >= (p1.price - p2.price):
+            return None
+        if not (ctx.feat.is_bull and ctx.feat.close > p3.price):
+            return None
+        if p3.bar_idx == self._state.last_signal_bar_idx:
+            return None
+        self._state.last_signal_bar_idx = p3.bar_idx
+        entry = ctx.feat.high + _TICK
+        stop = p3.price - _TICK
+        return PatternSignal(
+            detector=self.name,
+            side="long",
+            signal_bar_idx=ctx.feat.bar_idx,
+            entry_px=entry,
+            stop_px=stop,
+            timestamp_ns=ctx.feat.timestamp_ns,
+            reason=f"3-push wedge bottom: {p1.price:.4f} → {p2.price:.4f} → {p3.price:.4f}",
+            metadata={"p1_idx": p1.bar_idx, "p2_idx": p2.bar_idx, "p3_idx": p3.bar_idx},
+        )
+
+
+@PatternRegistry.register("wedge_short")
+class WedgeShortDetector(_WedgeBase):
+    side: Literal["long", "short"] = "short"
+
+    def on_bar(self, ctx: DetectorContext) -> Optional[PatternSignal]:
+        pivots = [
+            s for s in ctx.structure.confirmed_swing_highs if s.confirmed_at_idx <= ctx.feat.bar_idx
+        ]
+        if len(pivots) < 3:
+            return None
+        p1, p2, p3 = pivots[-3:]
+        if p3.bar_idx - p1.bar_idx > self.max_total_bars:
+            return None
+        if p2.bar_idx - p1.bar_idx < self.min_separation_bars:
+            return None
+        if p3.bar_idx - p2.bar_idx < self.min_separation_bars:
+            return None
+        if not (p1.price < p2.price < p3.price):
+            return None
+        if (p3.price - p2.price) >= (p2.price - p1.price):
+            return None
+        if not (not ctx.feat.is_bull and ctx.feat.close < p3.price):
+            return None
+        if p3.bar_idx == self._state.last_signal_bar_idx:
+            return None
+        self._state.last_signal_bar_idx = p3.bar_idx
+        entry = ctx.feat.low - _TICK
+        stop = p3.price + _TICK
+        return PatternSignal(
+            detector=self.name,
+            side="short",
+            signal_bar_idx=ctx.feat.bar_idx,
+            entry_px=entry,
+            stop_px=stop,
+            timestamp_ns=ctx.feat.timestamp_ns,
+            reason=f"3-push wedge top: {p1.price:.4f} → {p2.price:.4f} → {p3.price:.4f}",
+            metadata={"p1_idx": p1.bar_idx, "p2_idx": p2.bar_idx, "p3_idx": p3.bar_idx},
+        )

--- a/src/brooks/patterns/wedge.py
+++ b/src/brooks/patterns/wedge.py
@@ -44,9 +44,7 @@ class WedgeLongDetector(_WedgeBase):
     side: Literal["long", "short"] = "long"
 
     def on_bar(self, ctx: DetectorContext) -> Optional[PatternSignal]:
-        pivots = [
-            s for s in ctx.structure.confirmed_swing_lows if s.confirmed_at_idx <= ctx.feat.bar_idx
-        ]
+        pivots = [s for s in ctx.structure.confirmed_swing_lows if s.confirmed_at_idx <= ctx.feat.bar_idx]
         if len(pivots) < 3:
             return None
         p1, p2, p3 = pivots[-3:]
@@ -84,9 +82,7 @@ class WedgeShortDetector(_WedgeBase):
     side: Literal["long", "short"] = "short"
 
     def on_bar(self, ctx: DetectorContext) -> Optional[PatternSignal]:
-        pivots = [
-            s for s in ctx.structure.confirmed_swing_highs if s.confirmed_at_idx <= ctx.feat.bar_idx
-        ]
+        pivots = [s for s in ctx.structure.confirmed_swing_highs if s.confirmed_at_idx <= ctx.feat.bar_idx]
         if len(pivots) < 3:
             return None
         p1, p2, p3 = pivots[-3:]

--- a/tests/brooks/conftest.py
+++ b/tests/brooks/conftest.py
@@ -1,0 +1,113 @@
+"""Shared fixtures for Brooks detector tests."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Iterable, List, Tuple
+
+import pytest
+
+from src.core.base import Bar
+
+
+def mkbar(i: int, o: float, h: float, l: float, c: float, *, symbol: str = "BTCUSDT") -> Bar:
+    return Bar(
+        symbol=symbol,
+        timestamp=datetime(2025, 1, 1, 9, 0) + timedelta(minutes=5 * i),
+        open=o,
+        high=h,
+        low=l,
+        close=c,
+        volume=1.0,
+        amount=c,
+    )
+
+
+def make_series(values: Iterable[Tuple[float, float, float, float]]) -> List[Bar]:
+    """``values`` = iterable of (o, h, l, c)."""
+    out: List[Bar] = []
+    for i, (o, h, l, c) in enumerate(values):
+        out.append(mkbar(i, o, h, l, c))
+    return out
+
+
+@pytest.fixture
+def synthetic_h2_bars() -> List[Bar]:
+    """Hand-crafted bars designed to produce a valid H2 pattern."""
+    vals: list[tuple] = []
+    price = 100.0
+    for _ in range(15):
+        o = price
+        c = price + 1.0
+        h = c + 0.1
+        l = o - 0.1
+        vals.append((o, h, l, c))
+        price = c
+    for _ in range(3):
+        o = price
+        c = price - 0.8
+        h = o + 0.05
+        l = c - 0.1
+        vals.append((o, h, l, c))
+        price = c
+    leg1_low = price - 0.1
+    for _ in range(2):
+        o = price
+        c = price + 0.6
+        h = c + 0.05
+        l = o - 0.05
+        vals.append((o, h, l, c))
+        price = c
+    o = price
+    c = price - 0.9
+    h = o + 0.02
+    l = c - 0.05
+    vals.append((o, h, l, c))
+    price = c
+    o = price
+    l_r = leg1_low - 0.05
+    c_r = price + 0.6
+    h_r = c_r + 0.05
+    vals.append((o, h_r, l_r, c_r))
+    return make_series(vals)
+
+
+@pytest.fixture
+def synthetic_l2_bars() -> List[Bar]:
+    """Mirror: steady downtrend then L2 bear setup."""
+    vals: list[tuple] = []
+    price = 100.0
+    for _ in range(15):
+        o = price
+        c = price - 1.0
+        h = o + 0.1
+        l = c - 0.1
+        vals.append((o, h, l, c))
+        price = c
+    for _ in range(3):
+        o = price
+        c = price + 0.8
+        h = c + 0.1
+        l = o - 0.05
+        vals.append((o, h, l, c))
+        price = c
+    leg1_high = price + 0.1
+    for _ in range(2):
+        o = price
+        c = price - 0.6
+        h = o + 0.05
+        l = c - 0.05
+        vals.append((o, h, l, c))
+        price = c
+    o = price
+    c = price + 0.9
+    h = c + 0.05
+    l = o - 0.02
+    vals.append((o, h, l, c))
+    price = c
+    o = price
+    h_r = leg1_high + 0.05
+    c_r = price - 0.6
+    l_r = c_r - 0.05
+    vals.append((o, h_r, l_r, c_r))
+    return make_series(vals)

--- a/tests/brooks/test_patterns_double_tb.py
+++ b/tests/brooks/test_patterns_double_tb.py
@@ -1,0 +1,56 @@
+"""Double top / double bottom detector smoke tests."""
+
+from __future__ import annotations
+
+from typing import List
+
+from src.brooks.features import BarFeatureExtractor, ExtendedBarFeatures
+from src.brooks.patterns import (
+    DetectorContext,
+    DoubleBottomDetector,
+    DoubleTopDetector,
+)
+from src.brooks.structure import MarketStructureTracker
+from src.core.base import Bar
+
+from .conftest import make_series
+
+
+def _run(bars: List[Bar], detector, *, swing_k=2, breakout_lookback=6):
+    ext = BarFeatureExtractor(swing_k=swing_k, breakout_lookback=breakout_lookback, atr_period=5)
+    tr = MarketStructureTracker(ext, breakout_lookback=breakout_lookback)
+    hist: List[ExtendedBarFeatures] = []
+    signals = []
+    for b in bars:
+        ts_ns = int(b.timestamp.timestamp() * 1_000_000_000)
+        f = ext.on_bar(ts_ns, b.open, b.high, b.low, b.close)
+        s = tr.on_features(f)
+        hist.append(f)
+        sig = detector.on_bar(DetectorContext(feat=f, structure=s, recent_features=hist))
+        if sig is not None:
+            signals.append(sig)
+    return signals
+
+
+def test_double_bottom_registered_name_and_side():
+    det = DoubleBottomDetector()
+    assert det.name == "double_bottom"
+    assert det.side == "long"
+
+
+def test_double_top_registered_name_and_side():
+    det = DoubleTopDetector()
+    assert det.name == "double_top"
+    assert det.side == "short"
+
+
+def test_double_bottom_no_signal_without_two_lows():
+    vals = [(100.0, 100.5, 99.5, 100.0) for _ in range(10)]
+    signals = _run(make_series(vals), DoubleBottomDetector())
+    assert signals == []
+
+
+def test_double_top_no_signal_without_two_highs():
+    vals = [(100.0, 100.5, 99.5, 100.0) for _ in range(10)]
+    signals = _run(make_series(vals), DoubleTopDetector())
+    assert signals == []

--- a/tests/brooks/test_patterns_final_flag.py
+++ b/tests/brooks/test_patterns_final_flag.py
@@ -1,0 +1,46 @@
+"""Final flag detector smoke tests."""
+
+from __future__ import annotations
+
+from typing import List
+
+from src.brooks.features import BarFeatureExtractor, ExtendedBarFeatures
+from src.brooks.patterns import DetectorContext, FinalFlagDetector
+from src.brooks.structure import MarketStructureTracker
+from src.core.base import Bar
+
+from .conftest import make_series
+
+
+def _run(bars: List[Bar], detector, *, swing_k=2, breakout_lookback=6):
+    ext = BarFeatureExtractor(swing_k=swing_k, breakout_lookback=breakout_lookback, atr_period=5)
+    tr = MarketStructureTracker(ext, breakout_lookback=breakout_lookback)
+    hist: List[ExtendedBarFeatures] = []
+    signals = []
+    for b in bars:
+        ts_ns = int(b.timestamp.timestamp() * 1_000_000_000)
+        f = ext.on_bar(ts_ns, b.open, b.high, b.low, b.close)
+        s = tr.on_features(f)
+        hist.append(f)
+        sig = detector.on_bar(DetectorContext(feat=f, structure=s, recent_features=hist))
+        if sig is not None:
+            signals.append(sig)
+    return signals
+
+
+def test_final_flag_registered_name():
+    det = FinalFlagDetector()
+    assert det.name == "final_flag"
+
+
+def test_final_flag_no_signal_on_flat_series():
+    vals = [(100.0, 100.5, 99.5, 100.0) for _ in range(30)]
+    signals = _run(make_series(vals), FinalFlagDetector())
+    assert signals == []
+
+
+def test_final_flag_requires_min_history():
+    """No history → should not raise or emit."""
+    vals = [(100.0, 100.5, 99.5, 100.0) for _ in range(3)]
+    signals = _run(make_series(vals), FinalFlagDetector())
+    assert signals == []

--- a/tests/brooks/test_patterns_h2_l2.py
+++ b/tests/brooks/test_patterns_h2_l2.py
@@ -1,0 +1,70 @@
+"""H2 / L2 FSM behavioral tests."""
+
+from __future__ import annotations
+
+from typing import List
+
+from src.brooks.features import BarFeatureExtractor, ExtendedBarFeatures
+from src.brooks.patterns import DetectorContext, H2Detector, L2Detector
+from src.brooks.structure import MarketStructureTracker
+from src.core.base import Bar
+
+from .conftest import make_series
+
+
+def _run(bars: List[Bar], detector, *, breakout_lookback=8, swing_k=2):
+    ext = BarFeatureExtractor(swing_k=swing_k, breakout_lookback=breakout_lookback, atr_period=5)
+    tr = MarketStructureTracker(ext, breakout_lookback=breakout_lookback)
+    hist: List[ExtendedBarFeatures] = []
+    states = []
+    signals = []
+    for b in bars:
+        ts_ns = int(b.timestamp.timestamp() * 1_000_000_000)
+        f = ext.on_bar(ts_ns, b.open, b.high, b.low, b.close)
+        s = tr.on_features(f)
+        hist.append(f)
+        ctx = DetectorContext(feat=f, structure=s, recent_features=hist)
+        sig = detector.on_bar(ctx)
+        states.append(detector.state_snapshot()["state"])
+        if sig is not None:
+            signals.append(sig)
+    return states, signals
+
+
+def test_h2_forms_and_emits_signal(synthetic_h2_bars):
+    det = H2Detector()
+    states, signals = _run(synthetic_h2_bars, det, breakout_lookback=8, swing_k=2)
+    assert "H2_FORMED" in states, f"state trace: {states}"
+    assert len(signals) >= 1
+    sig = signals[0]
+    assert sig.side == "long"
+    assert sig.detector == "h2"
+    assert sig.entry_px > sig.stop_px  # long: entry above stop
+
+
+def test_l2_forms_and_emits_signal(synthetic_l2_bars):
+    det = L2Detector()
+    states, signals = _run(synthetic_l2_bars, det, breakout_lookback=8, swing_k=2)
+    assert "H2_FORMED" in states  # shared state machine naming
+    assert len(signals) >= 1
+    sig = signals[0]
+    assert sig.side == "short"
+    assert sig.detector == "l2"
+    assert sig.entry_px < sig.stop_px  # short: entry below stop
+
+
+def test_h2_no_signal_when_always_in_short():
+    """If always_in is short, H2 (long-side) should never fire."""
+    vals = []
+    p = 100.0
+    for _ in range(25):
+        o = p
+        c = p - 0.5
+        h = o + 0.05
+        l = c - 0.05
+        vals.append((o, h, l, c))
+        p = c
+    bars = make_series(vals)
+    det = H2Detector()
+    _, signals = _run(bars, det, breakout_lookback=8, swing_k=2)
+    assert signals == []

--- a/tests/brooks/test_patterns_measured_move.py
+++ b/tests/brooks/test_patterns_measured_move.py
@@ -1,0 +1,59 @@
+"""Measured-move TP helper tests."""
+
+from __future__ import annotations
+
+from typing import List
+
+from src.brooks.features import BarFeatureExtractor, ExtendedBarFeatures
+from src.brooks.patterns import DetectorContext, MeasuredMoveTargeter
+from src.brooks.structure import MarketStructureTracker
+
+from .conftest import make_series
+
+
+def _build_ctx(bars):
+    ext = BarFeatureExtractor(swing_k=2, breakout_lookback=5, atr_period=5)
+    tr = MarketStructureTracker(ext, breakout_lookback=5)
+    hist: List[ExtendedBarFeatures] = []
+    s = None
+    f = None
+    for b in bars:
+        ts_ns = int(b.timestamp.timestamp() * 1_000_000_000)
+        f = ext.on_bar(ts_ns, b.open, b.high, b.low, b.close)
+        s = tr.on_features(f)
+        hist.append(f)
+    return DetectorContext(feat=f, structure=s, recent_features=hist)
+
+
+def test_measured_move_registered_name():
+    det = MeasuredMoveTargeter()
+    assert det.name == "measured_move"
+
+
+def test_measured_move_on_bar_always_none():
+    ctx = _build_ctx(make_series([(100.0, 100.5, 99.5, 100.0) for _ in range(10)]))
+    assert MeasuredMoveTargeter().on_bar(ctx) is None
+
+
+def test_measured_move_target_long_projects_leg():
+    # Simple impulse: low at bar 0, high at bar 5 → leg = 5 → target = entry + 5
+    vals = [
+        (100.0, 100.2, 99.9, 100.1),
+        (100.1, 101.2, 100.0, 101.1),
+        (101.1, 102.2, 101.0, 102.1),
+        (102.1, 103.2, 102.0, 103.1),
+        (103.1, 104.2, 103.0, 104.1),
+        (104.1, 105.0, 104.0, 104.9),
+    ]
+    ctx = _build_ctx(make_series(vals))
+    det = MeasuredMoveTargeter()
+    tp = det.target(ctx, side="long", entry_px=105.0)
+    assert tp is not None
+    # Leg = high_after(105.0) − low_at_start(99.9) ≈ 5.1 → tp ≈ 110.1
+    assert 109.0 < tp < 111.0
+
+
+def test_measured_move_target_returns_none_on_short_history():
+    ctx = _build_ctx(make_series([(100.0, 100.5, 99.5, 100.0) for _ in range(3)]))
+    det = MeasuredMoveTargeter()
+    assert det.target(ctx, side="long", entry_px=100.0) is None

--- a/tests/brooks/test_patterns_registry.py
+++ b/tests/brooks/test_patterns_registry.py
@@ -9,7 +9,6 @@ from src.brooks.patterns.base import PatternDetector
 from src.brooks.patterns.h2_l2 import H2Detector
 from src.brooks.patterns.wedge import WedgeLongDetector, WedgeShortDetector
 
-
 EXPECTED = {
     "h2",
     "l2",

--- a/tests/brooks/test_patterns_registry.py
+++ b/tests/brooks/test_patterns_registry.py
@@ -1,0 +1,55 @@
+"""PatternRegistry sanity tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.brooks.patterns import PatternRegistry
+from src.brooks.patterns.base import PatternDetector
+from src.brooks.patterns.h2_l2 import H2Detector
+from src.brooks.patterns.wedge import WedgeLongDetector, WedgeShortDetector
+
+
+EXPECTED = {
+    "h2",
+    "l2",
+    "double_top",
+    "double_bottom",
+    "wedge_long",
+    "wedge_short",
+    "final_flag",
+    "measured_move",
+}
+
+
+def test_registry_contains_all_expected_detectors():
+    assert EXPECTED.issubset(set(PatternRegistry.all()))
+
+
+def test_registry_class_name_attribute_matches_key():
+    # Decorator assigns klass.name to the registry key.
+    assert H2Detector.name == "h2"
+    assert WedgeLongDetector.name == "wedge_long"
+    assert WedgeShortDetector.name == "wedge_short"
+
+
+def test_registry_build_returns_instance_with_name():
+    det = PatternRegistry.build("h2", max_leg_bars=12)
+    assert isinstance(det, H2Detector)
+    assert isinstance(det, PatternDetector)
+    assert det.name == "h2"
+    assert det.max_leg_bars == 12
+
+
+def test_registry_build_unknown_raises():
+    with pytest.raises(KeyError):
+        PatternRegistry.build("nope")
+
+
+def test_registry_duplicate_name_raises():
+    with pytest.raises(ValueError):
+
+        @PatternRegistry.register("h2")
+        class _Dup(PatternDetector):
+            def on_bar(self, ctx):
+                return None

--- a/tests/brooks/test_patterns_wedge.py
+++ b/tests/brooks/test_patterns_wedge.py
@@ -1,0 +1,53 @@
+"""Wedge (long / short) detector smoke tests."""
+
+from __future__ import annotations
+
+from typing import List
+
+from src.brooks.features import BarFeatureExtractor, ExtendedBarFeatures
+from src.brooks.patterns import DetectorContext, WedgeLongDetector, WedgeShortDetector
+from src.brooks.structure import MarketStructureTracker
+from src.core.base import Bar
+
+from .conftest import make_series
+
+
+def _run(bars: List[Bar], detector, *, swing_k=2, breakout_lookback=6):
+    ext = BarFeatureExtractor(swing_k=swing_k, breakout_lookback=breakout_lookback, atr_period=5)
+    tr = MarketStructureTracker(ext, breakout_lookback=breakout_lookback)
+    hist: List[ExtendedBarFeatures] = []
+    signals = []
+    for b in bars:
+        ts_ns = int(b.timestamp.timestamp() * 1_000_000_000)
+        f = ext.on_bar(ts_ns, b.open, b.high, b.low, b.close)
+        s = tr.on_features(f)
+        hist.append(f)
+        sig = detector.on_bar(DetectorContext(feat=f, structure=s, recent_features=hist))
+        if sig is not None:
+            signals.append(sig)
+    return signals
+
+
+def test_wedge_long_no_signal_on_flat_series():
+    """No 3-push wedge in a chop series → no signal."""
+    vals = [(100.0, 100.5, 99.5, 100.0) for _ in range(30)]
+    signals = _run(make_series(vals), WedgeLongDetector(min_separation_bars=1))
+    assert signals == []
+
+
+def test_wedge_short_no_signal_on_flat_series():
+    vals = [(100.0, 100.5, 99.5, 100.0) for _ in range(30)]
+    signals = _run(make_series(vals), WedgeShortDetector(min_separation_bars=1))
+    assert signals == []
+
+
+def test_wedge_long_detector_name_and_side():
+    det = WedgeLongDetector()
+    assert det.name == "wedge_long"
+    assert det.side == "long"
+
+
+def test_wedge_short_detector_name_and_side():
+    det = WedgeShortDetector()
+    assert det.name == "wedge_short"
+    assert det.side == "short"


### PR DESCRIPTION
## Summary

- Add `src/brooks/patterns/` skeleton: `PatternDetector` ABC, `DetectorContext`, `PatternSignal` (internal type), and `PatternRegistry` decorator/factory.
- Migrate H2/L2, double top/bottom, wedge (split into `wedge_long` / `wedge_short`), final flag, and measured-move detectors from `src/analysis/brooks/patterns/`. All are registered under their acceptance-spec names.
- Add `tests/brooks/test_patterns_*.py` — migrated H2/L2 behavioral tests plus smoke tests for the other detectors and a registry test that verifies the full detector set.

Old code under `src/analysis/brooks/` is untouched — Phase 3 cutover will delete it. Addresses [QUA-44](mention://issue/b550897f-83a0-4d60-9cdc-581194b2c3c1); parent epic [QUA-36](mention://issue/eaa74383-4b6d-4d5d-bf94-b802b3d7578d).

## Test plan

- [x] `pytest tests/brooks/test_patterns_*.py tests/brooks/test_features.py tests/brooks/test_structure.py tests/brooks/test_schema.py` — 48 passed
- [x] `pytest tests/strategies/brooks_v2/` — 17 passed (old tests untouched)
- [x] `PatternRegistry.all()` contains `{h2, l2, double_top, double_bottom, wedge_long, wedge_short, final_flag, measured_move}`
- [x] `PatternRegistry.build("h2", max_leg_bars=12)` returns a working `H2Detector`

🤖 Generated with [Claude Code](https://claude.com/claude-code)