### PR TITLE
feat(brooks): eval pipeline — golden + auto_label + runner + report (QUA-55)

### DIFF
--- a/scripts/brooks_label_silver.py
+++ b/scripts/brooks_label_silver.py
@@ -1,0 +1,183 @@
+"""Auto-label historical bars into a silver Brooks dataset.
+
+Reads OHLCV bars from a parquet/jsonl input file, runs the Brooks rule
+analyst plus N LLM analysts (loaded by name from
+``AnalystRegistry``), and writes a :class:`GoldenDataset` of silver
+samples wherever ``--min-agreement`` analysts agree.
+
+The script is intentionally agnostic about *where* the bars come from:
+the input file just needs the columns ``timestamp_ns, open, high, low,
+close, volume`` (extra columns are ignored). For testing without an LLM
+backend, omit ``--llm`` — the rule analyst alone will be enough to
+produce silver samples wherever it fires (with ``--min-agreement 1``).
+
+Usage
+-----
+    python scripts/brooks_label_silver.py \
+        --input data/brooks/raw/btcusdt_5m.parquet \
+        --output data/brooks/silver/btcusdt_5m.parquet \
+        --symbol BTCUSDT --interval 5m \
+        --llm openai:gpt-4o-mini --llm openai:gpt-4o \
+        --min-agreement 2
+
+    # Dry-run: scan only, do not write
+    python scripts/brooks_label_silver.py \
+        --input data/brooks/raw/sample.jsonl \
+        --symbol BTC --interval 5m \
+        --min-agreement 1 --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.brooks.analyst.base import AnalystRegistry  # noqa: E402
+from src.brooks.context import Bar  # noqa: E402
+from src.brooks.eval.auto_label import AutoLabeler  # noqa: E402
+from src.brooks.eval.golden import GoldenDataset  # noqa: E402
+
+# Importing the analyst package triggers registration of "rule" + "llm".
+import src.brooks.analyst  # noqa: E402,F401
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = _parse_args(argv)
+
+    bars = _load_bars(Path(args.input))
+    if not bars:
+        print(f"[no-data] {args.input!s} is empty; nothing to label")
+        return 0
+
+    rule_analyst = AnalystRegistry.build("rule")
+    llm_analysts = []
+    for spec in args.llm or []:
+        params = _parse_llm_spec(spec)
+        llm_analysts.append(AnalystRegistry.build("llm", **params))
+
+    labeler = AutoLabeler(
+        rule_analyst=rule_analyst,
+        llm_analysts=llm_analysts,
+        min_agreement=args.min_agreement,
+        max_concurrent=args.max_concurrent,
+        entry_tolerance=args.entry_tolerance,
+        min_bars_for_label=args.min_bars,
+    )
+
+    samples = asyncio.run(
+        labeler.label(bars=bars, symbol=args.symbol, interval=args.interval)
+    )
+
+    print(
+        f"[done] scanned {len(bars)} bars; emitted {len(samples)} silver samples "
+        f"(analysts={labeler.analyst_count}, min_agreement={labeler.min_agreement})"
+    )
+
+    if not samples or args.dry_run:
+        if args.dry_run:
+            print("[dry-run] not writing output file")
+        return 0
+
+    output = Path(args.output)
+    GoldenDataset.from_samples(samples).save(output)
+    print(f"[wrote] {len(samples)} samples → {output!s}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI plumbing
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: Optional[List[str]]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--input", required=True, help="parquet or jsonl file with OHLCV bars")
+    p.add_argument("--output", help="silver dataset output (parquet or jsonl)")
+    p.add_argument("--symbol", required=True)
+    p.add_argument("--interval", required=True, help='bar interval label, e.g. "5m"')
+    p.add_argument(
+        "--llm",
+        action="append",
+        default=[],
+        help='Add an LLM analyst, e.g. "openai:gpt-4o" or '
+        "JSON params via 'llm:{json}'",
+    )
+    p.add_argument("--min-agreement", type=int, default=2, dest="min_agreement")
+    p.add_argument("--max-concurrent", type=int, default=4, dest="max_concurrent")
+    p.add_argument("--entry-tolerance", type=float, default=0.005, dest="entry_tolerance")
+    p.add_argument("--min-bars", type=int, default=20, dest="min_bars")
+    p.add_argument("--dry-run", action="store_true")
+    args = p.parse_args(argv)
+    if not args.dry_run and not args.output:
+        p.error("--output is required unless --dry-run is set")
+    return args
+
+
+def _parse_llm_spec(spec: str) -> dict:
+    """Parse ``provider:model`` or ``provider:{json-params}`` into kwargs."""
+    if not spec:
+        raise ValueError("empty --llm spec")
+    if spec.startswith("{"):
+        return json.loads(spec)
+    if ":" not in spec:
+        raise ValueError(
+            f"invalid --llm spec {spec!r}; expected 'provider:model' or JSON object"
+        )
+    provider, rest = spec.split(":", 1)
+    rest = rest.strip()
+    if rest.startswith("{"):
+        params = json.loads(rest)
+        params.setdefault("provider", provider)
+        return params
+    return {"provider": provider, "model": rest}
+
+
+# ---------------------------------------------------------------------------
+# Bar loading
+# ---------------------------------------------------------------------------
+
+
+def _load_bars(path: Path) -> List[Bar]:
+    if not path.exists():
+        raise FileNotFoundError(f"input not found: {path!s}")
+    suffix = path.suffix.lower()
+    if suffix == ".parquet":
+        import pandas as pd
+
+        df = pd.read_parquet(path)
+        return [_row_to_bar(row.to_dict()) for _, row in df.iterrows()]
+    if suffix == ".jsonl":
+        out: List[Bar] = []
+        with path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                out.append(_row_to_bar(json.loads(line)))
+        return out
+    raise ValueError(f"unsupported input suffix: {suffix!r}")
+
+
+def _row_to_bar(row: dict) -> Bar:
+    return Bar(
+        timestamp_ns=int(row["timestamp_ns"]),
+        open=float(row["open"]),
+        high=float(row["high"]),
+        low=float(row["low"]),
+        close=float(row["close"]),
+        volume=float(row.get("volume", 0.0)),
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/brooks/eval/__init__.py
+++ b/src/brooks/eval/__init__.py
@@ -1,0 +1,29 @@
+"""Brooks evaluation pipeline.
+
+This package wires together the four ingredients needed to grade a Brooks
+:class:`~src.brooks.analyst.base.Analyst`:
+
+* :mod:`src.brooks.eval.golden` — load a hand-curated or auto-labeled
+  dataset of :class:`GoldenSample`'s (parquet or jsonl).
+* :mod:`src.brooks.eval.auto_label` — bootstrap silver labels from
+  rule + multi-LLM consensus voting.
+* :mod:`src.brooks.eval.runner` — replay each sample through an analyst,
+  score signals via the optional :class:`TraderEquation`, and emit per-bucket
+  metrics.
+* :mod:`src.brooks.eval.report` — turn an :class:`EvalReport` into an HTML
+  page (with per-pattern / regime / htf bucket tables and Wilson CIs).
+"""
+
+from src.brooks.eval.auto_label import AutoLabeler
+from src.brooks.eval.golden import GoldenDataset, GoldenSample
+from src.brooks.eval.report import EvalReport
+from src.brooks.eval.runner import EvalRunner, SampleResult
+
+__all__ = [
+    "AutoLabeler",
+    "EvalReport",
+    "EvalRunner",
+    "GoldenDataset",
+    "GoldenSample",
+    "SampleResult",
+]

--- a/src/brooks/eval/auto_label.py
+++ b/src/brooks/eval/auto_label.py
@@ -1,0 +1,260 @@
+"""Rule + multi-LLM consensus auto-labeler.
+
+The :class:`AutoLabeler` walks a bar series, asks every analyst (one rule
+analyst plus N LLM analysts) for signals at each candidate bar, and emits
+a :class:`~src.brooks.eval.golden.GoldenSample` (``source="silver"``)
+whenever at least ``min_agreement`` analysts agree on the same
+``(pattern, side)`` setup with similar entry/stop levels.
+
+The consensus is intentionally conservative — silver labels seed the
+golden dataset, so it is better to skip ambiguous bars than to embed
+disagreement into the corpus.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import statistics
+import uuid
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Tuple
+
+from src.brooks.analyst.base import Analyst
+from src.brooks.context import Bar, BrooksContext, TFSnapshot
+from src.brooks.eval.golden import GoldenSample
+from src.brooks.features import BarFeatureExtractor
+from src.brooks.regime import BrooksRegimeClassifier, RegimeSnapshot
+from src.brooks.schema import Signal
+from src.brooks.structure import MarketStructureTracker
+
+__all__ = ["AutoLabeler", "ConsensusVote"]
+
+
+@dataclass
+class ConsensusVote:
+    """Internal record describing the agreed-upon setup for a bar."""
+
+    pattern: str
+    side: str
+    entry: float
+    stop: float
+    target: Optional[float]
+    voters: List[str]
+    reasonings: List[str]
+
+
+class AutoLabeler:
+    """Generate silver :class:`GoldenSample`'s from analyst consensus.
+
+    Parameters
+    ----------
+    rule_analyst:
+        Required deterministic analyst — its output anchors each consensus
+        bucket. The rule analyst is also counted toward ``min_agreement``.
+    llm_analysts:
+        Stochastic analysts (typically ``LLMAnalyst`` instances). Set to
+        ``[]`` to vote with the rule analyst alone (mostly for tests).
+    min_agreement:
+        Minimum number of analysts that must agree on ``(pattern, side)``
+        before a sample is emitted.
+    max_concurrent:
+        Cap on concurrent ``analyze`` calls. Used to throttle LLM
+        rate limits.
+    entry_tolerance:
+        Maximum *relative* spread of entry prices (as a fraction of the
+        median entry) tolerated within a consensus group. Larger spreads
+        cause the bar to be rejected.
+    min_bars_for_label:
+        Bars before which ``label`` skips the candidate. Detectors need
+        history before they can produce signals; this avoids flooding the
+        analysts with empty contexts.
+    """
+
+    def __init__(
+        self,
+        rule_analyst: Analyst,
+        llm_analysts: Optional[Sequence[Analyst]] = None,
+        min_agreement: int = 2,
+        max_concurrent: int = 4,
+        entry_tolerance: float = 0.005,
+        min_bars_for_label: int = 20,
+    ) -> None:
+        if rule_analyst is None:
+            raise ValueError("AutoLabeler requires a rule analyst")
+        if min_agreement < 1:
+            raise ValueError("min_agreement must be >= 1")
+        if max_concurrent < 1:
+            raise ValueError("max_concurrent must be >= 1")
+        if entry_tolerance < 0:
+            raise ValueError("entry_tolerance must be non-negative")
+        self._rule = rule_analyst
+        self._llms: List[Analyst] = list(llm_analysts or [])
+        self._analysts: List[Analyst] = [self._rule, *self._llms]
+        self._min_agreement = int(min_agreement)
+        self._max_concurrent = int(max_concurrent)
+        self._entry_tolerance = float(entry_tolerance)
+        self._min_bars_for_label = int(min_bars_for_label)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @property
+    def min_agreement(self) -> int:
+        return self._min_agreement
+
+    @property
+    def analyst_count(self) -> int:
+        return len(self._analysts)
+
+    async def label(
+        self,
+        bars: Sequence[Bar],
+        symbol: str,
+        interval: str,
+        htf: Optional[dict] = None,
+    ) -> List[GoldenSample]:
+        """Walk ``bars`` bar-by-bar, returning silver samples on consensus.
+
+        Each candidate bar produces at most one sample (the strongest
+        consensus group on that bar wins). Bars before
+        ``min_bars_for_label`` are skipped — pattern detectors generally
+        need ~20 bars of warmup.
+        """
+        if len(bars) < max(self._min_bars_for_label, 1):
+            return []
+
+        regime_history = _precompute_regimes(bars)
+        sem = asyncio.Semaphore(self._max_concurrent)
+        out: List[GoldenSample] = []
+
+        for idx in range(self._min_bars_for_label, len(bars)):
+            ctx_bars = list(bars[: idx + 1])
+            ctx = BrooksContext(
+                symbol=symbol,
+                primary=TFSnapshot(interval=interval, bars=ctx_bars),
+                htf=dict(htf or {}),
+            )
+            signal_lists = await _gather_signals(self._analysts, ctx, sem)
+            vote = _resolve_consensus(
+                signal_lists,
+                analyst_names=[a.name for a in self._analysts],
+                min_agreement=self._min_agreement,
+                entry_tolerance=self._entry_tolerance,
+            )
+            if vote is None:
+                continue
+            regime_snap = regime_history[idx]
+            htf_aligned = bool(htf and ctx.htf_aligned_for(vote.side))
+            sample = GoldenSample(
+                id=f"silver-{symbol}-{interval}-{idx}-{uuid.uuid4().hex[:8]}",
+                symbol=symbol,
+                interval=interval,
+                bars=ctx_bars,
+                target_bar_idx=idx,
+                expected_pattern=vote.pattern,
+                expected_side=vote.side,  # type: ignore[arg-type]
+                expected_entry=vote.entry,
+                expected_stop=vote.stop,
+                expected_target=vote.target,
+                regime=regime_snap.regime.value,
+                htf_aligned=htf_aligned,
+                source="silver",
+                reasoning=" || ".join(r for r in vote.reasonings if r),
+                meta={
+                    "voters": list(vote.voters),
+                    "agreement": len(vote.voters),
+                    "regime_confidence": round(regime_snap.confidence, 4),
+                },
+            )
+            out.append(sample)
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+async def _gather_signals(
+    analysts: Sequence[Analyst],
+    ctx: BrooksContext,
+    sem: asyncio.Semaphore,
+) -> List[List[Signal]]:
+    async def _one(a: Analyst) -> List[Signal]:
+        async with sem:
+            return list(await a.analyze(ctx))
+
+    return await asyncio.gather(*[_one(a) for a in analysts])
+
+
+def _resolve_consensus(
+    signal_lists: List[List[Signal]],
+    analyst_names: Sequence[str],
+    min_agreement: int,
+    entry_tolerance: float,
+) -> Optional[ConsensusVote]:
+    """Bucket signals by (pattern, side) and return the strongest agreement."""
+    buckets: dict[Tuple[str, str], List[Tuple[str, Signal]]] = defaultdict(list)
+    for name, sigs in zip(analyst_names, signal_lists):
+        seen: set[Tuple[str, str]] = set()
+        for s in sigs:
+            key = (s.pattern, s.side)
+            if key in seen:
+                continue
+            seen.add(key)
+            buckets[key].append((name, s))
+
+    best: Optional[ConsensusVote] = None
+    for (pattern, side), entries in buckets.items():
+        if len(entries) < min_agreement:
+            continue
+        signals = [s for _, s in entries]
+        if not _entries_compatible(signals, entry_tolerance):
+            continue
+        entry = statistics.median(s.entry_px for s in signals)
+        stop = statistics.median(s.stop_px for s in signals)
+        targets = [s.target_px for s in signals if s.target_px is not None]
+        target = statistics.median(targets) if targets else None
+        vote = ConsensusVote(
+            pattern=pattern,
+            side=side,
+            entry=float(entry),
+            stop=float(stop),
+            target=float(target) if target is not None else None,
+            voters=[name for name, _ in entries],
+            reasonings=[s.reasoning for s in signals],
+        )
+        if best is None or len(vote.voters) > len(best.voters):
+            best = vote
+    return best
+
+
+def _entries_compatible(signals: Sequence[Signal], tolerance: float) -> bool:
+    if tolerance <= 0:
+        return True
+    entries = [s.entry_px for s in signals]
+    if not entries:
+        return False
+    base = statistics.median(entries)
+    if base == 0:
+        return all(math.isclose(e, 0.0) for e in entries)
+    spread = (max(entries) - min(entries)) / abs(base)
+    return spread <= tolerance
+
+
+def _precompute_regimes(bars: Sequence[Bar]) -> List[RegimeSnapshot]:
+    """Replay every bar through the regime classifier; return per-bar snapshots."""
+    ext = BarFeatureExtractor()
+    tracker = MarketStructureTracker(ext)
+    classifier = BrooksRegimeClassifier()
+    history: List = []
+    snapshots: List[RegimeSnapshot] = []
+    for bar in bars:
+        feat = ext.on_bar(bar.timestamp_ns, bar.open, bar.high, bar.low, bar.close)
+        struct = tracker.on_features(feat)
+        history.append(feat)
+        snapshots.append(classifier.classify(history, struct))
+    return snapshots

