### PR TITLE
feat(brooks/risk): Kelly + StopLadder + TimeStop + PortfolioGuard (QUA-48)

### DIFF
--- a/src/brooks/risk/__init__.py
+++ b/src/brooks/risk/__init__.py
@@ -1,0 +1,28 @@
+"""Brooks risk layer.
+
+Composable components for the strategy → decision → risk → execution pipeline:
+
+* :class:`FixedPercentSizer` / :class:`KellySizer` — position sizing.
+* :class:`StopLadder` — initial → BE → partial_trail → swing_trail stop upgrades.
+* :class:`TimeStop` — N-bar invalidation.
+* :class:`PortfolioGuard` — daily / per-symbol / correlation-group gates.
+* :class:`PositionState` — mutable per-position state threaded through all of
+  the above.
+"""
+
+from src.brooks.risk.portfolio_guard import PortfolioGuard
+from src.brooks.risk.sizer import FixedPercentSizer, KellySizer, Sizer
+from src.brooks.risk.state import LadderStage, PositionState
+from src.brooks.risk.stop_ladder import StopLadder
+from src.brooks.risk.time_stop import TimeStop
+
+__all__ = [
+    "FixedPercentSizer",
+    "KellySizer",
+    "LadderStage",
+    "PortfolioGuard",
+    "PositionState",
+    "Sizer",
+    "StopLadder",
+    "TimeStop",
+]

--- a/src/brooks/risk/portfolio_guard.py
+++ b/src/brooks/risk/portfolio_guard.py
@@ -1,0 +1,79 @@
+"""Portfolio-level entry gate.
+
+Three limits applied before a new position opens:
+
+1. Max aggregate daily risk — sum of ``risk_pct`` across open positions plus
+   the candidate's ``new_risk_pct`` must not exceed ``max_daily_risk_pct``.
+2. Max concurrent positions per symbol.
+3. Correlation groups — each group names a set of symbols that share a risk
+   factor (e.g. same sector, stable/coin basket); only one open position per
+   group is allowed.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Tuple
+
+from src.brooks.risk.state import PositionState
+
+
+class PortfolioGuard:
+    def __init__(
+        self,
+        max_daily_risk_pct: float = 0.03,
+        max_symbol_positions: int = 1,
+        correlation_groups: Optional[Dict[str, List[str]]] = None,
+    ):
+        if max_daily_risk_pct < 0:
+            raise ValueError("max_daily_risk_pct must be non-negative")
+        if max_symbol_positions < 1:
+            raise ValueError("max_symbol_positions must be >= 1")
+        self.max_daily_risk_pct = max_daily_risk_pct
+        self.max_symbol_positions = max_symbol_positions
+        self.correlation_groups: Dict[str, List[str]] = correlation_groups or {}
+
+    def can_open(
+        self,
+        new_symbol: str,
+        new_risk_pct: float,
+        open_positions: Dict[str, PositionState],
+    ) -> Tuple[bool, str]:
+        """Check all gates. Returns (ok, reason)."""
+        if new_risk_pct < 0:
+            return False, "new_risk_pct must be non-negative"
+
+        active = [p for p in open_positions.values() if p.qty_open > 0]
+
+        symbol_count = sum(1 for p in active if p.symbol == new_symbol)
+        if symbol_count >= self.max_symbol_positions:
+            return (
+                False,
+                f"symbol {new_symbol} already has {symbol_count} open position(s) "
+                f"(max {self.max_symbol_positions})",
+            )
+
+        daily_risk = sum(p.risk_pct for p in active) + new_risk_pct
+        if daily_risk > self.max_daily_risk_pct:
+            return (
+                False,
+                f"daily risk {daily_risk:.4f} would exceed cap {self.max_daily_risk_pct:.4f}",
+            )
+
+        conflict_group = self._find_correlation_conflict(new_symbol, active)
+        if conflict_group is not None:
+            return (
+                False,
+                f"correlation group {conflict_group!r} already has an open position",
+            )
+
+        return True, "ok"
+
+    def _find_correlation_conflict(
+        self, new_symbol: str, active: List[PositionState]
+    ) -> Optional[str]:
+        for group_name, members in self.correlation_groups.items():
+            if new_symbol not in members:
+                continue
+            if any(p.symbol in members for p in active):
+                return group_name
+        return None

--- a/src/brooks/risk/sizer.py
+++ b/src/brooks/risk/sizer.py
@@ -1,0 +1,111 @@
+"""Position sizing.
+
+Two concrete implementations plus a ``Sizer`` protocol:
+
+* :class:`FixedPercentSizer` — risk a fixed fraction of equity per trade
+  (default 0.5%). This matches the legacy ``BrooksRiskModel`` behaviour.
+* :class:`KellySizer` — derive the risk fraction from Kelly's criterion,
+  ``f* = p - (1 - p) / b`` where ``b = reward / risk``. A ``fraction``
+  multiplier (default 0.5 → half-Kelly) tempers full Kelly, and the final
+  value is clipped to ``[0, max_risk_pct]``.
+
+Both compute ``qty = (equity * risk_pct) / |entry - stop|`` and cap by
+``available_cash / entry_px`` (no leverage on the spot side).
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class Sizer(Protocol):
+    def size(
+        self,
+        equity: float,
+        entry_px: float,
+        stop_px: float,
+        probability: float,
+        expected_r: float,
+        available_cash: float,
+    ) -> float: ...
+
+
+def _apply_cap(qty: float, entry_px: float, available_cash: float) -> float:
+    if qty <= 0 or entry_px <= 0:
+        return 0.0
+    cash_cap = available_cash / entry_px if available_cash > 0 else 0.0
+    return max(0.0, min(qty, cash_cap))
+
+
+class FixedPercentSizer:
+    """Risk ``risk_pct`` of equity per trade."""
+
+    def __init__(self, risk_pct: float = 0.005):
+        if risk_pct < 0:
+            raise ValueError("risk_pct must be non-negative")
+        self.risk_pct = risk_pct
+
+    def size(
+        self,
+        equity: float,
+        entry_px: float,
+        stop_px: float,
+        probability: float = 0.0,
+        expected_r: float = 0.0,
+        available_cash: float = 0.0,
+    ) -> float:
+        per_unit = abs(entry_px - stop_px)
+        if per_unit <= 0 or equity <= 0 or self.risk_pct <= 0:
+            return 0.0
+        qty = (equity * self.risk_pct) / per_unit
+        cash = available_cash if available_cash > 0 else equity
+        return _apply_cap(qty, entry_px, cash)
+
+
+class KellySizer:
+    """Kelly-based sizer.
+
+    ``f* = p - (1 - p) / b`` where ``b = reward / risk`` (``expected_r``).
+    The effective risk fraction is ``clip(f* * fraction, 0, max_risk_pct)``.
+    """
+
+    def __init__(self, max_risk_pct: float = 0.02, fraction: float = 0.5):
+        if max_risk_pct < 0:
+            raise ValueError("max_risk_pct must be non-negative")
+        if fraction <= 0:
+            raise ValueError("fraction must be positive (use 0.5 for half-Kelly)")
+        self.max_risk_pct = max_risk_pct
+        self.fraction = fraction
+
+    @staticmethod
+    def kelly_fraction(probability: float, expected_r: float) -> float:
+        """Raw Kelly ``f*`` for this (p, b)."""
+        if expected_r <= 0:
+            return 0.0
+        return probability - (1.0 - probability) / expected_r
+
+    def effective_risk_pct(self, probability: float, expected_r: float) -> float:
+        f_star = self.kelly_fraction(probability, expected_r)
+        adj = f_star * self.fraction
+        if adj <= 0:
+            return 0.0
+        return min(adj, self.max_risk_pct)
+
+    def size(
+        self,
+        equity: float,
+        entry_px: float,
+        stop_px: float,
+        probability: float,
+        expected_r: float,
+        available_cash: float = 0.0,
+    ) -> float:
+        per_unit = abs(entry_px - stop_px)
+        if per_unit <= 0 or equity <= 0:
+            return 0.0
+        risk_pct = self.effective_risk_pct(probability, expected_r)
+        if risk_pct <= 0:
+            return 0.0
+        qty = (equity * risk_pct) / per_unit
+        cash = available_cash if available_cash > 0 else equity
+        return _apply_cap(qty, entry_px, cash)

