### PR TITLE
feat(brooks): analyst plugin layer + RuleAnalyst + decision/aggregator (Phase 2.5)

### DIFF
--- a/src/brooks/analyst/__init__.py
+++ b/src/brooks/analyst/__init__.py
@@ -1,0 +1,15 @@
+"""Analyst plugin layer.
+
+Importing this package triggers registration of all built-in analysts
+with :class:`AnalystRegistry`.
+"""
+
+from src.brooks.analyst import rule  # noqa: F401 — imported for side-effect
+from src.brooks.analyst.base import Analyst, AnalystRegistry
+from src.brooks.analyst.rule import RuleAnalyst
+
+__all__ = [
+    "Analyst",
+    "AnalystRegistry",
+    "RuleAnalyst",
+]

--- a/src/brooks/analyst/base.py
+++ b/src/brooks/analyst/base.py
@@ -1,0 +1,57 @@
+"""Analyst plugin protocol and registry.
+
+An :class:`Analyst` consumes a :class:`~src.brooks.context.BrooksContext`
+and produces zero-or-more unified :class:`~src.brooks.schema.Signal`
+records. Concrete analysts (rule, LLM, VLM) register themselves via the
+:class:`AnalystRegistry` decorator and are built by name.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Protocol, Type, runtime_checkable
+
+from src.brooks.context import BrooksContext
+from src.brooks.schema import Signal
+
+
+@runtime_checkable
+class Analyst(Protocol):
+    """The minimal interface every analyst implements."""
+
+    name: str
+
+    async def analyze(self, ctx: BrooksContext) -> List[Signal]: ...
+
+
+_ANALYSTS: Dict[str, Type] = {}
+
+
+class AnalystRegistry:
+    """Decorator + factory for :class:`Analyst` implementations."""
+
+    @classmethod
+    def register(cls, name: str):
+        def wrap(klass: Type) -> Type:
+            if name in _ANALYSTS and _ANALYSTS[name] is not klass:
+                raise ValueError(f"AnalystRegistry: name {name!r} already registered to {_ANALYSTS[name].__name__}")
+            _ANALYSTS[name] = klass
+            klass.name = name
+            return klass
+
+        return wrap
+
+    @classmethod
+    def build(cls, name: str, **params) -> Analyst:
+        if name not in _ANALYSTS:
+            raise KeyError(f"AnalystRegistry: unknown analyst {name!r}")
+        return _ANALYSTS[name](**params)
+
+    @classmethod
+    def all(cls) -> List[str]:
+        return list(_ANALYSTS.keys())
+
+    @classmethod
+    def get(cls, name: str) -> Type:
+        if name not in _ANALYSTS:
+            raise KeyError(f"AnalystRegistry: unknown analyst {name!r}")
+        return _ANALYSTS[name]

--- a/src/brooks/analyst/rule.py
+++ b/src/brooks/analyst/rule.py
@@ -1,0 +1,115 @@
+"""Rule-based analyst — runs every registered pattern detector once.
+
+The Phase 2 :class:`~src.brooks.context.BrooksContext` does not yet carry
+features / structure on its ``TFSnapshot``; the rule analyst rebuilds
+them from ``ctx.primary.bars`` so this layer can ship before Phase 3
+populates the context. Phase 3 will swap the streaming reconstruction
+out for direct field access.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from src.brooks.analyst.base import AnalystRegistry
+from src.brooks.context import BrooksContext
+from src.brooks.features import BarFeatureExtractor, ExtendedBarFeatures
+from src.brooks.patterns.base import DetectorContext, PatternSignal
+from src.brooks.patterns.registry import PatternRegistry
+from src.brooks.schema import Signal
+from src.brooks.structure import MarketStructure, MarketStructureTracker
+
+
+@AnalystRegistry.register("rule")
+class RuleAnalyst:
+    """Run every registered pattern detector and emit unified Signals.
+
+    Parameters
+    ----------
+    detector_names:
+        Optional explicit list of detector names. ``None`` selects every
+        detector currently in :class:`PatternRegistry`.
+    params:
+        Optional ``{detector_name: {param: value, ...}}`` mapping forwarded
+        to ``PatternRegistry.build`` when constructing each detector.
+    extractor_kwargs:
+        Optional kwargs for :class:`BarFeatureExtractor`. Defaults match
+        ``brooks_v2.strategy.BrooksStrategyV2`` so signal parity holds.
+    structure_kwargs:
+        Optional kwargs for :class:`MarketStructureTracker`.
+    """
+
+    name = "rule"
+
+    def __init__(
+        self,
+        detector_names: Optional[List[str]] = None,
+        params: Optional[Dict[str, Dict]] = None,
+        extractor_kwargs: Optional[Dict] = None,
+        structure_kwargs: Optional[Dict] = None,
+    ) -> None:
+        names = list(detector_names) if detector_names is not None else PatternRegistry.all()
+        param_map = params or {}
+        self._detectors = [PatternRegistry.build(n, **param_map.get(n, {})) for n in names]
+        self._detector_names = names
+        self._extractor_kwargs = extractor_kwargs or {}
+        self._structure_kwargs = structure_kwargs or {}
+
+    async def analyze(self, ctx: BrooksContext) -> List[Signal]:
+        """Replay every bar through each detector's FSM; emit signals
+        that arise on the latest bar.
+
+        The Brooks pattern detectors are stateful (H2/L2 build a multi-bar
+        pullback FSM, doubles wait for paired swings, etc.), so they must
+        observe the full history to decide whether the *current* bar
+        completes a setup. We discard signals that fired on earlier bars —
+        callers analysing those bars would have invoked the analyst with a
+        shorter context at the time.
+        """
+        bars = ctx.primary.bars
+        if not bars:
+            return []
+
+        ext = BarFeatureExtractor(**self._extractor_kwargs)
+        tracker = MarketStructureTracker(ext, **self._structure_kwargs)
+        history: List[ExtendedBarFeatures] = []
+        out: List[Signal] = []
+        last_idx = len(bars) - 1
+        last_struct: Optional[MarketStructure] = None
+
+        for i, bar in enumerate(bars):
+            feat = ext.on_bar(bar.timestamp_ns, bar.open, bar.high, bar.low, bar.close)
+            last_struct = tracker.on_features(feat)
+            history.append(feat)
+            detector_ctx = DetectorContext(
+                feat=feat,
+                structure=last_struct,
+                recent_features=history,
+                params={},
+            )
+            for det in self._detectors:
+                ps = det.on_bar(detector_ctx)
+                if ps is None:
+                    continue
+                if i == last_idx:
+                    out.append(_pattern_signal_to_signal(ps))
+        return out
+
+
+def _pattern_signal_to_signal(ps: PatternSignal) -> Signal:
+    """Promote an internal :class:`PatternSignal` to a unified :class:`Signal`."""
+    meta = dict(ps.metadata) if ps.metadata else {}
+    meta.setdefault("timestamp_ns", ps.timestamp_ns)
+    return Signal(
+        pattern=ps.detector,
+        side=ps.side,
+        signal_bar_idx=ps.signal_bar_idx,
+        entry_px=ps.entry_px,
+        stop_px=ps.stop_px,
+        target_px=None,
+        probability=0.5,
+        quality=0.5,
+        reasoning=ps.reason,
+        source=f"rule:{ps.detector}",
+        meta=meta,
+    )