--- a/src/brooks/eval/golden.py
+++ b/src/brooks/eval/golden.py
@@ -1,0 +1,301 @@
+"""Golden dataset loader for Brooks evaluation.
+
+A :class:`GoldenSample` is a single labeled bar window: the bars provide
+the analyst's input context, ``target_bar_idx`` points at the bar where
+the expected signal fires, and ``expected_*`` fields encode the ground
+truth (pattern, side, entry/stop/target, regime, HTF alignment).
+
+Two storage formats are supported transparently:
+
+* **parquet** — one row per sample; ``bars`` is stored as a JSON-encoded
+  string in the column so each parquet row stays scalar.
+* **jsonl**   — one JSON object per line, mirroring the parquet schema.
+
+Loaders pick the format from the file suffix; directories are walked
+recursively and every matching file is concatenated into a single
+:class:`GoldenDataset`.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Iterator, List, Literal, Optional
+
+from src.brooks.context import Bar
+
+__all__ = ["GoldenSample", "GoldenDataset"]
+
+
+SourceTag = Literal["human", "silver"]
+
+
+@dataclass
+class GoldenSample:
+    """One labeled (bars → expected signal) data point."""
+
+    id: str
+    symbol: str
+    interval: str
+    bars: List[Bar]
+    target_bar_idx: int
+    expected_pattern: str
+    expected_side: Literal["long", "short"]
+    expected_entry: float
+    expected_stop: float
+    expected_target: Optional[float] = None
+    regime: str = "unknown"
+    htf_aligned: bool = False
+    source: SourceTag = "human"
+    reasoning: str = ""
+    meta: dict = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.bars:
+            raise ValueError(f"GoldenSample {self.id!r}: bars must be non-empty")
+        if not 0 <= self.target_bar_idx < len(self.bars):
+            raise ValueError(
+                f"GoldenSample {self.id!r}: target_bar_idx={self.target_bar_idx} out of range [0, {len(self.bars)})"
+            )
+        if self.expected_side not in ("long", "short"):
+            raise ValueError(f"GoldenSample {self.id!r}: invalid side {self.expected_side!r}")
+        if self.expected_entry == self.expected_stop:
+            raise ValueError(f"GoldenSample {self.id!r}: entry must differ from stop")
+
+    # ------------------------------------------------------------------
+    # Convenience properties
+    # ------------------------------------------------------------------
+
+    @property
+    def context_bars(self) -> List[Bar]:
+        """Bars up to and including ``target_bar_idx`` (analyst input)."""
+        return self.bars[: self.target_bar_idx + 1]
+
+    @property
+    def future_bars(self) -> List[Bar]:
+        """Bars strictly after ``target_bar_idx`` (used for hit-rate scoring)."""
+        return self.bars[self.target_bar_idx + 1 :]
+
+    @property
+    def one_r(self) -> float:
+        """Absolute per-share risk (|entry − stop|)."""
+        return abs(self.expected_entry - self.expected_stop)
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict:
+        """Serialise to a JSON-friendly dict (bars become a list of dicts)."""
+        d = asdict(self)
+        d["bars"] = [_bar_to_dict(b) for b in self.bars]
+        return d
+
+    @classmethod
+    def from_dict(cls, raw: dict) -> "GoldenSample":
+        """Inverse of :meth:`to_dict` — parquet rows pass through here too."""
+        data = dict(raw)
+        bars_raw = data.pop("bars", None)
+        if bars_raw is None:
+            raise ValueError("GoldenSample.from_dict: missing 'bars' field")
+        if isinstance(bars_raw, str):
+            bars_raw = json.loads(bars_raw)
+        bars = [_bar_from_dict(b) for b in bars_raw]
+        meta = data.pop("meta", None)
+        if isinstance(meta, str):
+            try:
+                meta = json.loads(meta)
+            except (TypeError, ValueError):
+                meta = {}
+        if meta is None:
+            meta = {}
+        target_val = data.get("expected_target")
+        if target_val is not None:
+            try:
+                if float(target_val) != float(target_val):  # NaN check
+                    data["expected_target"] = None
+                else:
+                    data["expected_target"] = float(target_val)
+            except (TypeError, ValueError):
+                data["expected_target"] = None
+        return cls(bars=bars, meta=meta, **data)
+
+
+@dataclass
+class GoldenDataset:
+    """A collection of :class:`GoldenSample`'s with filter/iter helpers."""
+
+    samples: List[GoldenSample] = field(default_factory=list)
+
+    # ------------------------------------------------------------------
+    # Loading
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def load(cls, path: Path | str) -> "GoldenDataset":
+        """Load samples from a file or directory.
+
+        Supported suffixes: ``.parquet``, ``.jsonl`` (and ``.json`` as a
+        single-object-or-array convenience). Directories are walked
+        recursively and every matching file contributes its samples.
+        """
+        p = Path(path)
+        if not p.exists():
+            raise FileNotFoundError(f"GoldenDataset.load: {p!s} does not exist")
+        files: List[Path] = []
+        if p.is_dir():
+            for suffix in ("*.parquet", "*.jsonl", "*.json"):
+                files.extend(sorted(p.rglob(suffix)))
+            if not files:
+                return cls(samples=[])
+        else:
+            files = [p]
+
+        samples: List[GoldenSample] = []
+        for fp in files:
+            samples.extend(_load_one(fp))
+        return cls(samples=samples)
+
+    @classmethod
+    def from_samples(cls, samples: Iterable[GoldenSample]) -> "GoldenDataset":
+        return cls(samples=list(samples))
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
+    def save(self, path: Path | str) -> Path:
+        """Write the dataset to ``path``; format is chosen by the suffix."""
+        out = Path(path)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        suffix = out.suffix.lower()
+        if suffix == ".parquet":
+            _write_parquet(self.samples, out)
+        elif suffix in {".jsonl", ".json"}:
+            _write_jsonl(self.samples, out)
+        else:
+            raise ValueError(f"GoldenDataset.save: unsupported suffix {suffix!r}")
+        return out
+
+    # ------------------------------------------------------------------
+    # Filtering
+    # ------------------------------------------------------------------
+
+    def filter(self, **criteria: Any) -> "GoldenDataset":
+        """Return a new dataset whose samples match every keyword filter.
+
+        Filter values may be a single value (equality) or a collection
+        (membership). Unknown keys raise :class:`AttributeError`.
+        """
+        if not criteria:
+            return GoldenDataset(samples=list(self.samples))
+
+        def _matches(sample: GoldenSample) -> bool:
+            for key, want in criteria.items():
+                if not hasattr(sample, key):
+                    raise AttributeError(f"GoldenSample has no attribute {key!r}")
+                got = getattr(sample, key)
+                if isinstance(want, (list, tuple, set, frozenset)):
+                    if got not in want:
+                        return False
+                elif got != want:
+                    return False
+            return True
+
+        return GoldenDataset(samples=[s for s in self.samples if _matches(s)])
+
+    # ------------------------------------------------------------------
+    # Container protocol
+    # ------------------------------------------------------------------
+
+    def __iter__(self) -> Iterator[GoldenSample]:
+        return iter(self.samples)
+
+    def __len__(self) -> int:
+        return len(self.samples)
+
+    def __getitem__(self, idx: int) -> GoldenSample:
+        return self.samples[idx]
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+_BAR_FIELDS = ("timestamp_ns", "open", "high", "low", "close", "volume")
+
+
+def _bar_to_dict(bar: Bar) -> dict:
+    return {f: getattr(bar, f) for f in _BAR_FIELDS}
+
+
+def _bar_from_dict(raw: dict) -> Bar:
+    return Bar(
+        timestamp_ns=int(raw["timestamp_ns"]),
+        open=float(raw["open"]),
+        high=float(raw["high"]),
+        low=float(raw["low"]),
+        close=float(raw["close"]),
+        volume=float(raw.get("volume", 0.0)),
+    )
+
+
+def _load_one(path: Path) -> List[GoldenSample]:
+    suffix = path.suffix.lower()
+    if suffix == ".parquet":
+        return _read_parquet(path)
+    if suffix == ".jsonl":
+        return _read_jsonl(path)
+    if suffix == ".json":
+        return _read_json(path)
+    return []
+
+
+def _read_parquet(path: Path) -> List[GoldenSample]:
+    import pandas as pd  # local import to keep cold-import light
+
+    df = pd.read_parquet(path)
+    out: List[GoldenSample] = []
+    for _, row in df.iterrows():
+        out.append(GoldenSample.from_dict(row.to_dict()))
+    return out
+
+
+def _read_jsonl(path: Path) -> List[GoldenSample]:
+    out: List[GoldenSample] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            out.append(GoldenSample.from_dict(json.loads(line)))
+    return out
+
+
+def _read_json(path: Path) -> List[GoldenSample]:
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if isinstance(data, dict):
+        data = [data]
+    return [GoldenSample.from_dict(d) for d in data]
+
+
+def _write_parquet(samples: Iterable[GoldenSample], path: Path) -> None:
+    import pandas as pd
+
+    rows = []
+    for s in samples:
+        d = s.to_dict()
+        d["bars"] = json.dumps(d["bars"])
+        d["meta"] = json.dumps(d.get("meta") or {})
+        rows.append(d)
+    df = pd.DataFrame(rows)
+    df.to_parquet(path, index=False)
+
+
+def _write_jsonl(samples: Iterable[GoldenSample], path: Path) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        for s in samples:
+            fh.write(json.dumps(s.to_dict()) + "\n")