--- a/src/brooks/risk/state.py
+++ b/src/brooks/risk/state.py
@@ -1,0 +1,61 @@
+"""Shared position state for the Brooks risk layer.
+
+``PositionState`` holds everything the risk components (sizer, stop ladder,
+time stop, portfolio guard) need to decide what to do with an open position.
+The stop ladder walks a position through four stages:
+
+    initial → break_even → partial_trail → swing_trail
+
+Stage transitions are one-way; the stored ``stop_px`` never retreats (monotonic
+up for longs, monotonic down for shorts).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Literal, Optional
+
+LadderStage = Literal["initial", "break_even", "partial_trail", "swing_trail"]
+
+
+@dataclass
+class PositionState:
+    """Mutable state for one open position, threaded through the risk layer."""
+
+    symbol: str
+    side: Literal["long", "short"]
+    entry_px: float
+    stop_px: float
+    qty_initial: float
+    qty_open: float
+    one_r: float  # |entry - initial_stop|
+
+    # Risk contribution (fraction of equity at risk when the trade opened).
+    risk_pct: float = 0.0
+
+    # Entry bookkeeping.
+    entry_bar_idx: int = -1
+    entry_timestamp_ns: int = 0
+
+    # Stop ladder state.
+    ladder_stage: LadderStage = "initial"
+    partial_taken: bool = False
+    breakeven_moved: bool = False
+    max_unrealized_r: float = 0.0
+    highest_since_entry: Optional[float] = None
+    lowest_since_entry: Optional[float] = None
+
+    # Ring buffers for the partial_trail stage (bar-level extrema).
+    recent_lows: List[float] = field(default_factory=list)
+    recent_highs: List[float] = field(default_factory=list)
+
+    # Swing-point de-duplication for the swing_trail stage.
+    used_swing_lows: List[int] = field(default_factory=list)
+    used_swing_highs: List[int] = field(default_factory=list)
+
+    def unrealized_r(self, bar_close: float) -> float:
+        if self.one_r <= 0:
+            return 0.0
+        if self.side == "long":
+            return (bar_close - self.entry_px) / self.one_r
+        return (self.entry_px - bar_close) / self.one_r

--- a/src/brooks/risk/stop_ladder.py
+++ b/src/brooks/risk/stop_ladder.py
@@ -1,0 +1,153 @@
+"""Four-stage stop ladder.
+
+Walks a position through monotonic stop upgrades:
+
+    initial → break_even → partial_trail → swing_trail
+
+* ``initial``: hold the entry stop until unrealized ≥ 1R.
+* ``break_even``: stop moved to entry_px (+/- tick).
+* ``partial_trail``: once unrealized ≥ ``partial_trail_trigger_r``, stop tracks
+  the min of recent ``partial_trail_lookback`` bar lows (longs) or the max of
+  recent highs (shorts).
+* ``swing_trail``: each newly confirmed swing (low for longs, high for shorts)
+  snaps the stop just inside that swing.
+
+Stops only ever move in the favourable direction — never retreat.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from src.brooks.features import SwingPoint
+from src.brooks.risk.state import PositionState
+
+
+class StopLadder:
+    def __init__(
+        self,
+        partial_trail_trigger_r: float = 1.5,
+        partial_trail_lookback: int = 10,
+        use_swing_trail: bool = True,
+        tick_size: float = 0.0,
+    ):
+        if partial_trail_trigger_r <= 1.0:
+            raise ValueError("partial_trail_trigger_r must be > 1.0 (BE is the 1R stage)")
+        if partial_trail_lookback < 1:
+            raise ValueError("partial_trail_lookback must be >= 1")
+        self.partial_trail_trigger_r = partial_trail_trigger_r
+        self.partial_trail_lookback = partial_trail_lookback
+        self.use_swing_trail = use_swing_trail
+        self.tick_size = tick_size
+
+    def update(
+        self,
+        pos: PositionState,
+        bar_high: float,
+        bar_low: float,
+        bar_close: float,
+        confirmed_swings: List[SwingPoint],
+    ) -> Optional[float]:
+        """Advance the ladder for one bar. Returns a new stop_px if it moved."""
+        if pos.qty_open <= 0 or pos.one_r <= 0:
+            return None
+
+        self._track_extrema(pos, bar_high, bar_low)
+        r = pos.unrealized_r(bar_close)
+        if r > pos.max_unrealized_r:
+            pos.max_unrealized_r = r
+
+        proposed: Optional[float] = None
+
+        # Stage 1 → 2: initial → break_even at >= 1R.
+        if pos.ladder_stage == "initial" and r >= 1.0:
+            proposed = self._pick_stop(proposed, pos, pos.entry_px)
+            pos.ladder_stage = "break_even"
+            pos.breakeven_moved = True
+
+        # Stage 2 → 3: break_even → partial_trail at >= trigger R.
+        if pos.ladder_stage == "break_even" and r >= self.partial_trail_trigger_r:
+            pos.ladder_stage = "partial_trail"
+
+        # partial_trail: track recent bar extrema.
+        if pos.ladder_stage == "partial_trail":
+            trail = self._partial_trail_stop(pos)
+            if trail is not None:
+                proposed = self._pick_stop(proposed, pos, trail)
+
+        # Stage 3 → 4: partial_trail → swing_trail on first usable swing.
+        # (Also runs while in swing_trail to keep promoting.)
+        if self.use_swing_trail and pos.ladder_stage in ("partial_trail", "swing_trail"):
+            swing_stop = self._swing_trail_stop(pos, confirmed_swings)
+            if swing_stop is not None:
+                proposed = self._pick_stop(proposed, pos, swing_stop)
+                pos.ladder_stage = "swing_trail"
+
+        if proposed is None:
+            return None
+
+        if self._is_improvement(pos, proposed):
+            pos.stop_px = proposed
+            return proposed
+        return None
+
+    # ---- internals ------------------------------------------------------
+
+    def _track_extrema(self, pos: PositionState, bar_high: float, bar_low: float) -> None:
+        pos.highest_since_entry = max(pos.highest_since_entry or bar_high, bar_high)
+        pos.lowest_since_entry = min(pos.lowest_since_entry or bar_low, bar_low)
+
+        if pos.side == "long":
+            pos.recent_lows.append(bar_low)
+            if len(pos.recent_lows) > self.partial_trail_lookback:
+                del pos.recent_lows[: len(pos.recent_lows) - self.partial_trail_lookback]
+        else:
+            pos.recent_highs.append(bar_high)
+            if len(pos.recent_highs) > self.partial_trail_lookback:
+                del pos.recent_highs[: len(pos.recent_highs) - self.partial_trail_lookback]
+
+    def _partial_trail_stop(self, pos: PositionState) -> Optional[float]:
+        if pos.side == "long":
+            if not pos.recent_lows:
+                return None
+            return min(pos.recent_lows) - self.tick_size
+        if not pos.recent_highs:
+            return None
+        return max(pos.recent_highs) + self.tick_size
+
+    def _swing_trail_stop(
+        self, pos: PositionState, confirmed_swings: List[SwingPoint]
+    ) -> Optional[float]:
+        candidate: Optional[float] = None
+        kind = "low" if pos.side == "long" else "high"
+        used = pos.used_swing_lows if pos.side == "long" else pos.used_swing_highs
+        for s in confirmed_swings:
+            if s.kind != kind:
+                continue
+            if s.bar_idx <= pos.entry_bar_idx:
+                continue
+            if s.bar_idx in used:
+                continue
+            used.append(s.bar_idx)
+            offset = -self.tick_size if pos.side == "long" else self.tick_size
+            level = s.price + offset
+            if candidate is None or self._better(pos, level, candidate):
+                candidate = level
+        return candidate
+
+    @staticmethod
+    def _better(pos: PositionState, a: float, b: float) -> bool:
+        return a > b if pos.side == "long" else a < b
+
+    def _pick_stop(
+        self, current: Optional[float], pos: PositionState, proposed: float
+    ) -> float:
+        if current is None:
+            return proposed
+        return proposed if self._better(pos, proposed, current) else current
+
+    @staticmethod
+    def _is_improvement(pos: PositionState, new_stop: float) -> bool:
+        if pos.side == "long":
+            return new_stop > pos.stop_px
+        return new_stop < pos.stop_px