--- a/src/brooks/decision/__init__.py
+++ b/src/brooks/decision/__init__.py
@@ -1,0 +1,10 @@
+"""Decision-layer plumbing — signal aggregation, gating, and (later) the
+Trader's Equation evaluator.
+"""
+
+from src.brooks.decision.aggregator import AggregatedDecision, SignalAggregator
+
+__all__ = [
+    "AggregatedDecision",
+    "SignalAggregator",
+]

--- a/src/brooks/decision/aggregator.py
+++ b/src/brooks/decision/aggregator.py
@@ -1,0 +1,103 @@
+"""Signal aggregation with optional confluence gating.
+
+Operates on the unified :class:`~src.brooks.schema.Signal`. The Trader's
+Equation evaluator and risk model layer downstream are responsible for
+turning the aggregated output into a full :class:`~src.brooks.schema.Decision`;
+this layer's contract is only "combine signals → conservative entry/stop".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Literal, Optional
+
+from src.brooks.schema import Signal
+
+
+@dataclass
+class AggregatedDecision:
+    """Output of :class:`SignalAggregator` — a confluence-gated combination."""
+
+    side: Literal["long", "short"]
+    signal_bar_idx: int
+    entry_px: float
+    stop_px: float
+    timestamp_ns: int
+    hit_detectors: List[str]
+    reasons: List[str]
+    raw_signals: List[Signal] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "side": self.side,
+            "signal_bar_idx": self.signal_bar_idx,
+            "entry_px": round(self.entry_px, 6),
+            "stop_px": round(self.stop_px, 6),
+            "timestamp_ns": self.timestamp_ns,
+            "hit_detectors": list(self.hit_detectors),
+            "reasons": list(self.reasons),
+            "raw_signals": [s.model_dump() for s in self.raw_signals],
+        }
+
+
+class SignalAggregator:
+    """Combine multiple analysts'/detectors' signals.
+
+    Parameters
+    ----------
+    confluence_n:
+        Minimum # of signals agreeing on the same side for a bar to
+        produce a decision. ``1`` = any-of, ``≥2`` = confluence.
+    """
+
+    def __init__(self, confluence_n: int = 1):
+        if confluence_n < 1:
+            raise ValueError("confluence_n must be >= 1")
+        self.confluence_n = confluence_n
+
+    def resolve(self, signals: List[Signal]) -> Optional[AggregatedDecision]:
+        signals = [s for s in signals if s is not None]
+        if not signals:
+            return None
+        longs = [s for s in signals if s.side == "long"]
+        shorts = [s for s in signals if s.side == "short"]
+
+        pick: Optional[List[Signal]] = None
+        if len(longs) >= self.confluence_n and len(longs) >= len(shorts):
+            pick = longs
+        elif len(shorts) >= self.confluence_n:
+            pick = shorts
+        if pick is None:
+            return None
+
+        side: Literal["long", "short"] = pick[0].side
+        # Conservative entry: highest stop-price for long (latest breakout level),
+        # lowest for short. Conservative stop: tightest distance from entry.
+        if side == "long":
+            entry = max(s.entry_px for s in pick)
+            stop = min(s.stop_px for s in pick)
+        else:
+            entry = min(s.entry_px for s in pick)
+            stop = max(s.stop_px for s in pick)
+
+        return AggregatedDecision(
+            side=side,
+            signal_bar_idx=max(s.signal_bar_idx for s in pick),
+            entry_px=entry,
+            stop_px=stop,
+            timestamp_ns=_latest_timestamp(pick),
+            hit_detectors=[s.pattern for s in pick],
+            reasons=[s.reasoning for s in pick],
+            raw_signals=list(pick),
+        )
+
+
+def _latest_timestamp(signals: List[Signal]) -> int:
+    """Pull ``timestamp_ns`` from ``Signal.meta`` (where the rule analyst
+    stores it); fall back to ``0`` if no signal carries one."""
+    last = 0
+    for s in signals:
+        ts = s.meta.get("timestamp_ns") if s.meta else None
+        if isinstance(ts, int) and ts > last:
+            last = ts
+    return last

--- a/tests/brooks/test_aggregator.py
+++ b/tests/brooks/test_aggregator.py
@@ -1,0 +1,188 @@
+"""SignalAggregator tests covering confluence_n boundaries (1 / 2 / 3)."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.brooks.decision import AggregatedDecision, SignalAggregator
+from src.brooks.schema import Signal
+
+
+def _sig(
+    pattern: str,
+    side: str,
+    entry: float,
+    stop: float,
+    *,
+    idx: int = 10,
+    timestamp_ns: int = 0,
+) -> Signal:
+    return Signal(
+        pattern=pattern,
+        side=side,
+        signal_bar_idx=idx,
+        entry_px=entry,
+        stop_px=stop,
+        probability=0.5,
+        quality=0.5,
+        source=f"rule:{pattern}",
+        meta={"timestamp_ns": timestamp_ns} if timestamp_ns else {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Constructor
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_confluence_n_rejected():
+    with pytest.raises(ValueError):
+        SignalAggregator(confluence_n=0)
+
+
+# ---------------------------------------------------------------------------
+# confluence_n = 1 (any-of)
+# ---------------------------------------------------------------------------
+
+
+def test_confluence_1_single_signal_passes():
+    agg = SignalAggregator(confluence_n=1)
+    d = agg.resolve([_sig("h2", "long", 101.0, 99.0)])
+    assert isinstance(d, AggregatedDecision)
+    assert d.side == "long"
+    assert d.hit_detectors == ["h2"]
+    assert d.entry_px == 101.0
+    assert d.stop_px == 99.0
+
+
+def test_confluence_1_empty_returns_none():
+    assert SignalAggregator(confluence_n=1).resolve([]) is None
+
+
+def test_confluence_1_filters_none_inside_list():
+    agg = SignalAggregator(confluence_n=1)
+    d = agg.resolve([None, _sig("l2", "short", 99.0, 101.0)])  # type: ignore[list-item]
+    assert d is not None
+    assert d.side == "short"
+
+
+def test_confluence_1_long_wins_tie_against_short():
+    agg = SignalAggregator(confluence_n=1)
+    d = agg.resolve([_sig("h2", "long", 101.0, 99.0), _sig("l2", "short", 99.0, 101.0)])
+    # tie 1-vs-1: long preferred (>=)
+    assert d is not None and d.side == "long"
+
+
+# ---------------------------------------------------------------------------
+# confluence_n = 2
+# ---------------------------------------------------------------------------
+
+
+def test_confluence_2_split_sides_returns_none():
+    agg = SignalAggregator(confluence_n=2)
+    d = agg.resolve([_sig("h2", "long", 101.0, 99.0), _sig("l2", "short", 99.0, 101.0)])
+    assert d is None
+
+
+def test_confluence_2_two_longs_pass_with_conservative_levels():
+    agg = SignalAggregator(confluence_n=2)
+    d = agg.resolve(
+        [
+            _sig("h2", "long", 101.0, 99.0),
+            _sig("wedge_long", "long", 101.5, 98.5),
+        ]
+    )
+    assert d is not None
+    assert d.side == "long"
+    assert set(d.hit_detectors) == {"h2", "wedge_long"}
+    assert d.entry_px == 101.5  # conservative: highest entry for long
+    assert d.stop_px == 98.5  # conservative: lowest stop for long
+
+
+def test_confluence_2_one_long_two_shorts_picks_shorts():
+    agg = SignalAggregator(confluence_n=2)
+    d = agg.resolve(
+        [
+            _sig("h2", "long", 101.0, 99.0),
+            _sig("l2", "short", 99.5, 101.5),
+            _sig("double_top", "short", 99.0, 101.0),
+        ]
+    )
+    assert d is not None
+    assert d.side == "short"
+    # conservative entry for short = lowest entry; conservative stop = highest stop
+    assert d.entry_px == 99.0
+    assert d.stop_px == 101.5
+
+
+def test_confluence_2_single_signal_rejected():
+    agg = SignalAggregator(confluence_n=2)
+    assert agg.resolve([_sig("h2", "long", 101.0, 99.0)]) is None
+
+
+# ---------------------------------------------------------------------------
+# confluence_n = 3
+# ---------------------------------------------------------------------------
+
+
+def test_confluence_3_two_signals_rejected():
+    agg = SignalAggregator(confluence_n=3)
+    assert agg.resolve([_sig("h2", "long", 101.0, 99.0), _sig("wedge_long", "long", 101.2, 98.8)]) is None
+
+
+def test_confluence_3_three_longs_pass():
+    agg = SignalAggregator(confluence_n=3)
+    d = agg.resolve(
+        [
+            _sig("h2", "long", 101.0, 99.0, idx=10),
+            _sig("wedge_long", "long", 101.5, 98.5, idx=11),
+            _sig("double_bottom", "long", 100.8, 99.2, idx=12),
+        ]
+    )
+    assert d is not None
+    assert d.side == "long"
+    assert set(d.hit_detectors) == {"h2", "wedge_long", "double_bottom"}
+    assert d.signal_bar_idx == 12  # latest
+    assert d.entry_px == 101.5
+    assert d.stop_px == 98.5
+
+
+def test_confluence_3_mixed_sides_with_two_long_one_short_rejected():
+    agg = SignalAggregator(confluence_n=3)
+    d = agg.resolve(
+        [
+            _sig("h2", "long", 101.0, 99.0),
+            _sig("wedge_long", "long", 101.5, 98.5),
+            _sig("l2", "short", 99.0, 101.0),
+        ]
+    )
+    assert d is None
+
+
+# ---------------------------------------------------------------------------
+# Misc
+# ---------------------------------------------------------------------------
+
+
+def test_aggregated_decision_to_dict_roundtrips_signals():
+    agg = SignalAggregator(confluence_n=1)
+    d = agg.resolve([_sig("h2", "long", 101.0, 99.0, timestamp_ns=12345)])
+    assert d is not None
+    blob = d.to_dict()
+    assert blob["side"] == "long"
+    assert blob["hit_detectors"] == ["h2"]
+    assert blob["timestamp_ns"] == 12345
+    assert blob["raw_signals"][0]["pattern"] == "h2"
+    assert blob["raw_signals"][0]["source"] == "rule:h2"
+
+
+def test_timestamp_uses_latest_meta():
+    agg = SignalAggregator(confluence_n=2)
+    d = agg.resolve(
+        [
+            _sig("h2", "long", 101.0, 99.0, timestamp_ns=100),
+            _sig("wedge_long", "long", 101.5, 98.5, timestamp_ns=200),
+        ]
+    )
+    assert d is not None
+    assert d.timestamp_ns == 200

--- a/tests/brooks/test_analyst_rule.py
+++ b/tests/brooks/test_analyst_rule.py
@@ -1,0 +1,246 @@
+"""Behavioral tests for :class:`RuleAnalyst`.
+
+Three fixture flavors per the Phase 2.5 spec:
+  * ``bull_strong_trend_h2``   — uptrend then H2 setup → expect ``rule:h2`` long signal
+  * ``bear_weak_trend_l2``     — downtrend then L2 setup → expect ``rule:l2`` short signal
+  * ``range_no_signal``        — sideways chop → no signals
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import List
+
+import pytest
+
+from src.brooks.analyst import AnalystRegistry, RuleAnalyst
+from src.brooks.context import Bar as BrooksBar
+from src.brooks.context import BrooksContext, TFSnapshot
+from src.brooks.features import BarFeatureExtractor
+from src.brooks.patterns import DetectorContext, H2Detector, L2Detector
+from src.brooks.patterns.registry import PatternRegistry
+from src.brooks.schema import Signal
+from src.brooks.structure import MarketStructureTracker
+from src.core.base import Bar as CoreBar
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _to_brooks_bars(core_bars: List[CoreBar]) -> List[BrooksBar]:
+    return [
+        BrooksBar(
+            timestamp_ns=int(b.timestamp.timestamp() * 1_000_000_000),
+            open=b.open,
+            high=b.high,
+            low=b.low,
+            close=b.close,
+            volume=b.volume,
+        )
+        for b in core_bars
+    ]
+
+
+def _ctx_from(core_bars: List[CoreBar], symbol: str = "BTCUSDT") -> BrooksContext:
+    snap = TFSnapshot(interval="5m", bars=_to_brooks_bars(core_bars))
+    return BrooksContext(symbol=symbol, primary=snap)
+
+
+def _detector_only_signals(core_bars, detector_factory, **extractor_kwargs):
+    """Run a single detector standalone — establishes the parity baseline."""
+    ext = BarFeatureExtractor(**extractor_kwargs)
+    tr = MarketStructureTracker(ext, breakout_lookback=extractor_kwargs.get("breakout_lookback", 20))
+    hist = []
+    det = detector_factory()
+    out = []
+    for b in core_bars:
+        ts_ns = int(b.timestamp.timestamp() * 1_000_000_000)
+        f = ext.on_bar(ts_ns, b.open, b.high, b.low, b.close)
+        s = tr.on_features(f)
+        hist.append(f)
+        sig = det.on_bar(DetectorContext(feat=f, structure=s, recent_features=hist))
+        if sig is not None:
+            out.append(sig)
+    return out
+
+
+def _run(analyst, ctx) -> List[Signal]:
+    return asyncio.run(analyst.analyze(ctx))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def range_no_signal_bars() -> List[CoreBar]:
+    """Tight chop — alternating tiny doji-ish bars near 100.0."""
+    from .conftest import make_series
+
+    vals = []
+    p = 100.0
+    for i in range(40):
+        o = p
+        c = p + (0.05 if i % 2 == 0 else -0.05)
+        h = max(o, c) + 0.02
+        l = min(o, c) - 0.02
+        vals.append((o, h, l, c))
+        p = c
+    return make_series(vals)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+def test_registry_builds_rule_analyst():
+    a = AnalystRegistry.build("rule")
+    assert isinstance(a, RuleAnalyst)
+    assert a.name == "rule"
+    assert "rule" in AnalystRegistry.all()
+
+
+def test_registry_unknown_name_raises():
+    with pytest.raises(KeyError):
+        AnalystRegistry.build("does_not_exist")
+
+
+# ---------------------------------------------------------------------------
+# bull_strong_trend_h2 fixture
+# ---------------------------------------------------------------------------
+
+
+def test_bull_strong_trend_h2_emits_h2_long(synthetic_h2_bars):
+    ctx = _ctx_from(synthetic_h2_bars)
+    analyst = AnalystRegistry.build(
+        "rule",
+        detector_names=["h2"],
+        extractor_kwargs={"swing_k": 2, "breakout_lookback": 8, "atr_period": 5},
+        structure_kwargs={"breakout_lookback": 8},
+    )
+    signals = _run(analyst, ctx)
+    assert len(signals) == 1
+    sig = signals[0]
+    assert sig.pattern == "h2"
+    assert sig.side == "long"
+    assert sig.source == "rule:h2"
+    assert sig.entry_px > sig.stop_px
+    assert 0.0 <= sig.probability <= 1.0
+    assert 0.0 <= sig.quality <= 1.0
+
+
+def test_bull_strong_trend_h2_matches_standalone_detector(synthetic_h2_bars):
+    """RuleAnalyst output must equal H2Detector output bar-for-bar."""
+    baseline = _detector_only_signals(
+        synthetic_h2_bars,
+        H2Detector,
+        swing_k=2,
+        breakout_lookback=8,
+        atr_period=5,
+    )
+    ctx = _ctx_from(synthetic_h2_bars)
+    analyst = AnalystRegistry.build(
+        "rule",
+        detector_names=["h2"],
+        extractor_kwargs={"swing_k": 2, "breakout_lookback": 8, "atr_period": 5},
+        structure_kwargs={"breakout_lookback": 8},
+    )
+    signals = _run(analyst, ctx)
+    # Baseline runs every bar; analyst sees only the last bar — so analyst's
+    # signal corresponds to the baseline signal for that final bar (if any).
+    last_idx = len(synthetic_h2_bars) - 1
+    expected = [s for s in baseline if s.signal_bar_idx == last_idx]
+    assert len(signals) == len(expected) == 1
+    assert signals[0].signal_bar_idx == expected[0].signal_bar_idx
+    assert signals[0].entry_px == expected[0].entry_px
+    assert signals[0].stop_px == expected[0].stop_px
+
+
+# ---------------------------------------------------------------------------
+# bear_weak_trend_l2 fixture
+# ---------------------------------------------------------------------------
+
+
+def test_bear_weak_trend_l2_emits_l2_short(synthetic_l2_bars):
+    ctx = _ctx_from(synthetic_l2_bars)
+    analyst = AnalystRegistry.build(
+        "rule",
+        detector_names=["l2"],
+        extractor_kwargs={"swing_k": 2, "breakout_lookback": 8, "atr_period": 5},
+        structure_kwargs={"breakout_lookback": 8},
+    )
+    signals = _run(analyst, ctx)
+    assert len(signals) == 1
+    sig = signals[0]
+    assert sig.pattern == "l2"
+    assert sig.side == "short"
+    assert sig.source == "rule:l2"
+    assert sig.entry_px < sig.stop_px
+
+
+def test_bear_weak_trend_l2_matches_standalone_detector(synthetic_l2_bars):
+    baseline = _detector_only_signals(
+        synthetic_l2_bars,
+        L2Detector,
+        swing_k=2,
+        breakout_lookback=8,
+        atr_period=5,
+    )
+    ctx = _ctx_from(synthetic_l2_bars)
+    analyst = AnalystRegistry.build(
+        "rule",
+        detector_names=["l2"],
+        extractor_kwargs={"swing_k": 2, "breakout_lookback": 8, "atr_period": 5},
+        structure_kwargs={"breakout_lookback": 8},
+    )
+    signals = _run(analyst, ctx)
+    last_idx = len(synthetic_l2_bars) - 1
+    expected = [s for s in baseline if s.signal_bar_idx == last_idx]
+    assert len(signals) == len(expected) == 1
+    assert signals[0].entry_px == expected[0].entry_px
+    assert signals[0].stop_px == expected[0].stop_px
+
+
+# ---------------------------------------------------------------------------
+# range_no_signal fixture
+# ---------------------------------------------------------------------------
+
+
+def test_range_no_signal_emits_nothing(range_no_signal_bars):
+    ctx = _ctx_from(range_no_signal_bars)
+    analyst = AnalystRegistry.build("rule")  # all registered detectors
+    signals = _run(analyst, ctx)
+    assert signals == []
+
+
+# ---------------------------------------------------------------------------
+# Misc
+# ---------------------------------------------------------------------------
+
+
+def test_empty_context_returns_empty_signals():
+    ctx = BrooksContext(symbol="BTCUSDT", primary=TFSnapshot(interval="5m", bars=[]))
+    analyst = AnalystRegistry.build("rule")
+    assert _run(analyst, ctx) == []
+
+
+def test_default_detector_set_is_full_registry():
+    analyst = AnalystRegistry.build("rule")
+    # Cover every currently-registered detector.
+    assert set(analyst._detector_names) == set(PatternRegistry.all())
+
+
+def test_signal_meta_carries_timestamp(synthetic_h2_bars):
+    ctx = _ctx_from(synthetic_h2_bars)
+    analyst = AnalystRegistry.build(
+        "rule",
+        detector_names=["h2"],
+        extractor_kwargs={"swing_k": 2, "breakout_lookback": 8, "atr_period": 5},
+        structure_kwargs={"breakout_lookback": 8},
+    )
+    signals = _run(analyst, ctx)
+    assert signals
+    assert signals[0].meta.get("timestamp_ns")


### PR DESCRIPTION
## Summary

Implements [QUA-46](https://github.com/zsh-a/quant) (Phase 2.5):

- **`src/brooks/analyst/`** — `Analyst` Protocol + `AnalystRegistry` (decorator/factory) + `RuleAnalyst`, the first concrete analyst. The rule analyst fans out every registered pattern detector and promotes their internal `PatternSignal` to the unified `Signal` schema (`source = "rule:<name>"`).
- **`src/brooks/decision/aggregator.py`** — migrated from `src/analysis/brooks/aggregator.py`; consumes the `Signal` schema while preserving confluence_n gating and conservative entry/stop semantics. Old aggregator left untouched for `brooks_v2` (Phase 3 cutover deletes it).
- **Tests** — `tests/brooks/test_analyst_rule.py` covers the three required fixtures (`bull_strong_trend_h2`, `bear_weak_trend_l2`, `range_no_signal`) plus parity vs. standalone H2/L2 detectors; `tests/brooks/test_aggregator.py` covers confluence_n=1/2/3 boundaries, side ties, and round-trip serialization.

## Design notes

The Phase 2 `BrooksContext.TFSnapshot` doesn't carry features/structure yet, so `RuleAnalyst.analyze` rebuilds them by streaming `ctx.primary.bars` through `BarFeatureExtractor` + `MarketStructureTracker`. Brooks pattern detectors are stateful (H2/L2 build a multi-bar pullback FSM, doubles wait for paired swings), so the analyst replays every bar through each detector and only emits signals that fire on the latest bar. Phase 3 will swap the replay for direct field access on `TFSnapshot`.

## Test plan

- [x] `pytest tests/brooks/ tests/strategies/brooks_v2/` → 136 passed
- [x] `ruff check` + `ruff format --check` clean
- [x] `AnalystRegistry.build("rule").analyze(ctx)` returns the same H2/L2 entry/stop as standalone detector replay (parity tests)
- [x] confluence_n boundaries verified (1 / 2 / 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)