--- a/src/brooks/eval/report.py
+++ b/src/brooks/eval/report.py
@@ -1,0 +1,403 @@
+"""HTML / DataFrame report for an :class:`EvalRunner` execution.
+
+The :class:`EvalReport` carries the per-sample :class:`SampleResult`
+records and exposes:
+
+* :meth:`to_dataframe` — a flat ``pandas.DataFrame`` of every row.
+* :meth:`bucket_metrics` — pattern / regime / htf_aligned / source
+  precision-recall-F1 with Wilson 95% confidence intervals.
+* :meth:`cost_summary` — aggregate latency, token usage, and cache hit
+  rate (only meaningful for LLM analysts; rule analysts fill 0s).
+* :meth:`to_html` — a self-contained HTML page with the headline
+  metrics and one table per bucket dimension.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import math
+import statistics
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from src.brooks.eval.runner import SampleResult
+
+__all__ = ["EvalReport", "BucketMetrics"]
+
+
+@dataclass
+class BucketMetrics:
+    """Precision / recall / F1 with Wilson CI for one bucket."""
+
+    bucket: str
+    value: str
+    samples: int
+    pattern_precision: float
+    pattern_recall: float
+    pattern_f1: float
+    side_accuracy: float
+    hit_rate_1r: float
+    hit_rate_2r: float
+    avg_realized_r: float
+    pattern_precision_ci: tuple[float, float]
+    hit_rate_1r_ci: tuple[float, float]
+
+    def to_row(self) -> dict:
+        return {
+            "bucket": self.bucket,
+            "value": self.value,
+            "samples": self.samples,
+            "pattern_precision": round(self.pattern_precision, 4),
+            "pattern_recall": round(self.pattern_recall, 4),
+            "pattern_f1": round(self.pattern_f1, 4),
+            "side_accuracy": round(self.side_accuracy, 4),
+            "hit_rate_1r": round(self.hit_rate_1r, 4),
+            "hit_rate_2r": round(self.hit_rate_2r, 4),
+            "avg_realized_r": round(self.avg_realized_r, 4),
+            "pattern_precision_ci_lo": round(self.pattern_precision_ci[0], 4),
+            "pattern_precision_ci_hi": round(self.pattern_precision_ci[1], 4),
+            "hit_rate_1r_ci_lo": round(self.hit_rate_1r_ci[0], 4),
+            "hit_rate_1r_ci_hi": round(self.hit_rate_1r_ci[1], 4),
+        }
+
+
+@dataclass
+class EvalReport:
+    """Aggregated output of :meth:`EvalRunner.run`."""
+
+    results: List[SampleResult] = field(default_factory=list)
+    analyst_name: str = "analyst"
+    dataset_size: int = 0
+
+    # ------------------------------------------------------------------
+    # Aggregate metrics
+    # ------------------------------------------------------------------
+
+    def overall(self) -> BucketMetrics:
+        return _bucket_metrics("overall", "all", self.results)
+
+    def bucket_metrics(self, dimension: str) -> List[BucketMetrics]:
+        """Group results by ``dimension`` and compute per-bucket metrics.
+
+        Supported dimensions: ``pattern``, ``regime``, ``htf_aligned``,
+        ``source``.
+        """
+        getter = _DIMENSION_GETTERS.get(dimension)
+        if getter is None:
+            raise ValueError(f"unknown bucket dimension: {dimension!r}")
+        groups: dict[str, List[SampleResult]] = {}
+        for r in self.results:
+            key = str(getter(r))
+            groups.setdefault(key, []).append(r)
+        return [_bucket_metrics(dimension, key, rows) for key, rows in sorted(groups.items())]
+
+    def cost_summary(self) -> dict:
+        if not self.results:
+            return {
+                "samples": 0,
+                "avg_latency_ms": 0.0,
+                "p95_latency_ms": 0.0,
+                "total_input_tokens": 0,
+                "total_output_tokens": 0,
+                "cache_hit_rate": 0.0,
+            }
+        latencies = [r.latency_ms for r in self.results]
+        in_tokens = sum(r.input_tokens for r in self.results)
+        out_tokens = sum(r.output_tokens for r in self.results)
+        cache_eligible = [r for r in self.results if r.input_tokens or r.output_tokens]
+        cache_hits = sum(1 for r in cache_eligible if r.cache_hit)
+        cache_hit_rate = cache_hits / len(cache_eligible) if cache_eligible else 0.0
+        return {
+            "samples": len(self.results),
+            "avg_latency_ms": round(statistics.fmean(latencies), 3),
+            "p95_latency_ms": round(_percentile(latencies, 95), 3),
+            "total_input_tokens": in_tokens,
+            "total_output_tokens": out_tokens,
+            "cache_hit_rate": round(cache_hit_rate, 4),
+        }
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def to_dataframe(self):
+        import pandas as pd
+
+        rows = [r.to_row() for r in self.results]
+        return pd.DataFrame(rows)
+
+    def to_json(self) -> str:
+        payload = {
+            "analyst": self.analyst_name,
+            "dataset_size": self.dataset_size,
+            "overall": self.overall().to_row(),
+            "buckets": {dim: [b.to_row() for b in self.bucket_metrics(dim)] for dim in _DIMENSION_GETTERS},
+            "cost": self.cost_summary(),
+            "rows": [r.to_row() for r in self.results],
+        }
+        return json.dumps(payload, indent=2, default=_json_default)
+
+    def to_html(self, path: Optional[Path | str] = None) -> str:
+        """Render an HTML report. If ``path`` is provided, also writes it."""
+        body_parts: List[str] = []
+        body_parts.append(_render_header(self.analyst_name, self.dataset_size, len(self.results)))
+        body_parts.append(_render_overall(self.overall()))
+        body_parts.append(_render_cost(self.cost_summary()))
+        for dim in _DIMENSION_GETTERS:
+            body_parts.append(_render_bucket_table(dim, self.bucket_metrics(dim)))
+        body_parts.append(_render_sample_table(self.results[:50]))
+        html_doc = _HTML_TEMPLATE.format(
+            title=html.escape(f"Brooks Eval — {self.analyst_name}"),
+            body="\n".join(body_parts),
+        )
+        if path is not None:
+            out = Path(path)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(html_doc, encoding="utf-8")
+        return html_doc
+
+
+# ---------------------------------------------------------------------------
+# Bucketing helpers
+# ---------------------------------------------------------------------------
+
+
+def _dim_pattern(r: SampleResult) -> str:
+    return r.expected_pattern
+
+
+def _dim_regime(r: SampleResult) -> str:
+    return r.regime
+
+
+def _dim_htf(r: SampleResult) -> str:
+    return "aligned" if r.htf_aligned else "unaligned"
+
+
+def _dim_source(r: SampleResult) -> str:
+    return r.source
+
+
+_DIMENSION_GETTERS = {
+    "pattern": _dim_pattern,
+    "regime": _dim_regime,
+    "htf_aligned": _dim_htf,
+    "source": _dim_source,
+}
+
+
+def _bucket_metrics(dimension: str, value: str, rows: List[SampleResult]) -> BucketMetrics:
+    n = len(rows)
+    if n == 0:
+        zero_ci = (0.0, 0.0)
+        return BucketMetrics(
+            bucket=dimension,
+            value=value,
+            samples=0,
+            pattern_precision=0.0,
+            pattern_recall=0.0,
+            pattern_f1=0.0,
+            side_accuracy=0.0,
+            hit_rate_1r=0.0,
+            hit_rate_2r=0.0,
+            avg_realized_r=0.0,
+            pattern_precision_ci=zero_ci,
+            hit_rate_1r_ci=zero_ci,
+        )
+
+    # Pattern-level precision & recall over this bucket.
+    predicted = [r for r in rows if r.predicted_signal is not None]
+    matched = [r for r in rows if r.pattern_match]
+    side_matched = [r for r in rows if r.side_match]
+    precision = len(matched) / len(predicted) if predicted else 0.0
+    recall = len(matched) / n
+    f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) > 0 else 0.0
+    side_accuracy = len(side_matched) / n
+
+    hit_1r_n = sum(1 for r in rows if r.hit_1r == "hit")
+    hit_2r_n = sum(1 for r in rows if r.hit_2r == "hit")
+    resolved_1r = sum(1 for r in rows if r.hit_1r in ("hit", "miss"))
+    resolved_2r = sum(1 for r in rows if r.hit_2r in ("hit", "miss"))
+    hit_rate_1r = hit_1r_n / resolved_1r if resolved_1r else 0.0
+    hit_rate_2r = hit_2r_n / resolved_2r if resolved_2r else 0.0
+
+    realized = [r.realized_r for r in rows if r.realized_r is not None]
+    avg_r = statistics.fmean(realized) if realized else 0.0
+
+    return BucketMetrics(
+        bucket=dimension,
+        value=value,
+        samples=n,
+        pattern_precision=precision,
+        pattern_recall=recall,
+        pattern_f1=f1,
+        side_accuracy=side_accuracy,
+        hit_rate_1r=hit_rate_1r,
+        hit_rate_2r=hit_rate_2r,
+        avg_realized_r=avg_r,
+        pattern_precision_ci=_wilson(len(matched), max(1, len(predicted))),
+        hit_rate_1r_ci=_wilson(hit_1r_n, max(1, resolved_1r)),
+    )
+
+
+def _wilson(successes: int, trials: int, z: float = 1.96) -> tuple[float, float]:
+    """Wilson score interval for a binomial proportion at confidence ``z``."""
+    if trials <= 0:
+        return (0.0, 0.0)
+    p = successes / trials
+    denom = 1 + z * z / trials
+    centre = (p + z * z / (2 * trials)) / denom
+    half = (z * math.sqrt((p * (1 - p) + z * z / (4 * trials)) / trials)) / denom
+    lo = max(0.0, centre - half)
+    hi = min(1.0, centre + half)
+    return (round(lo, 4), round(hi, 4))
+
+
+def _percentile(values: Iterable[float], pct: float) -> float:
+    arr = sorted(values)
+    if not arr:
+        return 0.0
+    if len(arr) == 1:
+        return arr[0]
+    rank = (pct / 100.0) * (len(arr) - 1)
+    lo = int(math.floor(rank))
+    hi = int(math.ceil(rank))
+    if lo == hi:
+        return arr[lo]
+    return arr[lo] + (arr[hi] - arr[lo]) * (rank - lo)
+
+
+def _json_default(o):
+    if isinstance(o, set):
+        return sorted(o)
+    return str(o)
+
+
+# ---------------------------------------------------------------------------
+# HTML rendering
+# ---------------------------------------------------------------------------
+
+
+_HTML_TEMPLATE = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{title}</title>
+<style>
+body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; margin: 24px; color: #1f2933; }}
+h1 {{ font-size: 1.4rem; margin-bottom: 0.2rem; }}
+h2 {{ font-size: 1.1rem; margin-top: 1.5rem; border-bottom: 1px solid #d9e2ec; padding-bottom: 4px; }}
+table {{ border-collapse: collapse; margin: 0.4rem 0 1rem; font-size: 0.85rem; }}
+th, td {{ border: 1px solid #cbd5e0; padding: 4px 8px; text-align: right; }}
+th:first-child, td:first-child {{ text-align: left; }}
+tr:nth-child(even) {{ background: #f7fafc; }}
+.kpi {{ display: inline-block; background: #edf2f7; padding: 6px 10px; margin: 4px 8px 4px 0; border-radius: 4px; font-size: 0.9rem; }}
+.kpi b {{ font-size: 1.05rem; }}
+.muted {{ color: #627d98; font-size: 0.8rem; }}
+</style>
+</head>
+<body>
+{body}
+</body>
+</html>
+"""
+
+
+def _render_header(analyst_name: str, dataset_size: int, sample_count: int) -> str:
+    return (
+        f"<h1>Brooks Eval — {html.escape(analyst_name)}</h1>"
+        f"<p class='muted'>dataset size: {dataset_size} · scored: {sample_count}</p>"
+    )
+
+
+def _render_overall(b: BucketMetrics) -> str:
+    return (
+        "<h2>Overall</h2>"
+        + _kpi("samples", b.samples)
+        + _kpi("pattern P", _pct(b.pattern_precision))
+        + _kpi("pattern R", _pct(b.pattern_recall))
+        + _kpi("pattern F1", _pct(b.pattern_f1))
+        + _kpi("side acc", _pct(b.side_accuracy))
+        + _kpi("hit-1R", _pct(b.hit_rate_1r))
+        + _kpi("hit-2R", _pct(b.hit_rate_2r))
+        + _kpi("avg R", f"{b.avg_realized_r:.2f}")
+    )
+
+
+def _render_cost(cost: dict) -> str:
+    return (
+        "<h2>Cost</h2>"
+        + _kpi("avg latency", f"{cost.get('avg_latency_ms', 0.0):.1f} ms")
+        + _kpi("p95 latency", f"{cost.get('p95_latency_ms', 0.0):.1f} ms")
+        + _kpi("input tokens", cost.get("total_input_tokens", 0))
+        + _kpi("output tokens", cost.get("total_output_tokens", 0))
+        + _kpi("cache hit", _pct(cost.get("cache_hit_rate", 0.0)))
+    )
+
+
+def _render_bucket_table(dimension: str, buckets: List[BucketMetrics]) -> str:
+    headers = [
+        dimension,
+        "n",
+        "P",
+        "R",
+        "F1",
+        "side",
+        "hit-1R",
+        "1R CI",
+        "hit-2R",
+        "avg R",
+    ]
+    rows = []
+    for b in buckets:
+        rows.append(
+            "<tr>"
+            f"<td>{html.escape(b.value)}</td>"
+            f"<td>{b.samples}</td>"
+            f"<td>{_pct(b.pattern_precision)}</td>"
+            f"<td>{_pct(b.pattern_recall)}</td>"
+            f"<td>{_pct(b.pattern_f1)}</td>"
+            f"<td>{_pct(b.side_accuracy)}</td>"
+            f"<td>{_pct(b.hit_rate_1r)}</td>"
+            f"<td>{_pct(b.hit_rate_1r_ci[0])}–{_pct(b.hit_rate_1r_ci[1])}</td>"
+            f"<td>{_pct(b.hit_rate_2r)}</td>"
+            f"<td>{b.avg_realized_r:.2f}</td>"
+            "</tr>"
+        )
+    body = "<thead><tr>" + "".join(f"<th>{h}</th>" for h in headers) + "</tr></thead>"
+    body += "<tbody>" + ("\n".join(rows) or "<tr><td colspan='10'>no data</td></tr>") + "</tbody>"
+    return f"<h2>By {html.escape(dimension)}</h2><table>{body}</table>"
+
+
+def _render_sample_table(rows: List[SampleResult]) -> str:
+    if not rows:
+        return "<h2>Samples</h2><p class='muted'>no samples</p>"
+    headers = ["id", "expect", "predict", "side", "regime", "hit-1R", "realized R", "latency"]
+    body_rows = []
+    for r in rows:
+        pred = f"{r.predicted_signal.pattern}/{r.predicted_signal.side}" if r.predicted_signal else "—"
+        body_rows.append(
+            "<tr>"
+            f"<td>{html.escape(r.sample_id)}</td>"
+            f"<td>{html.escape(r.expected_pattern)}</td>"
+            f"<td>{html.escape(pred)}</td>"
+            f"<td>{html.escape(r.expected_side)}</td>"
+            f"<td>{html.escape(r.regime)}</td>"
+            f"<td>{r.hit_1r}</td>"
+            f"<td>{r.realized_r if r.realized_r is None else f'{r.realized_r:.2f}'}</td>"
+            f"<td>{r.latency_ms:.1f} ms</td>"
+            "</tr>"
+        )
+    body = "<thead><tr>" + "".join(f"<th>{h}</th>" for h in headers) + "</tr></thead>"
+    body += "<tbody>" + "\n".join(body_rows) + "</tbody>"
+    return f"<h2>Samples (first {len(rows)})</h2><table>{body}</table>"
+
+
+def _kpi(label: str, value) -> str:
+    return f"<span class='kpi'>{html.escape(label)} <b>{html.escape(str(value))}</b></span>"
+
+
+def _pct(x: float) -> str:
+    return f"{x * 100:.1f}%"