--- a/src/brooks/risk/time_stop.py
+++ b/src/brooks/risk/time_stop.py
@@ -1,0 +1,25 @@
+"""N-bar invalidation.
+
+If a trade fails to reach 1R within ``max_bars_to_1r`` bars of the entry, the
+setup is treated as stale and exited at market. Tracks ``max_unrealized_r`` so
+a trade that briefly touched 1R and pulled back is not forced to exit.
+"""
+
+from __future__ import annotations
+
+from src.brooks.risk.state import PositionState
+
+
+class TimeStop:
+    def __init__(self, max_bars_to_1r: int = 10):
+        if max_bars_to_1r < 1:
+            raise ValueError("max_bars_to_1r must be >= 1")
+        self.max_bars_to_1r = max_bars_to_1r
+
+    def should_exit(
+        self,
+        pos: PositionState,
+        bars_since_entry: int,
+        max_unrealized_r: float,
+    ) -> bool:
+        return bars_since_entry >= self.max_bars_to_1r and max_unrealized_r < 1.0

--- a/tests/brooks/test_risk_portfolio.py
+++ b/tests/brooks/test_risk_portfolio.py
@@ -1,0 +1,142 @@
+"""Tests for src.brooks.risk.portfolio_guard."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.brooks.risk.portfolio_guard import PortfolioGuard
+from src.brooks.risk.state import PositionState
+
+
+def _open_pos(symbol: str, risk_pct: float = 0.01) -> PositionState:
+    return PositionState(
+        symbol=symbol,
+        side="long",
+        entry_px=100.0,
+        stop_px=99.0,
+        qty_initial=1.0,
+        qty_open=1.0,
+        one_r=1.0,
+        risk_pct=risk_pct,
+    )
+
+
+class TestDailyRisk:
+    def test_allows_when_under_cap(self):
+        guard = PortfolioGuard(max_daily_risk_pct=0.03)
+        ok, _ = guard.can_open(
+            new_symbol="ETHUSDT",
+            new_risk_pct=0.01,
+            open_positions={"BTCUSDT": _open_pos("BTCUSDT", 0.01)},
+        )
+        assert ok is True
+
+    def test_rejects_when_over_cap(self):
+        guard = PortfolioGuard(max_daily_risk_pct=0.03)
+        ok, reason = guard.can_open(
+            new_symbol="ETHUSDT",
+            new_risk_pct=0.02,
+            open_positions={
+                "BTCUSDT": _open_pos("BTCUSDT", 0.01),
+                "SOLUSDT": _open_pos("SOLUSDT", 0.015),
+            },
+        )
+        assert ok is False
+        assert "daily risk" in reason
+
+    def test_accepts_at_exact_cap(self):
+        guard = PortfolioGuard(max_daily_risk_pct=0.03)
+        ok, _ = guard.can_open(
+            new_symbol="ETHUSDT",
+            new_risk_pct=0.015,
+            open_positions={"BTCUSDT": _open_pos("BTCUSDT", 0.015)},
+        )
+        assert ok is True
+
+    def test_closed_positions_dont_count(self):
+        guard = PortfolioGuard(max_daily_risk_pct=0.02)
+        closed = _open_pos("BTCUSDT", 0.02)
+        closed.qty_open = 0.0
+        ok, _ = guard.can_open(
+            new_symbol="ETHUSDT",
+            new_risk_pct=0.015,
+            open_positions={"BTCUSDT": closed},
+        )
+        assert ok is True
+
+
+class TestSymbolCap:
+    def test_default_rejects_second_position_in_same_symbol(self):
+        guard = PortfolioGuard(max_daily_risk_pct=0.1, max_symbol_positions=1)
+        ok, reason = guard.can_open(
+            new_symbol="BTCUSDT",
+            new_risk_pct=0.01,
+            open_positions={"BTCUSDT": _open_pos("BTCUSDT", 0.01)},
+        )
+        assert ok is False
+        assert "BTCUSDT" in reason
+
+    def test_larger_cap_allows_multiple(self):
+        guard = PortfolioGuard(max_daily_risk_pct=0.1, max_symbol_positions=2)
+        ok, _ = guard.can_open(
+            new_symbol="BTCUSDT",
+            new_risk_pct=0.01,
+            open_positions={"BTCUSDT": _open_pos("BTCUSDT", 0.01)},
+        )
+        assert ok is True
+
+
+class TestCorrelationGroups:
+    def test_rejects_conflicting_group(self):
+        guard = PortfolioGuard(
+            max_daily_risk_pct=0.1,
+            max_symbol_positions=5,
+            correlation_groups={"layer1": ["BTCUSDT", "ETHUSDT", "SOLUSDT"]},
+        )
+        ok, reason = guard.can_open(
+            new_symbol="ETHUSDT",
+            new_risk_pct=0.01,
+            open_positions={"BTCUSDT": _open_pos("BTCUSDT", 0.01)},
+        )
+        assert ok is False
+        assert "layer1" in reason
+
+    def test_allows_when_no_group_conflict(self):
+        guard = PortfolioGuard(
+            max_daily_risk_pct=0.1,
+            correlation_groups={
+                "layer1": ["BTCUSDT", "ETHUSDT"],
+                "defi": ["UNIUSDT", "AAVEUSDT"],
+            },
+        )
+        ok, _ = guard.can_open(
+            new_symbol="UNIUSDT",
+            new_risk_pct=0.01,
+            open_positions={"BTCUSDT": _open_pos("BTCUSDT", 0.01)},
+        )
+        assert ok is True
+
+    def test_new_symbol_not_in_any_group_passes_group_check(self):
+        guard = PortfolioGuard(
+            max_daily_risk_pct=0.1,
+            correlation_groups={"layer1": ["BTCUSDT", "ETHUSDT"]},
+        )
+        ok, _ = guard.can_open(
+            new_symbol="DOGEUSDT",
+            new_risk_pct=0.01,
+            open_positions={"BTCUSDT": _open_pos("BTCUSDT", 0.01)},
+        )
+        assert ok is True
+
+
+class TestValidation:
+    def test_rejects_negative_new_risk(self):
+        guard = PortfolioGuard()
+        ok, _ = guard.can_open("ETHUSDT", -0.01, {})
+        assert ok is False
+
+    def test_rejects_invalid_construction(self):
+        with pytest.raises(ValueError):
+            PortfolioGuard(max_daily_risk_pct=-0.01)
+        with pytest.raises(ValueError):
+            PortfolioGuard(max_symbol_positions=0)

--- a/tests/brooks/test_risk_sizer.py
+++ b/tests/brooks/test_risk_sizer.py
@@ -1,0 +1,110 @@
+"""Tests for src.brooks.risk.sizer."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from src.brooks.risk.sizer import FixedPercentSizer, KellySizer
+
+
+class TestFixedPercentSizer:
+    def test_basic_sizing(self):
+        sizer = FixedPercentSizer(risk_pct=0.01)
+        qty = sizer.size(
+            equity=100_000, entry_px=100.0, stop_px=99.0,
+            probability=0.6, expected_r=2.0, available_cash=100_000,
+        )
+        # risk_usd = 1000, per_unit = 1, qty = 1000, cash_cap = 1000 → 1000
+        assert qty == pytest.approx(1000.0)
+
+    def test_zero_risk_returns_zero(self):
+        sizer = FixedPercentSizer(risk_pct=0.0)
+        assert sizer.size(100_000, 100.0, 99.0, 0.5, 2.0, 100_000) == 0.0
+
+    def test_stop_equals_entry_returns_zero(self):
+        sizer = FixedPercentSizer(risk_pct=0.01)
+        assert sizer.size(100_000, 100.0, 100.0, 0.5, 2.0, 100_000) == 0.0
+
+    def test_cash_cap_binds(self):
+        sizer = FixedPercentSizer(risk_pct=0.5)  # want to risk 50k on a $1 stop
+        qty = sizer.size(100_000, 100.0, 99.0, 0.5, 2.0, 10_000)
+        # Without cap: 50_000 / 1 = 50_000. Cash cap = 10_000 / 100 = 100.
+        assert qty == pytest.approx(100.0)
+
+    def test_rejects_negative_risk_pct(self):
+        with pytest.raises(ValueError):
+            FixedPercentSizer(risk_pct=-0.01)
+
+
+class TestKellySizer:
+    def test_kelly_fraction_formula(self):
+        """f* = p - (1 - p) / b.   p=0.6, b=2 → 0.4."""
+        assert KellySizer.kelly_fraction(0.6, 2.0) == pytest.approx(0.4)
+        assert KellySizer.kelly_fraction(0.5, 1.0) == pytest.approx(0.0)
+        assert KellySizer.kelly_fraction(0.7, 1.5) == pytest.approx(0.7 - 0.3 / 1.5)
+
+    def test_kelly_fraction_negative_when_edge_negative(self):
+        # p=0.4, b=1: f* = 0.4 - 0.6 = -0.2
+        assert KellySizer.kelly_fraction(0.4, 1.0) == pytest.approx(-0.2)
+
+    def test_kelly_fraction_zero_b_returns_zero(self):
+        assert KellySizer.kelly_fraction(0.6, 0.0) == 0.0
+
+    def test_half_kelly_uncapped(self):
+        """Half-Kelly of f*=0.4 is 0.2 — larger than any sane max, so cap binds."""
+        sizer = KellySizer(max_risk_pct=1.0, fraction=0.5)
+        assert sizer.effective_risk_pct(0.6, 2.0) == pytest.approx(0.2)
+
+    def test_half_kelly_capped_to_max_risk_pct(self):
+        """Spec acceptance: cap to max_risk_pct=0.02."""
+        sizer = KellySizer(max_risk_pct=0.02, fraction=0.5)
+        assert sizer.effective_risk_pct(0.6, 2.0) == pytest.approx(0.02)
+
+    def test_fraction_one_equals_full_kelly(self):
+        sizer = KellySizer(max_risk_pct=1.0, fraction=1.0)
+        assert sizer.effective_risk_pct(0.6, 2.0) == pytest.approx(0.4)
+
+    def test_negative_edge_returns_zero_size(self):
+        sizer = KellySizer(max_risk_pct=0.02, fraction=0.5)
+        qty = sizer.size(
+            equity=100_000, entry_px=100.0, stop_px=99.0,
+            probability=0.4, expected_r=1.0, available_cash=100_000,
+        )
+        assert qty == 0.0
+
+    def test_size_uses_capped_risk_pct(self):
+        sizer = KellySizer(max_risk_pct=0.02, fraction=0.5)
+        qty = sizer.size(
+            equity=100_000, entry_px=100.0, stop_px=99.0,
+            probability=0.6, expected_r=2.0, available_cash=100_000,
+        )
+        # effective risk_pct = 0.02 → risk_usd = 2000, per_unit = 1 → qty 2000
+        # cash cap = 100_000 / 100 = 1000 → 1000 wins.
+        assert qty == pytest.approx(1000.0)
+
+    def test_size_no_cash_cap_when_unconstrained(self):
+        sizer = KellySizer(max_risk_pct=0.02, fraction=0.5)
+        qty = sizer.size(
+            equity=100_000, entry_px=10.0, stop_px=9.0,
+            probability=0.6, expected_r=2.0, available_cash=100_000,
+        )
+        # risk 2000 / 1 = 2000; cash cap 100_000 / 10 = 10_000 → 2000 wins
+        assert qty == pytest.approx(2000.0)
+
+    def test_zero_entry_rejected(self):
+        sizer = KellySizer(max_risk_pct=0.02, fraction=0.5)
+        qty = sizer.size(100_000, 0.0, -1.0, 0.6, 2.0, 100_000)
+        assert qty == 0.0
+
+    def test_rejects_invalid_construction(self):
+        with pytest.raises(ValueError):
+            KellySizer(max_risk_pct=-0.01)
+        with pytest.raises(ValueError):
+            KellySizer(fraction=0.0)
+
+    def test_finite_qty(self):
+        sizer = KellySizer(max_risk_pct=0.02, fraction=0.5)
+        qty = sizer.size(100_000, 100.0, 99.0, 0.6, 2.0, 100_000)
+        assert math.isfinite(qty)

--- a/tests/brooks/test_risk_stop_ladder.py
+++ b/tests/brooks/test_risk_stop_ladder.py
@@ -1,0 +1,202 @@
+"""Tests for src.brooks.risk.stop_ladder.
+
+Each test uses a hand-crafted bar sequence to step a position through the
+four ladder stages in order, then verifies the stop never retreats when
+price moves back against us.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.brooks.features import SwingPoint
+from src.brooks.risk.state import PositionState
+from src.brooks.risk.stop_ladder import StopLadder
+
+
+def _make_long_pos(entry: float = 100.0, stop: float = 99.0) -> PositionState:
+    return PositionState(
+        symbol="BTCUSDT",
+        side="long",
+        entry_px=entry,
+        stop_px=stop,
+        qty_initial=1.0,
+        qty_open=1.0,
+        one_r=abs(entry - stop),
+        entry_bar_idx=0,
+    )
+
+
+def _make_short_pos(entry: float = 100.0, stop: float = 101.0) -> PositionState:
+    return PositionState(
+        symbol="BTCUSDT",
+        side="short",
+        entry_px=entry,
+        stop_px=stop,
+        qty_initial=1.0,
+        qty_open=1.0,
+        one_r=abs(entry - stop),
+        entry_bar_idx=0,
+    )
+
+
+class TestLongLadder:
+    def test_all_four_stages_in_order(self):
+        ladder = StopLadder(
+            partial_trail_trigger_r=1.5,
+            partial_trail_lookback=5,
+            use_swing_trail=True,
+        )
+        pos = _make_long_pos(entry=100.0, stop=99.0)  # 1R = 1
+
+        # Stage 0 (initial): price holds near entry → no move.
+        assert ladder.update(pos, 100.2, 99.8, 100.1, []) is None
+        assert pos.ladder_stage == "initial"
+        assert pos.stop_px == pytest.approx(99.0)
+
+        # Stage 1 → 2: push close to 101 (1R exactly) → break_even.
+        new_stop = ladder.update(pos, 101.0, 100.0, 101.0, [])
+        assert new_stop == pytest.approx(100.0)
+        assert pos.ladder_stage == "break_even"
+        assert pos.stop_px == pytest.approx(100.0)
+
+        # Stage 2 → 3: push close to 101.5 (1.5R) → partial_trail.
+        # With no new bar-lows below 100 recorded, the trail stop equals min
+        # of recent_lows which is still > 100 → improvement picked.
+        new_stop = ladder.update(pos, 101.6, 101.3, 101.5, [])
+        assert pos.ladder_stage == "partial_trail"
+        assert pos.stop_px >= 100.0  # monotonic
+        partial_stop = pos.stop_px
+
+        # Push harder — partial_trail should lift the stop to min of recent lows.
+        ladder.update(pos, 102.0, 101.5, 101.9, [])
+        assert pos.stop_px >= partial_stop
+
+        # Stage 3 → 4: a confirmed swing_low above current stop → swing_trail.
+        swings = [
+            SwingPoint(bar_idx=3, price=101.0, kind="low", confirmed_at_idx=6),
+        ]
+        ladder.update(pos, 102.5, 102.0, 102.4, swings)
+        # swing price 101 should beat partial-trail min (which tracked lows ~100-ish).
+        assert pos.ladder_stage == "swing_trail"
+        assert pos.stop_px == pytest.approx(101.0)
+
+    def test_stop_never_retreats(self):
+        ladder = StopLadder(partial_trail_trigger_r=1.5, partial_trail_lookback=5)
+        pos = _make_long_pos(entry=100.0, stop=99.0)
+
+        # Promote to break_even.
+        ladder.update(pos, 101.2, 100.5, 101.1, [])
+        assert pos.stop_px == pytest.approx(100.0)
+
+        # Push into partial_trail with a bar whose low drags recent_lows down.
+        ladder.update(pos, 101.6, 101.2, 101.5, [])
+        high_water_stop = pos.stop_px
+        assert high_water_stop >= 100.0
+
+        # Now a pullback bar with a much lower low — partial_trail math would
+        # suggest a lower stop, but the ladder must not retreat.
+        ladder.update(pos, 101.4, 100.3, 101.0, [])
+        assert pos.stop_px == pytest.approx(high_water_stop)
+
+    def test_swing_below_current_stop_ignored(self):
+        ladder = StopLadder(partial_trail_trigger_r=1.5, partial_trail_lookback=5)
+        pos = _make_long_pos(entry=100.0, stop=99.0)
+
+        # Walk to partial_trail, pin stop around 100.5.
+        ladder.update(pos, 101.2, 100.5, 101.1, [])  # → break_even
+        ladder.update(pos, 101.6, 100.7, 101.5, [])  # → partial_trail
+        before = pos.stop_px
+
+        swings = [
+            SwingPoint(bar_idx=2, price=99.5, kind="low", confirmed_at_idx=5),
+        ]
+        ladder.update(pos, 101.8, 101.0, 101.7, swings)
+        assert pos.stop_px >= before
+
+    def test_swing_before_entry_ignored(self):
+        ladder = StopLadder(partial_trail_trigger_r=1.5, partial_trail_lookback=5)
+        pos = _make_long_pos(entry=100.0, stop=99.0)
+        pos.entry_bar_idx = 10
+
+        ladder.update(pos, 101.2, 100.5, 101.1, [])
+        ladder.update(pos, 101.6, 101.3, 101.5, [])
+        before = pos.stop_px
+
+        swings = [
+            SwingPoint(bar_idx=5, price=101.0, kind="low", confirmed_at_idx=8),
+        ]
+        ladder.update(pos, 101.8, 101.4, 101.7, swings)
+        assert pos.stop_px == pytest.approx(before)
+        assert pos.ladder_stage != "swing_trail"
+
+    def test_max_unrealized_r_tracked(self):
+        ladder = StopLadder()
+        pos = _make_long_pos(entry=100.0, stop=99.0)
+        ladder.update(pos, 102.0, 101.0, 101.8, [])
+        assert pos.max_unrealized_r == pytest.approx(1.8)
+
+        # A pullback bar should NOT reduce max_unrealized_r.
+        ladder.update(pos, 101.5, 100.5, 101.0, [])
+        assert pos.max_unrealized_r == pytest.approx(1.8)
+
+
+class TestShortLadder:
+    def test_short_stages_in_order(self):
+        ladder = StopLadder(partial_trail_trigger_r=1.5, partial_trail_lookback=5)
+        pos = _make_short_pos(entry=100.0, stop=101.0)  # 1R = 1
+
+        # 1R: close at 99 → break_even at 100.
+        new_stop = ladder.update(pos, 100.0, 99.0, 99.0, [])
+        assert new_stop == pytest.approx(100.0)
+        assert pos.ladder_stage == "break_even"
+
+        # 1.5R: close at 98.5 → partial_trail.
+        ladder.update(pos, 99.0, 98.3, 98.5, [])
+        assert pos.ladder_stage == "partial_trail"
+        assert pos.stop_px <= 100.0  # monotonic (lower is better for short)
+
+        # Confirmed swing high → swing_trail.
+        swings = [
+            SwingPoint(bar_idx=3, price=99.2, kind="high", confirmed_at_idx=6),
+        ]
+        ladder.update(pos, 99.0, 98.2, 98.5, swings)
+        assert pos.ladder_stage == "swing_trail"
+        assert pos.stop_px == pytest.approx(99.2)
+
+    def test_short_stop_never_retreats(self):
+        ladder = StopLadder(partial_trail_trigger_r=1.5, partial_trail_lookback=5)
+        pos = _make_short_pos(entry=100.0, stop=101.0)
+
+        ladder.update(pos, 100.0, 99.0, 99.0, [])
+        assert pos.stop_px == pytest.approx(100.0)
+        low_water_stop = pos.stop_px
+
+        # A bar that spikes above high_water would normally ratchet partial_trail
+        # up. Ensure stop does not move back up (unfavourable for short).
+        ladder.update(pos, 99.9, 99.0, 99.5, [])
+        assert pos.stop_px <= low_water_stop
+
+
+class TestLadderEdgeCases:
+    def test_flat_position_no_update(self):
+        ladder = StopLadder()
+        pos = _make_long_pos()
+        pos.qty_open = 0
+        assert ladder.update(pos, 101.0, 100.0, 101.0, []) is None
+
+    def test_swing_trail_disabled(self):
+        ladder = StopLadder(partial_trail_trigger_r=1.5, use_swing_trail=False)
+        pos = _make_long_pos(entry=100.0, stop=99.0)
+        ladder.update(pos, 101.2, 100.5, 101.1, [])  # → break_even
+        ladder.update(pos, 101.8, 101.3, 101.7, [])  # → partial_trail
+
+        swings = [SwingPoint(bar_idx=3, price=101.2, kind="low", confirmed_at_idx=6)]
+        ladder.update(pos, 102.0, 101.6, 101.9, swings)
+        assert pos.ladder_stage != "swing_trail"
+
+    def test_construction_validation(self):
+        with pytest.raises(ValueError):
+            StopLadder(partial_trail_trigger_r=0.9)  # must be > 1.0
+        with pytest.raises(ValueError):
+            StopLadder(partial_trail_lookback=0)

--- a/tests/brooks/test_risk_time_stop.py
+++ b/tests/brooks/test_risk_time_stop.py
@@ -1,0 +1,50 @@
+"""Tests for src.brooks.risk.time_stop."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.brooks.risk.state import PositionState
+from src.brooks.risk.time_stop import TimeStop
+
+
+def _pos() -> PositionState:
+    return PositionState(
+        symbol="BTCUSDT",
+        side="long",
+        entry_px=100.0,
+        stop_px=99.0,
+        qty_initial=1.0,
+        qty_open=1.0,
+        one_r=1.0,
+    )
+
+
+class TestTimeStop:
+    def test_exit_when_no_progress(self):
+        stop = TimeStop(max_bars_to_1r=10)
+        assert stop.should_exit(_pos(), bars_since_entry=10, max_unrealized_r=0.3) is True
+
+    def test_exit_exactly_at_boundary(self):
+        """spec: bars_since_entry >= max_bars AND max_r < 1.0."""
+        stop = TimeStop(max_bars_to_1r=10)
+        # 10 bars, 0.9R max → exit.
+        assert stop.should_exit(_pos(), 10, 0.9) is True
+
+    def test_no_exit_before_boundary(self):
+        stop = TimeStop(max_bars_to_1r=10)
+        assert stop.should_exit(_pos(), 9, 0.0) is False
+
+    def test_no_exit_if_reached_1r(self):
+        stop = TimeStop(max_bars_to_1r=10)
+        assert stop.should_exit(_pos(), 50, 1.0) is False
+        assert stop.should_exit(_pos(), 50, 2.5) is False
+
+    def test_no_exit_if_briefly_touched_1r(self):
+        """Trade that hit 1R and pulled back should NOT be time-stopped."""
+        stop = TimeStop(max_bars_to_1r=10)
+        assert stop.should_exit(_pos(), 15, 1.2) is False
+
+    def test_construction_validation(self):
+        with pytest.raises(ValueError):
+            TimeStop(max_bars_to_1r=0)