--- a/src/brooks/eval/runner.py
+++ b/src/brooks/eval/runner.py
@@ -1,0 +1,274 @@
+"""Replay a :class:`GoldenDataset` through an :class:`Analyst`.
+
+The runner is intentionally narrow: per sample it builds a
+:class:`BrooksContext` from the labeled bars, asks the analyst for
+signals, and records the prediction (best matching signal vs. ground
+truth) plus optional Trader's Equation scoring and 1R/2R hit-rate
+checks against the post-target bars.
+
+The output :class:`EvalReport` carries the raw per-sample rows so
+:mod:`src.brooks.eval.report` can render them into HTML or hand them
+off as a :class:`pandas.DataFrame`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, List, Literal, Optional, Sequence
+
+from src.brooks.analyst.base import Analyst
+from src.brooks.context import Bar, BrooksContext, TFSnapshot
+from src.brooks.decision.trader_equation import TraderEquation
+from src.brooks.eval.golden import GoldenDataset, GoldenSample
+from src.brooks.schema import Signal
+
+if TYPE_CHECKING:  # pragma: no cover - type-only import to break cycle
+    from src.brooks.eval.report import EvalReport
+
+__all__ = ["EvalRunner", "SampleResult"]
+
+
+HitFlag = Literal["hit", "miss", "unresolved"]
+
+
+@dataclass
+class SampleResult:
+    """Per-sample evaluation record consumed by :class:`EvalReport`."""
+
+    sample_id: str
+    symbol: str
+    interval: str
+    expected_pattern: str
+    expected_side: str
+    regime: str
+    htf_aligned: bool
+    source: str
+    pattern_match: bool
+    side_match: bool
+    pattern_emitted: List[str] = field(default_factory=list)
+    predicted_signal: Optional[Signal] = None
+    expected_r: Optional[float] = None
+    probability: Optional[float] = None
+    realized_r: Optional[float] = None
+    hit_1r: HitFlag = "unresolved"
+    hit_2r: HitFlag = "unresolved"
+    latency_ms: float = 0.0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_hit: bool = False
+    error: Optional[str] = None
+
+    def to_row(self) -> dict:
+        return {
+            "sample_id": self.sample_id,
+            "symbol": self.symbol,
+            "interval": self.interval,
+            "expected_pattern": self.expected_pattern,
+            "expected_side": self.expected_side,
+            "regime": self.regime,
+            "htf_aligned": bool(self.htf_aligned),
+            "source": self.source,
+            "pattern_emitted": ",".join(self.pattern_emitted),
+            "pattern_match": bool(self.pattern_match),
+            "side_match": bool(self.side_match),
+            "predicted_pattern": self.predicted_signal.pattern if self.predicted_signal else None,
+            "predicted_side": self.predicted_signal.side if self.predicted_signal else None,
+            "predicted_entry": self.predicted_signal.entry_px if self.predicted_signal else None,
+            "predicted_stop": self.predicted_signal.stop_px if self.predicted_signal else None,
+            "expected_r": self.expected_r,
+            "probability": self.probability,
+            "realized_r": self.realized_r,
+            "hit_1r": self.hit_1r,
+            "hit_2r": self.hit_2r,
+            "latency_ms": self.latency_ms,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "cache_hit": bool(self.cache_hit),
+            "error": self.error,
+        }
+
+
+class EvalRunner:
+    """Run an analyst against every sample in a dataset."""
+
+    def __init__(
+        self,
+        analyst: Analyst,
+        dataset: GoldenDataset,
+        te: Optional[TraderEquation] = None,
+        max_concurrent: int = 4,
+    ) -> None:
+        if analyst is None:
+            raise ValueError("EvalRunner requires an analyst")
+        if dataset is None:
+            raise ValueError("EvalRunner requires a dataset")
+        if max_concurrent < 1:
+            raise ValueError("max_concurrent must be >= 1")
+        self._analyst = analyst
+        self._dataset = dataset
+        self._te = te
+        self._max_concurrent = int(max_concurrent)
+
+    @property
+    def analyst(self) -> Analyst:
+        return self._analyst
+
+    @property
+    def dataset(self) -> GoldenDataset:
+        return self._dataset
+
+    async def run(self) -> "EvalReport":
+        """Score every sample. Returns a populated :class:`EvalReport`."""
+        from src.brooks.eval.report import EvalReport  # local import avoids cycle
+
+        sem = asyncio.Semaphore(self._max_concurrent)
+
+        async def _score(sample: GoldenSample) -> SampleResult:
+            async with sem:
+                return await _score_sample(sample, self._analyst, self._te)
+
+        results = await asyncio.gather(*[_score(s) for s in self._dataset])
+        return EvalReport(
+            results=list(results),
+            analyst_name=getattr(self._analyst, "name", "analyst"),
+            dataset_size=len(self._dataset),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Per-sample scoring
+# ---------------------------------------------------------------------------
+
+
+async def _score_sample(
+    sample: GoldenSample,
+    analyst: Analyst,
+    te: Optional[TraderEquation],
+) -> SampleResult:
+    ctx_bars = sample.context_bars
+    ctx = BrooksContext(
+        symbol=sample.symbol,
+        primary=TFSnapshot(interval=sample.interval, bars=ctx_bars),
+    )
+    started = time.perf_counter()
+    error: Optional[str] = None
+    signals: List[Signal] = []
+    try:
+        signals = list(await analyst.analyze(ctx))
+    except Exception as exc:  # pragma: no cover - propagated via SampleResult.error
+        error = f"{type(exc).__name__}: {exc}"
+    latency = (time.perf_counter() - started) * 1000.0
+
+    predicted = _pick_signal(signals, sample)
+    pattern_match = predicted is not None and predicted.pattern == sample.expected_pattern
+    side_match = predicted is not None and predicted.side == sample.expected_side
+
+    result = SampleResult(
+        sample_id=sample.id,
+        symbol=sample.symbol,
+        interval=sample.interval,
+        expected_pattern=sample.expected_pattern,
+        expected_side=sample.expected_side,
+        regime=sample.regime,
+        htf_aligned=sample.htf_aligned,
+        source=sample.source,
+        pattern_match=pattern_match,
+        side_match=side_match,
+        pattern_emitted=sorted({s.pattern for s in signals}),
+        predicted_signal=predicted,
+        latency_ms=latency,
+        error=error,
+    )
+
+    if predicted is not None:
+        meta = predicted.meta or {}
+        result.input_tokens = int(meta.get("input_tokens", 0) or 0)
+        result.output_tokens = int(meta.get("output_tokens", 0) or 0)
+        result.cache_hit = bool(meta.get("cache_hit", False))
+
+    if te is not None and predicted is not None:
+        prob, expected_r = te.score(
+            predicted,
+            regime=sample.regime,
+            htf_aligned=sample.htf_aligned,
+        )
+        result.probability = float(prob)
+        result.expected_r = float(expected_r)
+
+    if predicted is not None:
+        realized, hit_1r, hit_2r = _realized_r(predicted, sample.future_bars)
+        result.realized_r = realized
+        result.hit_1r = hit_1r
+        result.hit_2r = hit_2r
+
+    return result
+
+
+def _pick_signal(signals: Sequence[Signal], sample: GoldenSample) -> Optional[Signal]:
+    """Pick the signal that best matches the ground truth.
+
+    Preference order: exact ``(pattern, side)`` match → same side →
+    first emitted signal.
+    """
+    if not signals:
+        return None
+    for s in signals:
+        if s.pattern == sample.expected_pattern and s.side == sample.expected_side:
+            return s
+    for s in signals:
+        if s.side == sample.expected_side:
+            return s
+    return signals[0]
+
+
+def _realized_r(
+    signal: Signal,
+    future_bars: Sequence[Bar],
+) -> tuple[Optional[float], HitFlag, HitFlag]:
+    """Walk forward and return (realized_R, hit_1r, hit_2r).
+
+    The simulation is intentionally minimal: we walk forward bar-by-bar
+    flagging whether 1R / 2R were touched in either direction. The
+    realized R is determined by the first decisive event (stop or 2R
+    target). If neither is reached within the window, we report the
+    final mark-to-market vs entry as the realized R and resolve the hit
+    flags as ``"miss"`` (we observed enough bars to know the signal did
+    not work out within the window).
+    """
+    if not future_bars:
+        return None, "unresolved", "unresolved"
+
+    one_r = abs(signal.entry_px - signal.stop_px)
+    if one_r <= 0:
+        return None, "unresolved", "unresolved"
+
+    side = signal.side
+    entry = signal.entry_px
+    stop = signal.stop_px
+    target_1r = entry + (one_r if side == "long" else -one_r)
+    target_2r = entry + (2 * one_r if side == "long" else -2 * one_r)
+
+    hit_1r: HitFlag = "miss"
+    hit_2r: HitFlag = "miss"
+
+    for bar in future_bars:
+        hit_stop = bar.low <= stop if side == "long" else bar.high >= stop
+        hit_2r_now = bar.high >= target_2r if side == "long" else bar.low <= target_2r
+        hit_1r_now = bar.high >= target_1r if side == "long" else bar.low <= target_1r
+
+        if hit_1r_now:
+            hit_1r = "hit"
+        if hit_2r_now:
+            hit_1r = "hit"
+            hit_2r = "hit"
+            realized = 2.0
+            return realized, hit_1r, hit_2r
+        if hit_stop:
+            realized = -1.0
+            return realized, hit_1r, hit_2r
+
+    last_close = future_bars[-1].close
+    realized = (last_close - entry) / one_r if side == "long" else (entry - last_close) / one_r
+    return realized, hit_1r, hit_2r

--- a/tests/brooks/test_eval_auto_label.py
+++ b/tests/brooks/test_eval_auto_label.py
@@ -1,0 +1,257 @@
+"""Tests for :class:`AutoLabeler`.
+
+The auto-labeler couples a deterministic rule analyst with stochastic LLM
+analysts and emits silver samples via majority vote. We replace both
+sides with controllable :class:`MockAnalyst` instances so the tests can
+assert the consensus mechanics without spinning up real detectors or
+networking.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import List
+
+import pytest
+
+from src.brooks.context import Bar, BrooksContext
+from src.brooks.eval.auto_label import AutoLabeler
+from src.brooks.schema import Signal
+
+# ---------------------------------------------------------------------------
+# Test analyst implementation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MockAnalyst:
+    """Programmable analyst used by the auto-label tests."""
+
+    name: str
+    fire_at_indices: dict = field(default_factory=dict)
+    calls: list = field(default_factory=list)
+
+    async def analyze(self, ctx: BrooksContext) -> List[Signal]:
+        idx = len(ctx.primary.bars) - 1
+        self.calls.append(idx)
+        spec = self.fire_at_indices.get(idx)
+        if spec is None:
+            return []
+        return [
+            Signal(
+                pattern=spec["pattern"],
+                side=spec["side"],
+                signal_bar_idx=idx,
+                entry_px=spec["entry"],
+                stop_px=spec["stop"],
+                target_px=spec.get("target"),
+                probability=spec.get("probability", 0.5),
+                quality=spec.get("quality", 0.5),
+                reasoning=spec.get("reasoning", f"{self.name}@{idx}"),
+                source=f"mock:{self.name}",
+            )
+        ]
+
+
+def _bars(n: int = 30, base: float = 100.0) -> List[Bar]:
+    return [
+        Bar(
+            timestamp_ns=1_700_000_000_000_000_000 + i * 60_000_000_000,
+            open=base + i,
+            high=base + i + 1,
+            low=base + i - 0.5,
+            close=base + i + 0.5,
+            volume=1.0,
+        )
+        for i in range(n)
+    ]
+
+
+def _setup(idx: int, **overrides) -> dict:
+    base = dict(pattern="h2", side="long", entry=110.0, stop=109.0, target=112.0)
+    base.update(overrides)
+    return base
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Construction validation
+# ---------------------------------------------------------------------------
+
+
+def test_requires_rule_analyst():
+    with pytest.raises(ValueError):
+        AutoLabeler(rule_analyst=None)  # type: ignore[arg-type]
+
+
+def test_min_agreement_lower_bound():
+    with pytest.raises(ValueError):
+        AutoLabeler(rule_analyst=MockAnalyst(name="rule"), min_agreement=0)
+
+
+# ---------------------------------------------------------------------------
+# Consensus mechanics
+# ---------------------------------------------------------------------------
+
+
+def test_two_of_three_agreement_emits_silver_sample():
+    rule = MockAnalyst(name="rule", fire_at_indices={25: _setup(25)})
+    llm_a = MockAnalyst(name="llm_a", fire_at_indices={25: _setup(25)})
+    llm_b = MockAnalyst(name="llm_b", fire_at_indices={25: _setup(25, side="short", entry=99.0, stop=100.0)})
+
+    labeler = AutoLabeler(
+        rule_analyst=rule,
+        llm_analysts=[llm_a, llm_b],
+        min_agreement=2,
+        min_bars_for_label=20,
+    )
+    samples = _run(labeler.label(bars=_bars(28), symbol="BTC", interval="5m"))
+
+    # Only the (h2, long) bucket has 2 voters; the lone short bucket is dropped.
+    assert len(samples) == 1
+    sample = samples[0]
+    assert sample.expected_pattern == "h2"
+    assert sample.expected_side == "long"
+    assert sample.target_bar_idx == 25
+    assert sample.source == "silver"
+    assert sample.meta["agreement"] == 2
+    assert "rule" in sample.meta["voters"]
+    assert "llm_a" in sample.meta["voters"]
+
+
+def test_below_min_agreement_emits_nothing():
+    rule = MockAnalyst(name="rule", fire_at_indices={25: _setup(25)})
+    llm_a = MockAnalyst(name="llm_a")  # silent
+    llm_b = MockAnalyst(name="llm_b")  # silent
+    labeler = AutoLabeler(
+        rule_analyst=rule,
+        llm_analysts=[llm_a, llm_b],
+        min_agreement=2,
+        min_bars_for_label=20,
+    )
+    samples = _run(labeler.label(bars=_bars(28), symbol="BTC", interval="5m"))
+    assert samples == []
+
+
+def test_min_agreement_one_emits_rule_only():
+    rule = MockAnalyst(name="rule", fire_at_indices={25: _setup(25)})
+    labeler = AutoLabeler(
+        rule_analyst=rule,
+        llm_analysts=[],
+        min_agreement=1,
+        min_bars_for_label=20,
+    )
+    samples = _run(labeler.label(bars=_bars(28), symbol="BTC", interval="5m"))
+    assert len(samples) == 1
+    assert samples[0].meta["agreement"] == 1
+
+
+def test_entry_tolerance_rejects_wide_spreads():
+    """Two analysts agree on (h2, long) but with very different entries → reject."""
+    rule = MockAnalyst(name="rule", fire_at_indices={25: _setup(25, entry=100.0, stop=99.0)})
+    llm_a = MockAnalyst(name="llm_a", fire_at_indices={25: _setup(25, entry=120.0, stop=119.0)})
+    labeler = AutoLabeler(
+        rule_analyst=rule,
+        llm_analysts=[llm_a],
+        min_agreement=2,
+        entry_tolerance=0.01,
+        min_bars_for_label=20,
+    )
+    samples = _run(labeler.label(bars=_bars(28), symbol="BTC", interval="5m"))
+    assert samples == []
+
+
+def test_entry_tolerance_zero_allows_any_spread():
+    rule = MockAnalyst(name="rule", fire_at_indices={25: _setup(25, entry=100.0, stop=99.0)})
+    llm_a = MockAnalyst(name="llm_a", fire_at_indices={25: _setup(25, entry=120.0, stop=119.0)})
+    labeler = AutoLabeler(
+        rule_analyst=rule,
+        llm_analysts=[llm_a],
+        min_agreement=2,
+        entry_tolerance=0.0,
+        min_bars_for_label=20,
+    )
+    samples = _run(labeler.label(bars=_bars(28), symbol="BTC", interval="5m"))
+    assert len(samples) == 1
+
+
+def test_skips_bars_before_warmup():
+    rule = MockAnalyst(name="rule", fire_at_indices={i: _setup(i) for i in range(0, 10)})
+    labeler = AutoLabeler(
+        rule_analyst=rule,
+        llm_analysts=[],
+        min_agreement=1,
+        min_bars_for_label=20,
+    )
+    samples = _run(labeler.label(bars=_bars(15), symbol="BTC", interval="5m"))
+    assert samples == []
+    # The labeler must not even invoke the analyst before the warmup boundary.
+    assert rule.calls == []
+
+
+def test_strongest_bucket_wins_when_multiple_agree():
+    """When two distinct (pattern, side) groups both reach the threshold,
+    the larger group is chosen for the silver sample."""
+    setup_long = _setup(25, pattern="h2", side="long", entry=110.0, stop=109.0)
+    setup_short = _setup(25, pattern="l2", side="short", entry=109.0, stop=110.0)
+
+    rule = MockAnalyst(name="rule", fire_at_indices={25: setup_long})
+    a = MockAnalyst(name="a", fire_at_indices={25: setup_long})
+    b = MockAnalyst(name="b", fire_at_indices={25: setup_long})
+    c = MockAnalyst(name="c", fire_at_indices={25: setup_short})
+    d = MockAnalyst(name="d", fire_at_indices={25: setup_short})
+
+    labeler = AutoLabeler(
+        rule_analyst=rule,
+        llm_analysts=[a, b, c, d],
+        min_agreement=2,
+        min_bars_for_label=20,
+    )
+    samples = _run(labeler.label(bars=_bars(28), symbol="BTC", interval="5m"))
+    assert len(samples) == 1
+    # The 3-vote (h2, long) bucket beats the 2-vote (l2, short) bucket.
+    assert samples[0].expected_pattern == "h2"
+    assert samples[0].meta["agreement"] == 3
+
+
+def test_consensus_uses_median_entry_and_stop():
+    rule = MockAnalyst(name="rule", fire_at_indices={25: _setup(25, entry=100.0, stop=99.0)})
+    a = MockAnalyst(name="a", fire_at_indices={25: _setup(25, entry=100.4, stop=99.2)})
+    b = MockAnalyst(name="b", fire_at_indices={25: _setup(25, entry=100.2, stop=99.1)})
+    labeler = AutoLabeler(
+        rule_analyst=rule,
+        llm_analysts=[a, b],
+        min_agreement=2,
+        entry_tolerance=0.05,
+        min_bars_for_label=20,
+    )
+    samples = _run(labeler.label(bars=_bars(28), symbol="BTC", interval="5m"))
+    assert len(samples) == 1
+    s = samples[0]
+    assert s.expected_entry == pytest.approx(100.2)
+    assert s.expected_stop == pytest.approx(99.1)
+
+
+def test_regime_is_populated_from_classifier():
+    rule = MockAnalyst(name="rule", fire_at_indices={25: _setup(25)})
+    a = MockAnalyst(name="a", fire_at_indices={25: _setup(25)})
+    labeler = AutoLabeler(
+        rule_analyst=rule,
+        llm_analysts=[a],
+        min_agreement=2,
+        min_bars_for_label=20,
+    )
+    samples = _run(labeler.label(bars=_bars(28), symbol="BTC", interval="5m"))
+    assert len(samples) == 1
+    # The synthetic strictly-up bars resolve to one of the bull regimes.
+    assert "bull" in samples[0].regime or samples[0].regime in {
+        "breakout_mode",
+        "climax",
+        "weak_bull_trend",
+        "strong_bull_trend",
+        "unknown",
+    }