### PR DESCRIPTION
## Summary
Phase 3.2 — composable Brooks risk layer under `src/brooks/risk/`.

* `sizer.py` — `FixedPercentSizer` (0.5% default) + `KellySizer` (half-kelly, capped to `max_risk_pct`). Formula: `f* = p - (1-p)/b`.
* `stop_ladder.py` — four-stage monotonic ladder: `initial → break_even → partial_trail (N-bar lookback) → swing_trail`. Stops never retreat.
* `time_stop.py` — N-bar invalidation: exit when `bars_since_entry >= max_bars_to_1r AND max_unrealized_r < 1.0`.
* `portfolio_guard.py` — daily risk cap, per-symbol cap, correlation-group conflict.
* `state.py` — shared `PositionState` threaded through all components.

Legacy `src/strategies/brooks_v2/risk.py` left in place; Phase 3.7 cutover will retire it.

## Test plan
- [x] `pytest tests/brooks/test_risk_sizer.py` — 17 tests, including Kelly p=0.6/b=2 → f\*=0.4, half=0.2, cap to 0.02.
- [x] `pytest tests/brooks/test_risk_stop_ladder.py` — four-stage promotion in order + non-retreat on pullback, both long and short.
- [x] `pytest tests/brooks/test_risk_time_stop.py` — boundary behaviour + protection of trades that briefly touched 1R.
- [x] `pytest tests/brooks/test_risk_portfolio.py` — daily cap, per-symbol cap, correlation-group rejection.
- [x] Full `tests/brooks/` — 139 passed, no regressions.