--- a/tests/brooks/test_eval_golden.py
+++ b/tests/brooks/test_eval_golden.py
@@ -1,0 +1,210 @@
+"""Tests for :mod:`src.brooks.eval.golden`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from src.brooks.context import Bar
+from src.brooks.eval.golden import GoldenDataset, GoldenSample
+
+
+def _bars(n: int, base: float = 100.0) -> List[Bar]:
+    out = []
+    for i in range(n):
+        c = base + i
+        out.append(
+            Bar(
+                timestamp_ns=1_700_000_000_000_000_000 + i * 60_000_000_000,
+                open=c - 0.5,
+                high=c + 0.5,
+                low=c - 0.6,
+                close=c,
+                volume=1.0,
+            )
+        )
+    return out
+
+
+def _sample(idx: int = 5, **overrides) -> GoldenSample:
+    base = dict(
+        id=f"sample-{idx}",
+        symbol="BTCUSDT",
+        interval="5m",
+        bars=_bars(10),
+        target_bar_idx=idx,
+        expected_pattern="h2",
+        expected_side="long",
+        expected_entry=110.0,
+        expected_stop=109.0,
+        expected_target=112.0,
+        regime="weak_bull_trend",
+        htf_aligned=True,
+        source="human",
+        reasoning="leg-1 / leg-2 setup",
+    )
+    base.update(overrides)
+    return GoldenSample(**base)
+
+
+# ---------------------------------------------------------------------------
+# GoldenSample
+# ---------------------------------------------------------------------------
+
+
+def test_sample_round_trip_dict():
+    s = _sample()
+    raw = s.to_dict()
+    rebuilt = GoldenSample.from_dict(raw)
+    assert rebuilt.id == s.id
+    assert rebuilt.bars[0].close == s.bars[0].close
+    assert rebuilt.expected_target == s.expected_target
+
+
+def test_sample_validates_target_idx():
+    with pytest.raises(ValueError):
+        _sample(target_bar_idx=99)
+
+
+def test_sample_validates_entry_neq_stop():
+    with pytest.raises(ValueError):
+        _sample(expected_entry=100.0, expected_stop=100.0)
+
+
+def test_sample_validates_side():
+    with pytest.raises(ValueError):
+        _sample(expected_side="upward")  # type: ignore[arg-type]
+
+
+def test_sample_context_and_future_split():
+    s = _sample(idx=4)
+    assert len(s.context_bars) == 5
+    assert len(s.future_bars) == 5
+    assert s.context_bars[-1] == s.bars[4]
+    assert s.future_bars[0] == s.bars[5]
+
+
+def test_sample_one_r():
+    s = _sample(expected_entry=110.0, expected_stop=109.5)
+    assert s.one_r == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# GoldenDataset persistence
+# ---------------------------------------------------------------------------
+
+
+def test_dataset_roundtrip_jsonl(tmp_path: Path):
+    ds = GoldenDataset.from_samples(
+        [_sample(idx=4), _sample(idx=5, expected_side="short", expected_entry=99.0, expected_stop=100.0)]
+    )
+    path = tmp_path / "ds.jsonl"
+    ds.save(path)
+    reloaded = GoldenDataset.load(path)
+    assert len(reloaded) == 2
+    assert reloaded[1].expected_side == "short"
+    assert reloaded[0].bars[-1].timestamp_ns == ds[0].bars[-1].timestamp_ns
+
+
+def test_dataset_roundtrip_parquet(tmp_path: Path):
+    pytest.importorskip("pyarrow")
+    ds = GoldenDataset.from_samples([_sample(idx=4), _sample(idx=5)])
+    path = tmp_path / "ds.parquet"
+    ds.save(path)
+    reloaded = GoldenDataset.load(path)
+    assert len(reloaded) == 2
+    assert reloaded[0].expected_pattern == "h2"
+    assert reloaded[0].bars[3].open == ds[0].bars[3].open
+
+
+def test_dataset_roundtrip_directory(tmp_path: Path):
+    GoldenDataset.from_samples([_sample(idx=4)]).save(tmp_path / "a.jsonl")
+    GoldenDataset.from_samples(
+        [_sample(idx=5, expected_pattern="l2", expected_side="short", expected_entry=99.0, expected_stop=100.0)]
+    ).save(tmp_path / "b.jsonl")
+    loaded = GoldenDataset.load(tmp_path)
+    assert len(loaded) == 2
+    patterns = {s.expected_pattern for s in loaded}
+    assert patterns == {"h2", "l2"}
+
+
+def test_dataset_save_unsupported_suffix(tmp_path: Path):
+    ds = GoldenDataset.from_samples([_sample()])
+    with pytest.raises(ValueError):
+        ds.save(tmp_path / "ds.csv")
+
+
+def test_dataset_load_missing_path(tmp_path: Path):
+    with pytest.raises(FileNotFoundError):
+        GoldenDataset.load(tmp_path / "missing.jsonl")
+
+
+def test_dataset_load_empty_directory(tmp_path: Path):
+    assert len(GoldenDataset.load(tmp_path)) == 0
+
+
+# ---------------------------------------------------------------------------
+# Filter
+# ---------------------------------------------------------------------------
+
+
+def test_filter_by_value():
+    ds = GoldenDataset.from_samples(
+        [
+            _sample(idx=4, expected_pattern="h2"),
+            _sample(idx=5, expected_pattern="l2", expected_side="short", expected_entry=99.0, expected_stop=100.0),
+            _sample(idx=6, expected_pattern="h2"),
+        ]
+    )
+    h2 = ds.filter(expected_pattern="h2")
+    assert len(h2) == 2
+    assert all(s.expected_pattern == "h2" for s in h2)
+
+
+def test_filter_by_membership():
+    ds = GoldenDataset.from_samples(
+        [
+            _sample(idx=4, regime="weak_bull_trend"),
+            _sample(idx=5, regime="strong_bull_trend"),
+            _sample(idx=6, regime="tight_trading_range"),
+        ]
+    )
+    bulls = ds.filter(regime={"weak_bull_trend", "strong_bull_trend"})
+    assert len(bulls) == 2
+
+
+def test_filter_unknown_attr_raises():
+    ds = GoldenDataset.from_samples([_sample()])
+    with pytest.raises(AttributeError):
+        ds.filter(does_not_exist="x")
+
+
+def test_iteration_and_indexing():
+    samples = [_sample(idx=i + 1) for i in range(3)]
+    ds = GoldenDataset.from_samples(samples)
+    assert list(ds) == samples
+    assert ds[1] == samples[1]
+    assert len(ds) == 3
+
+
+# ---------------------------------------------------------------------------
+# Manual JSON ingestion
+# ---------------------------------------------------------------------------
+
+
+def test_load_json_array_file(tmp_path: Path):
+    path = tmp_path / "ds.json"
+    payload = [_sample(idx=2).to_dict(), _sample(idx=3).to_dict()]
+    path.write_text(json.dumps(payload))
+    loaded = GoldenDataset.load(path)
+    assert len(loaded) == 2
+
+
+def test_load_json_single_object(tmp_path: Path):
+    path = tmp_path / "ds.json"
+    path.write_text(json.dumps(_sample(idx=2).to_dict()))
+    loaded = GoldenDataset.load(path)
+    assert len(loaded) == 1

--- a/tests/brooks/test_eval_report.py
+++ b/tests/brooks/test_eval_report.py
@@ -1,0 +1,298 @@
+"""Tests for :class:`EvalReport` — bucketing, Wilson CI, and HTML
+serialisation. Includes the spec acceptance test that wires
+:class:`RuleAnalyst` end-to-end against a 30-sample mock dataset.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from src.brooks.analyst import AnalystRegistry
+from src.brooks.context import Bar
+from src.brooks.eval.golden import GoldenDataset, GoldenSample
+from src.brooks.eval.report import EvalReport, _wilson
+from src.brooks.eval.runner import EvalRunner, SampleResult
+from src.brooks.schema import Signal
+
+# ---------------------------------------------------------------------------
+# SampleResult fixtures
+# ---------------------------------------------------------------------------
+
+
+def _result(
+    *,
+    sample_id: str = "s",
+    pattern: str = "h2",
+    side: str = "long",
+    regime: str = "weak_bull_trend",
+    htf_aligned: bool = True,
+    source: str = "human",
+    pattern_match: bool = True,
+    side_match: bool = True,
+    realized_r: float = 1.0,
+    hit_1r: str = "hit",
+    hit_2r: str = "miss",
+    predicted: bool = True,
+    latency_ms: float = 12.0,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_hit: bool = False,
+) -> SampleResult:
+    sig = (
+        Signal(
+            pattern=pattern,
+            side=side,  # type: ignore[arg-type]
+            signal_bar_idx=4,
+            entry_px=100.0,
+            stop_px=99.0,
+            target_px=102.0,
+            probability=0.55,
+            quality=0.6,
+            source=f"rule:{pattern}",
+        )
+        if predicted
+        else None
+    )
+    return SampleResult(
+        sample_id=sample_id,
+        symbol="BTC",
+        interval="5m",
+        expected_pattern=pattern,
+        expected_side=side,
+        regime=regime,
+        htf_aligned=htf_aligned,
+        source=source,
+        pattern_match=pattern_match,
+        side_match=side_match,
+        pattern_emitted=[pattern] if predicted else [],
+        predicted_signal=sig,
+        realized_r=realized_r,
+        hit_1r=hit_1r,
+        hit_2r=hit_2r,
+        latency_ms=latency_ms,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_hit=cache_hit,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Wilson interval
+# ---------------------------------------------------------------------------
+
+
+def test_wilson_centered_around_proportion():
+    lo, hi = _wilson(50, 100)
+    assert 0.39 < lo < 0.41
+    assert 0.59 < hi < 0.61
+
+
+def test_wilson_zero_trials_returns_zero_interval():
+    assert _wilson(0, 0) == (0.0, 0.0)
+
+
+def test_wilson_perfect_score_caps_at_one():
+    lo, hi = _wilson(10, 10)
+    assert hi == 1.0
+    assert lo > 0.5
+
+
+# ---------------------------------------------------------------------------
+# Bucket metrics
+# ---------------------------------------------------------------------------
+
+
+def test_overall_metrics_blend_pattern_and_hit_rate():
+    rows = [
+        _result(sample_id="a", pattern_match=True, hit_1r="hit", hit_2r="miss", realized_r=1.0),
+        _result(sample_id="b", pattern_match=False, hit_1r="miss", hit_2r="miss", realized_r=-1.0),
+        _result(sample_id="c", pattern_match=True, hit_1r="hit", hit_2r="hit", realized_r=2.0),
+        _result(sample_id="d", pattern_match=True, hit_1r="hit", hit_2r="hit", realized_r=2.0),
+    ]
+    report = EvalReport(results=rows, dataset_size=4, analyst_name="test")
+    overall = report.overall()
+    assert overall.samples == 4
+    assert overall.pattern_precision == 0.75
+    assert overall.pattern_recall == 0.75
+    assert overall.hit_rate_1r == 0.75
+    assert overall.hit_rate_2r == 0.5
+    assert overall.avg_realized_r == pytest.approx(1.0)
+
+
+def test_bucket_by_pattern_groups_correctly():
+    rows = [
+        _result(sample_id="a", pattern="h2"),
+        _result(sample_id="b", pattern="h2"),
+        _result(sample_id="c", pattern="l2", side="short", side_match=True),
+    ]
+    buckets = EvalReport(results=rows).bucket_metrics("pattern")
+    keys = [b.value for b in buckets]
+    assert keys == ["h2", "l2"]
+
+
+def test_bucket_by_htf_alignment():
+    rows = [
+        _result(sample_id="a", htf_aligned=True),
+        _result(sample_id="b", htf_aligned=False),
+        _result(sample_id="c", htf_aligned=False),
+    ]
+    by_htf = {b.value: b for b in EvalReport(results=rows).bucket_metrics("htf_aligned")}
+    assert by_htf["aligned"].samples == 1
+    assert by_htf["unaligned"].samples == 2
+
+
+def test_bucket_by_source():
+    rows = [
+        _result(sample_id="a", source="human"),
+        _result(sample_id="b", source="silver"),
+    ]
+    by_source = {b.value: b for b in EvalReport(results=rows).bucket_metrics("source")}
+    assert by_source["human"].samples == 1
+    assert by_source["silver"].samples == 1
+
+
+def test_bucket_unknown_dimension_raises():
+    with pytest.raises(ValueError):
+        EvalReport(results=[_result()]).bucket_metrics("nonsense")
+
+
+def test_buckets_include_confidence_intervals():
+    rows = [_result(sample_id=f"r{i}", hit_1r="hit") for i in range(5)] + [
+        _result(sample_id=f"m{i}", hit_1r="miss") for i in range(5)
+    ]
+    overall = EvalReport(results=rows).overall()
+    lo, hi = overall.hit_rate_1r_ci
+    assert lo < 0.5 < hi
+    assert lo >= 0.0 and hi <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Cost summary
+# ---------------------------------------------------------------------------
+
+
+def test_cost_summary_aggregates_tokens_and_cache():
+    rows = [
+        _result(sample_id="a", latency_ms=10.0, input_tokens=100, output_tokens=20, cache_hit=True),
+        _result(sample_id="b", latency_ms=30.0, input_tokens=80, output_tokens=15, cache_hit=False),
+        _result(sample_id="c", latency_ms=20.0),  # no LLM tokens
+    ]
+    cost = EvalReport(results=rows).cost_summary()
+    assert cost["samples"] == 3
+    assert cost["total_input_tokens"] == 180
+    assert cost["total_output_tokens"] == 35
+    # Two rows had token usage; one was a cache hit → 0.5
+    assert cost["cache_hit_rate"] == 0.5
+
+
+def test_cost_summary_empty():
+    cost = EvalReport(results=[]).cost_summary()
+    assert cost["samples"] == 0
+    assert cost["cache_hit_rate"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Serialisation
+# ---------------------------------------------------------------------------
+
+
+def test_to_dataframe_has_one_row_per_result():
+    rows = [_result(sample_id=f"r{i}") for i in range(3)]
+    df = EvalReport(results=rows).to_dataframe()
+    assert len(df) == 3
+    assert {"pattern_match", "side_match", "realized_r"}.issubset(set(df.columns))
+
+
+def test_to_html_writes_self_contained_document(tmp_path: Path):
+    rows = [_result(sample_id=f"r{i}") for i in range(3)]
+    out = tmp_path / "report.html"
+    EvalReport(results=rows, dataset_size=3, analyst_name="rule").to_html(out)
+    assert out.exists()
+    body = out.read_text(encoding="utf-8")
+    assert "<!doctype html>" in body
+    assert "Brooks Eval" in body
+    # Each bucket dimension must produce a <table> and the headline KPIs are present.
+    assert body.count("<table>") >= 4
+    assert "pattern P" in body
+    assert "hit-1R" in body
+
+
+def test_to_json_includes_buckets_and_rows():
+    import json as _json
+
+    rows = [_result(sample_id=f"r{i}") for i in range(2)]
+    payload = _json.loads(EvalReport(results=rows, dataset_size=2, analyst_name="rule").to_json())
+    assert set(payload["buckets"]) == {"pattern", "regime", "htf_aligned", "source"}
+    assert payload["overall"]["samples"] == 2
+    assert len(payload["rows"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Spec acceptance — RuleAnalyst on a 30-sample dataset
+# ---------------------------------------------------------------------------
+
+
+def _bar(i: int, base: float, future: List[Bar] = None) -> Bar:
+    return Bar(
+        timestamp_ns=1_700_000_000_000_000_000 + i * 60_000_000_000,
+        open=base,
+        high=base + 0.1,
+        low=base - 0.1,
+        close=base,
+        volume=1.0,
+    )
+
+
+def _build_30_sample_fixture() -> GoldenDataset:
+    """Build a 30-sample dataset of mostly-flat bars labeled with synthetic
+    expected setups. The rule analyst will not match these (no real
+    Brooks setup is in the bars) so this test exercises the runner +
+    report plumbing rather than detector accuracy."""
+    samples = []
+    for i in range(30):
+        bars = [_bar(j, 100.0 + 0.01 * j) for j in range(40)]
+        samples.append(
+            GoldenSample(
+                id=f"silver-{i}",
+                symbol=f"SYM{i % 3}",
+                interval="5m",
+                bars=bars,
+                target_bar_idx=29,
+                expected_pattern=("h2" if i % 2 == 0 else "l2"),
+                expected_side=("long" if i % 2 == 0 else "short"),
+                expected_entry=100.5,
+                expected_stop=99.5 if i % 2 == 0 else 101.5,
+                expected_target=102.0 if i % 2 == 0 else 98.0,
+                regime=("weak_bull_trend" if i % 2 == 0 else "weak_bear_trend"),
+                htf_aligned=(i % 3 == 0),
+                source=("human" if i < 5 else "silver"),
+            )
+        )
+    return GoldenDataset.from_samples(samples)
+
+
+def test_acceptance_rule_analyst_produces_html_report(tmp_path: Path):
+    dataset = _build_30_sample_fixture()
+    runner = EvalRunner(analyst=AnalystRegistry.build("rule"), dataset=dataset)
+    report = asyncio.run(runner.run())
+
+    assert report.dataset_size == 30
+    assert len(report.results) == 30
+
+    out = tmp_path / "rule_report.html"
+    body = report.to_html(out)
+    assert out.exists()
+    assert "<!doctype html>" in body
+    # Bucket dimensions all rendered.
+    assert "By pattern" in body
+    assert "By regime" in body
+    assert "By htf_aligned" in body
+    assert "By source" in body
+
+    # DataFrame round-trip works.
+    df = report.to_dataframe()
+    assert len(df) == 30

--- a/tests/brooks/test_eval_runner.py
+++ b/tests/brooks/test_eval_runner.py
@@ -1,0 +1,274 @@
+"""Tests for :class:`EvalRunner` — pattern matching, hit-rate scoring,
+and Trader's-Equation integration."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import List
+
+import pandas as pd
+import pytest
+
+from src.brooks.context import Bar, BrooksContext
+from src.brooks.decision.hit_rate import HitRateTable
+from src.brooks.decision.trader_equation import TraderEquation
+from src.brooks.eval.golden import GoldenDataset, GoldenSample
+from src.brooks.eval.runner import EvalRunner, _realized_r
+from src.brooks.schema import Signal
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _bar(i: int, o: float, h: float, l: float, c: float) -> Bar:
+    return Bar(
+        timestamp_ns=1_700_000_000_000_000_000 + i * 60_000_000_000,
+        open=o,
+        high=h,
+        low=l,
+        close=c,
+        volume=1.0,
+    )
+
+
+def _flat_bars(n: int = 10, base: float = 100.0) -> List[Bar]:
+    return [_bar(i, base, base + 0.1, base - 0.1, base) for i in range(n)]
+
+
+def _sample_with_future(
+    *,
+    sample_id: str = "s",
+    symbol: str = "BTC",
+    expected_pattern: str = "h2",
+    expected_side: str = "long",
+    entry: float = 100.0,
+    stop: float = 99.0,
+    target: float = 102.0,
+    future: List[Bar] = None,
+    regime: str = "weak_bull_trend",
+    htf_aligned: bool = True,
+    source: str = "human",
+) -> GoldenSample:
+    if future is None:
+        future = []
+    bars = _flat_bars(5) + future
+    return GoldenSample(
+        id=sample_id,
+        symbol=symbol,
+        interval="5m",
+        bars=bars,
+        target_bar_idx=4,
+        expected_pattern=expected_pattern,
+        expected_side=expected_side,  # type: ignore[arg-type]
+        expected_entry=entry,
+        expected_stop=stop,
+        expected_target=target,
+        regime=regime,
+        htf_aligned=htf_aligned,
+        source=source,
+    )
+
+
+@dataclass
+class FixedAnalyst:
+    """Analyst that returns a fixed signal list keyed by ``sample_id``."""
+
+    name: str = "fixed"
+    by_id: dict = field(default_factory=dict)
+
+    async def analyze(self, ctx: BrooksContext) -> List[Signal]:
+        return list(self.by_id.get(ctx.symbol, []))
+
+
+def _sig(
+    pattern: str = "h2",
+    side: str = "long",
+    entry: float = 100.0,
+    stop: float = 99.0,
+    target: float = 102.0,
+) -> Signal:
+    return Signal(
+        pattern=pattern,
+        side=side,  # type: ignore[arg-type]
+        signal_bar_idx=4,
+        entry_px=entry,
+        stop_px=stop,
+        target_px=target,
+        probability=0.55,
+        quality=0.6,
+        source=f"rule:{pattern}",
+    )
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Pattern / side matching
+# ---------------------------------------------------------------------------
+
+
+def test_runner_pattern_match_picks_exact_signal():
+    sample = _sample_with_future(sample_id="ok", symbol="ok")
+    analyst = FixedAnalyst(by_id={"ok": [_sig(pattern="l2", side="short", entry=100.0, stop=101.0), _sig()]})
+    ds = GoldenDataset.from_samples([sample])
+    report = _run(EvalRunner(analyst=analyst, dataset=ds).run())
+    assert len(report.results) == 1
+    r = report.results[0]
+    assert r.pattern_match is True
+    assert r.side_match is True
+    assert r.predicted_signal.pattern == "h2"
+    assert "h2" in r.pattern_emitted
+    assert "l2" in r.pattern_emitted
+
+
+def test_runner_pattern_miss_when_only_other_pattern_emits():
+    sample = _sample_with_future(sample_id="miss", symbol="miss")
+    analyst = FixedAnalyst(by_id={"miss": [_sig(pattern="wedge")]})
+    ds = GoldenDataset.from_samples([sample])
+    report = _run(EvalRunner(analyst=analyst, dataset=ds).run())
+    r = report.results[0]
+    assert r.pattern_match is False
+    # Side still matches because the wedge signal is also long.
+    assert r.side_match is True
+
+
+def test_runner_no_signal_marks_neither_match():
+    sample = _sample_with_future(sample_id="empty", symbol="empty")
+    analyst = FixedAnalyst()
+    ds = GoldenDataset.from_samples([sample])
+    report = _run(EvalRunner(analyst=analyst, dataset=ds).run())
+    r = report.results[0]
+    assert r.pattern_match is False
+    assert r.side_match is False
+    assert r.predicted_signal is None
+
+
+# ---------------------------------------------------------------------------
+# Hit-rate / realized R
+# ---------------------------------------------------------------------------
+
+
+def test_realized_r_long_target_2r_returns_2():
+    sig = _sig(entry=100.0, stop=99.0)
+    future = [
+        _bar(5, 100.0, 100.5, 100.0, 100.4),
+        _bar(6, 100.4, 102.5, 100.0, 102.5),  # touches 2R target (102.0)
+    ]
+    realized, h1, h2 = _realized_r(sig, future)
+    assert realized == 2.0
+    assert h1 == "hit"
+    assert h2 == "hit"
+
+
+def test_realized_r_long_stop_returns_minus_1():
+    sig = _sig(entry=100.0, stop=99.0)
+    future = [_bar(5, 100.0, 100.2, 98.9, 99.0)]  # touches stop
+    realized, h1, h2 = _realized_r(sig, future)
+    assert realized == -1.0
+    assert h1 == "miss"
+    assert h2 == "miss"
+
+
+def test_realized_r_long_1r_only_then_window_ends():
+    sig = _sig(entry=100.0, stop=99.0)
+    future = [
+        _bar(5, 100.0, 101.2, 100.0, 100.5),  # touches 1R = 101.0
+        _bar(6, 100.5, 100.7, 100.3, 100.4),
+    ]
+    realized, h1, h2 = _realized_r(sig, future)
+    assert h1 == "hit"
+    assert h2 == "miss"
+    # Final mark to market is the last close minus entry in R units = 0.4
+    assert realized == pytest.approx(0.4)
+
+
+def test_realized_r_short_target_2r_returns_2():
+    sig = _sig(side="short", entry=100.0, stop=101.0, target=98.0)
+    future = [
+        _bar(5, 100.0, 100.0, 99.5, 99.6),
+        _bar(6, 99.6, 99.7, 97.5, 97.5),  # touches 2R target (98.0)
+    ]
+    realized, h1, h2 = _realized_r(sig, future)
+    assert realized == 2.0
+    assert h1 == "hit"
+    assert h2 == "hit"
+
+
+def test_realized_r_no_future_returns_unresolved():
+    sig = _sig()
+    realized, h1, h2 = _realized_r(sig, [])
+    assert realized is None
+    assert h1 == "unresolved"
+    assert h2 == "unresolved"
+
+
+def test_runner_records_realized_r_for_predicted_signal():
+    future = [
+        _bar(5, 100.0, 100.2, 100.0, 100.1),
+        _bar(6, 100.1, 102.5, 100.0, 102.5),  # 2R hit
+    ]
+    sample = _sample_with_future(sample_id="realized", symbol="realized", future=future)
+    analyst = FixedAnalyst(by_id={"realized": [_sig()]})
+    report = _run(EvalRunner(analyst=analyst, dataset=GoldenDataset.from_samples([sample])).run())
+    r = report.results[0]
+    assert r.realized_r == 2.0
+    assert r.hit_1r == "hit"
+    assert r.hit_2r == "hit"
+
+
+# ---------------------------------------------------------------------------
+# TraderEquation integration
+# ---------------------------------------------------------------------------
+
+
+def test_runner_scores_with_trader_equation():
+    df = pd.DataFrame(
+        [
+            {
+                "pattern": "h2",
+                "regime": "weak_bull_trend",
+                "htf_aligned": True,
+                "side": "long",
+                "samples": 100,
+                "hit_rate_1r": 0.7,
+                "hit_rate_2r": 0.4,
+                "avg_realized_r": 0.8,
+            }
+        ]
+    )
+    te = TraderEquation(HitRateTable(df))
+
+    sample = _sample_with_future(sample_id="te", symbol="te", future=[_bar(5, 100.0, 100.2, 100.0, 100.1)])
+    analyst = FixedAnalyst(by_id={"te": [_sig()]})
+
+    report = _run(EvalRunner(analyst=analyst, dataset=GoldenDataset.from_samples([sample]), te=te).run())
+    r = report.results[0]
+    # Probability should come from the table (0.7), not the prior.
+    assert r.probability == pytest.approx(0.7)
+    # E[R] = 0.7 * 2 - 0.3 - 0.05 = 1.05
+    assert r.expected_r == pytest.approx(1.05, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# EvalReport plumbing exposed by the runner
+# ---------------------------------------------------------------------------
+
+
+def test_runner_validates_inputs():
+    with pytest.raises(ValueError):
+        EvalRunner(analyst=None, dataset=GoldenDataset())  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        EvalRunner(analyst=FixedAnalyst(), dataset=None)  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        EvalRunner(analyst=FixedAnalyst(), dataset=GoldenDataset(), max_concurrent=0)
+
+
+def test_runner_runs_empty_dataset():
+    analyst = FixedAnalyst()
+    report = _run(EvalRunner(analyst=analyst, dataset=GoldenDataset()).run())
+    assert report.results == []
+    assert report.dataset_size == 0


### PR DESCRIPTION
## Summary
Phase 4.4 introduces `src/brooks/eval/` — a self-contained evaluation stack that loads golden / silver Brooks samples, scores any analyst against them, and renders an HTML report with per-bucket precision / recall / hit-rate (with Wilson 95% CIs).

- `GoldenDataset` + `GoldenSample` — parquet/jsonl loader with filter/iterate helpers and round-trip persistence
- `AutoLabeler` — rule + N-LLM consensus voter that emits silver samples wherever `min_agreement` analysts agree on `(pattern, side)` with similar entry/stop levels
- `EvalRunner` — replays each sample through an analyst, records the best-matching signal, optionally scores via `TraderEquation`, and walks future bars to compute realized R / 1R / 2R hit flags
- `EvalReport` — bucket metrics by pattern / regime / htf_aligned / source, cost summary (latency + tokens + cache), self-contained HTML page
- `scripts/brooks_label_silver.py` — CLI driver wiring rule + LLM analysts to `AutoLabeler`
- `tests/brooks/test_eval_*.py` — 56 new tests

## Test plan
- [x] `pytest tests/brooks/test_eval_*.py` — 56/56 passing
- [x] `pytest tests/brooks/` — 333/333 passing (no regressions)
- [x] `python scripts/brooks_label_silver.py --help` — CLI parses
- [x] CLI dry-run on a 3-bar synthetic jsonl input

🤖 Generated with [Claude Code](https://claude.com/claude-code)