### PR TITLE
feat(brooks): ensemble analysts — Vote / Router / Critic (QUA-54)

### DIFF
--- a/config/brooks/ensemble_router.yaml
+++ b/config/brooks/ensemble_router.yaml
@@ -1,0 +1,19 @@
+# RouterAnalyst defaults — analyst selection per Brooks regime.
+#
+# Each value is the registered analyst name (`AnalystRegistry`).
+# Strong/clean trends and climaxes route to the strict rule analyst —
+# overfit-prone LLM/VLM judgement is reserved for fuzzier regimes:
+#   * tight ranges        → LLM picks subtle reversal patterns
+#   * broad ranges        → producer/critic raises the bar before entering
+#   * breakout transitions → VLM reads chart shape better than text rules
+default: rule
+routes:
+  strong_bull_trend: rule
+  weak_bull_trend: rule
+  strong_bear_trend: rule
+  weak_bear_trend: rule
+  climax: rule
+  tight_trading_range: "llm:claude-opus-4-7"
+  broad_trading_range: "ensemble.critic"
+  breakout_mode: "vlm:gemini-2.5-pro"
+  unknown: rule

--- a/src/brooks/analyst/__init__.py
+++ b/src/brooks/analyst/__init__.py
@@ -4,15 +4,19 @@ Importing this package triggers registration of all built-in analysts
 with :class:`AnalystRegistry`.
 """
 
-from src.brooks.analyst import llm, rule  # noqa: F401 — imported for side-effect
+from src.brooks.analyst import ensemble, llm, rule  # noqa: F401 — imported for side-effect
 from src.brooks.analyst.base import Analyst, AnalystRegistry
+from src.brooks.analyst.ensemble import CriticAnalyst, RouterAnalyst, VoteAnalyst
 from src.brooks.analyst.llm import LLMAnalyst, LLMSignalBatch
 from src.brooks.analyst.rule import RuleAnalyst
 
 __all__ = [
     "Analyst",
     "AnalystRegistry",
+    "CriticAnalyst",
     "LLMAnalyst",
     "LLMSignalBatch",
+    "RouterAnalyst",
     "RuleAnalyst",
+    "VoteAnalyst",
 ]

--- a/src/brooks/analyst/ensemble.py
+++ b/src/brooks/analyst/ensemble.py
@@ -1,0 +1,278 @@
+"""Ensemble analysts — Vote / Router / Critic.
+
+All three wrap one or more base :class:`Analyst` instances and implement
+the same :class:`~src.brooks.analyst.base.Analyst` Protocol, so they are
+interchangeable via
+``BrooksStrategy(analyst="ensemble.vote"|"ensemble.router"|"ensemble.critic")``.
+
+* :class:`VoteAnalyst`   — concurrent fan-out + consensus filter
+* :class:`RouterAnalyst` — regime-based routing to a single sub-analyst
+* :class:`CriticAnalyst` — producer/critic pipeline with rejection + probability adjustment
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from src.brooks.analyst.base import Analyst, AnalystRegistry
+from src.brooks.context import BrooksContext
+from src.brooks.regime import BrooksRegime
+from src.brooks.schema import Signal
+
+__all__ = ["VoteAnalyst", "RouterAnalyst", "CriticAnalyst"]
+
+
+# ---------------------------------------------------------------------------
+# VoteAnalyst
+# ---------------------------------------------------------------------------
+
+
+@AnalystRegistry.register("ensemble.vote")
+class VoteAnalyst:
+    """Run several analysts concurrently and keep only consensus signals.
+
+    Signals are grouped by ``(pattern, side)`` with ``signal_bar_idx``
+    tolerated within ±1 bar (adjacent pullback/breakout bars frequently
+    fire one bar apart across detectors). A group survives only when
+    at least ``min_agree_count`` *distinct* analysts contribute to it.
+
+    The surviving signal's numeric fields are weighted averages over the
+    group, with weights taken from ``weights[analyst.name]`` (default 1.0).
+    """
+
+    name = "ensemble.vote"
+
+    def __init__(
+        self,
+        analysts: Sequence[Analyst],
+        weights: Optional[Dict[str, float]] = None,
+        min_agree_count: int = 2,
+    ) -> None:
+        if not analysts:
+            raise ValueError("VoteAnalyst requires at least one analyst")
+        if min_agree_count < 1:
+            raise ValueError("min_agree_count must be >= 1")
+        self._analysts: List[Analyst] = list(analysts)
+        self._weights: Dict[str, float] = weights or {a.name: 1.0 for a in self._analysts}
+        self._min_agree: int = min_agree_count
+
+    async def analyze(self, ctx: BrooksContext) -> List[Signal]:
+        batches = await asyncio.gather(*[a.analyze(ctx) for a in self._analysts])
+        tagged: List[Tuple[str, Signal]] = []
+        for analyst, batch in zip(self._analysts, batches):
+            for sig in batch:
+                tagged.append((analyst.name, sig))
+        groups = _cluster_signals(tagged)
+
+        kept: List[Signal] = []
+        for group in groups:
+            voters = {name for name, _ in group}
+            if len(voters) < self._min_agree:
+                continue
+            kept.append(_merge_group(group, self._weights))
+        return kept
+
+
+def _cluster_signals(
+    tagged: List[Tuple[str, Signal]],
+) -> List[List[Tuple[str, Signal]]]:
+    """Cluster by ``(pattern, side)`` with ``signal_bar_idx`` within ±1.
+
+    Iterative single-linkage clustering — a new signal joins the first
+    existing cluster whose ``(pattern, side)`` matches and whose nearest
+    member is within one bar.
+    """
+    groups: List[List[Tuple[str, Signal]]] = []
+    for item in tagged:
+        _, sig = item
+        placed = False
+        for g in groups:
+            head = g[0][1]
+            if head.pattern != sig.pattern or head.side != sig.side:
+                continue
+            if any(abs(gs.signal_bar_idx - sig.signal_bar_idx) <= 1 for _, gs in g):
+                g.append(item)
+                placed = True
+                break
+        if not placed:
+            groups.append([item])
+    return groups
+
+
+def _merge_group(
+    group: List[Tuple[str, Signal]],
+    weights: Dict[str, float],
+) -> Signal:
+    """Weighted-average merge of a consensus group into one :class:`Signal`."""
+    ws = [float(weights.get(name, 1.0)) for name, _ in group]
+    total_w = sum(ws) or 1.0
+
+    def wavg(attr: str) -> float:
+        return sum(w * getattr(s, attr) for w, (_, s) in zip(ws, group)) / total_w
+
+    entry_px = wavg("entry_px")
+    stop_px = wavg("stop_px")
+    # A merged signal must keep Signal's entry!=stop invariant; if inputs
+    # all collapsed to the same price (degenerate case), nudge by epsilon
+    # in the stop direction consistent with `side`.
+    if entry_px == stop_px:
+        eps = max(1e-9, abs(entry_px) * 1e-9)
+        side = group[0][1].side
+        stop_px = stop_px - eps if side == "long" else stop_px + eps
+
+    targets = [(w, s.target_px) for w, (_, s) in zip(ws, group) if s.target_px is not None]
+    if targets:
+        tw = sum(w for w, _ in targets) or 1.0
+        target_px: Optional[float] = sum(w * tp for w, tp in targets) / tw
+    else:
+        target_px = None
+
+    voters = sorted({name for name, _ in group})
+    reasoning = " | ".join(f"{name}: {s.reasoning}" for name, s in group if s.reasoning)
+    template = group[0][1]
+
+    return Signal(
+        pattern=template.pattern,
+        side=template.side,
+        signal_bar_idx=int(round(wavg("signal_bar_idx"))),
+        entry_px=entry_px,
+        stop_px=stop_px,
+        target_px=target_px,
+        probability=min(1.0, max(0.0, wavg("probability"))),
+        quality=min(1.0, max(0.0, wavg("quality"))),
+        reasoning=reasoning,
+        source="ensemble.vote",
+        meta={
+            "voters": voters,
+            "votes": len(voters),
+            "vote_weights": {n: float(weights.get(n, 1.0)) for n in voters},
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# RouterAnalyst
+# ---------------------------------------------------------------------------
+
+
+@AnalystRegistry.register("ensemble.router")
+class RouterAnalyst:
+    """Route the call to a single sub-analyst based on the primary regime.
+
+    ``routes`` maps :class:`~src.brooks.regime.BrooksRegime` → analyst.
+    When the current regime is missing from ``routes``, or when the
+    context lacks a regime altogether, ``default`` handles the call.
+    Every returned signal carries ``meta["routed_by"] = <regime.value>``.
+    """
+
+    name = "ensemble.router"
+
+    def __init__(
+        self,
+        routes: Dict[BrooksRegime, Analyst],
+        default: Analyst,
+    ) -> None:
+        if default is None:
+            raise ValueError("RouterAnalyst requires a non-None default analyst")
+        self._routes: Dict[BrooksRegime, Analyst] = dict(routes)
+        self._default: Analyst = default
+
+    async def analyze(self, ctx: BrooksContext) -> List[Signal]:
+        regime_snap = ctx.primary.regime
+        if regime_snap is None:
+            analyst = self._default
+            routed_by = BrooksRegime.UNKNOWN.value
+        else:
+            regime = getattr(regime_snap, "regime", regime_snap)
+            analyst = self._routes.get(regime, self._default)
+            routed_by = regime.value if hasattr(regime, "value") else str(regime)
+
+        signals = await analyst.analyze(ctx)
+        for s in signals:
+            s.meta["routed_by"] = routed_by
+        return signals
+
+
+# ---------------------------------------------------------------------------
+# CriticAnalyst
+# ---------------------------------------------------------------------------
+
+
+@AnalystRegistry.register("ensemble.critic")
+class CriticAnalyst:
+    """Producer/critic pipeline — producer proposes, critic confirms.
+
+    ``producer.analyze(ctx)`` returns candidate signals. They are
+    attached to the context as ``ctx.candidates`` (plus the optional
+    ``ctx.critic_overlay`` prompt snippet) and handed to the critic,
+    which returns one signal per candidate it endorses. Each critic
+    signal carries ``meta["confirms"] = candidate_idx`` (or ``-1`` for
+    "rejected") plus an adjusted ``probability``; the kept candidates
+    inherit that probability and the critic's reasoning.
+    """
+
+    name = "ensemble.critic"
+
+    def __init__(
+        self,
+        producer: Analyst,
+        critic: Analyst,
+        critic_prompt_overlay: Optional[str] = None,
+    ) -> None:
+        self._producer: Analyst = producer
+        self._critic: Analyst = critic
+        self._overlay: Optional[str] = critic_prompt_overlay
+
+    async def analyze(self, ctx: BrooksContext) -> List[Signal]:
+        candidates = await self._producer.analyze(ctx)
+        if not candidates:
+            return []
+        critic_ctx = _inject_candidates(ctx, candidates, self._overlay)
+        critique = await self._critic.analyze(critic_ctx)
+        return _apply_critique(candidates, critique)
+
+
+def _inject_candidates(
+    ctx: BrooksContext,
+    candidates: List[Signal],
+    overlay: Optional[str],
+) -> BrooksContext:
+    """Return a shallow copy of ``ctx`` carrying ``candidates`` + overlay."""
+    new_ctx = replace(ctx)
+    new_ctx.candidates = list(candidates)  # type: ignore[attr-defined]
+    new_ctx.critic_overlay = overlay  # type: ignore[attr-defined]
+    return new_ctx
+
+
+def _apply_critique(
+    candidates: List[Signal],
+    critique: List[Signal],
+) -> List[Signal]:
+    """Promote candidates the critic confirmed; drop the rest."""
+    kept: List[Signal] = []
+    for c_sig in critique:
+        idx = c_sig.meta.get("confirms", -1)
+        if idx is None or idx < 0 or idx >= len(candidates):
+            continue
+        cand = candidates[idx]
+        merged_meta = {
+            **cand.meta,
+            **c_sig.meta,
+            "producer_source": cand.source,
+            "critic_source": c_sig.source,
+        }
+        critic_reason = c_sig.reasoning.strip() if c_sig.reasoning else ""
+        reasoning = f"{cand.reasoning} | critic: {critic_reason}" if critic_reason else cand.reasoning
+        kept.append(
+            cand.model_copy(
+                update={
+                    "probability": c_sig.probability,
+                    "reasoning": reasoning,
+                    "source": "ensemble.critic",
+                    "meta": merged_meta,
+                }
+            )
+        )
+    return kept

--- a/tests/brooks/test_analyst_ensemble.py
+++ b/tests/brooks/test_analyst_ensemble.py
@@ -1,0 +1,375 @@
+"""Behavioral tests for ensemble analysts (Phase 4.3).
+
+Three suites match the three plug-in analysts:
+
+* ``test_vote``    — concurrent fan-out + consensus filter
+* ``test_router``  — regime-based dispatch
+* ``test_critic``  — producer/critic confirmation pipeline
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import pytest
+
+from src.brooks.analyst import (
+    AnalystRegistry,
+    CriticAnalyst,
+    RouterAnalyst,
+    VoteAnalyst,
+)
+from src.brooks.analyst.base import Analyst
+from src.brooks.context import Bar, BrooksContext, TFSnapshot
+from src.brooks.regime import BrooksRegime, RegimeSnapshot
+from src.brooks.schema import Signal
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _ctx(regime: Optional[BrooksRegime] = None) -> BrooksContext:
+    bars = [
+        Bar(
+            timestamp_ns=1_000_000_000 * (i + 1),
+            open=100.0 + i,
+            high=100.5 + i,
+            low=99.5 + i,
+            close=100.2 + i,
+            volume=1.0,
+        )
+        for i in range(5)
+    ]
+    snap = TFSnapshot(interval="5m", bars=bars)
+    if regime is not None:
+        snap.regime = RegimeSnapshot(regime=regime, confidence=0.8)
+    return BrooksContext(symbol="BTCUSDT", primary=snap)
+
+
+def _signal(
+    *,
+    pattern: str = "h2",
+    side: str = "long",
+    signal_bar_idx: int = 4,
+    entry_px: float = 101.0,
+    stop_px: float = 99.5,
+    target_px: Optional[float] = 103.0,
+    probability: float = 0.6,
+    quality: float = 0.7,
+    reasoning: str = "",
+    source: str = "x",
+    meta: Optional[dict] = None,
+) -> Signal:
+    return Signal(
+        pattern=pattern,
+        side=side,
+        signal_bar_idx=signal_bar_idx,
+        entry_px=entry_px,
+        stop_px=stop_px,
+        target_px=target_px,
+        probability=probability,
+        quality=quality,
+        reasoning=reasoning,
+        source=source,
+        meta=dict(meta or {}),
+    )
+
+
+@dataclass
+class MockAnalyst:
+    """In-process Analyst double — returns a fixed signal list and counts calls."""
+
+    name: str
+    signals: List[Signal] = field(default_factory=list)
+    delay_s: float = 0.0
+    call_count: int = 0
+    last_ctx: Optional[BrooksContext] = None
+    raise_exc: Optional[Exception] = None
+
+    async def analyze(self, ctx: BrooksContext) -> List[Signal]:
+        self.call_count += 1
+        self.last_ctx = ctx
+        if self.delay_s:
+            await asyncio.sleep(self.delay_s)
+        if self.raise_exc is not None:
+            raise self.raise_exc
+        return [s.model_copy(deep=True) for s in self.signals]
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Registry / Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_registry_knows_all_three_ensemble_analysts() -> None:
+    assert "ensemble.vote" in AnalystRegistry.all()
+    assert "ensemble.router" in AnalystRegistry.all()
+    assert "ensemble.critic" in AnalystRegistry.all()
+    assert AnalystRegistry.get("ensemble.vote") is VoteAnalyst
+    assert AnalystRegistry.get("ensemble.router") is RouterAnalyst
+    assert AnalystRegistry.get("ensemble.critic") is CriticAnalyst
+
+
+def test_ensemble_analysts_satisfy_analyst_protocol() -> None:
+    a = MockAnalyst(name="a", signals=[])
+    b = MockAnalyst(name="b", signals=[])
+    assert isinstance(VoteAnalyst([a, b]), Analyst)
+    assert isinstance(RouterAnalyst({}, default=a), Analyst)
+    assert isinstance(CriticAnalyst(producer=a, critic=b), Analyst)
+
+
+# ---------------------------------------------------------------------------
+# test_vote
+# ---------------------------------------------------------------------------
+
+
+class TestVote:
+    def test_two_analysts_agree_one_signal_kept(self) -> None:
+        a1 = MockAnalyst("a1", [_signal(probability=0.6, quality=0.7, source="a1")])
+        a2 = MockAnalyst("a2", [_signal(probability=0.8, quality=0.9, source="a2")])
+        vote = VoteAnalyst([a1, a2], min_agree_count=2)
+        out = _run(vote.analyze(_ctx()))
+        assert len(out) == 1
+        sig = out[0]
+        assert sig.pattern == "h2"
+        assert sig.side == "long"
+        assert sig.source == "ensemble.vote"
+        # equal weights → simple averages
+        assert sig.probability == pytest.approx(0.7)
+        assert sig.quality == pytest.approx(0.8)
+        assert sig.meta["votes"] == 2
+        assert sorted(sig.meta["voters"]) == ["a1", "a2"]
+
+    def test_disagreement_drops_signal(self) -> None:
+        # Two analysts each emit a signal but on different patterns —
+        # neither group meets the 2-vote consensus floor.
+        a1 = MockAnalyst("a1", [_signal(pattern="h2", source="a1")])
+        a2 = MockAnalyst("a2", [_signal(pattern="l2", side="short", entry_px=99.0, stop_px=101.0, source="a2")])
+        vote = VoteAnalyst([a1, a2], min_agree_count=2)
+        out = _run(vote.analyze(_ctx()))
+        assert out == []
+
+    def test_signals_within_one_bar_idx_are_grouped(self) -> None:
+        a1 = MockAnalyst("a1", [_signal(signal_bar_idx=4, source="a1")])
+        a2 = MockAnalyst("a2", [_signal(signal_bar_idx=5, source="a2")])  # +1 bar
+        vote = VoteAnalyst([a1, a2], min_agree_count=2)
+        out = _run(vote.analyze(_ctx()))
+        assert len(out) == 1
+        assert out[0].signal_bar_idx in (4, 5)
+
+    def test_signals_more_than_one_bar_apart_are_separate_groups(self) -> None:
+        a1 = MockAnalyst("a1", [_signal(signal_bar_idx=2, source="a1")])
+        a2 = MockAnalyst("a2", [_signal(signal_bar_idx=4, source="a2")])  # gap = 2
+        vote = VoteAnalyst([a1, a2], min_agree_count=2)
+        out = _run(vote.analyze(_ctx()))
+        assert out == []
+
+    def test_weights_are_applied_to_probability_average(self) -> None:
+        a1 = MockAnalyst("a1", [_signal(probability=0.4, quality=0.5, source="a1")])
+        a2 = MockAnalyst("a2", [_signal(probability=0.9, quality=0.5, source="a2")])
+        vote = VoteAnalyst([a1, a2], weights={"a1": 1.0, "a2": 3.0}, min_agree_count=2)
+        out = _run(vote.analyze(_ctx()))
+        assert len(out) == 1
+        # (1*0.4 + 3*0.9) / 4 = 3.1/4 = 0.775
+        assert out[0].probability == pytest.approx(0.775)
+
+    def test_min_agree_three_requires_three_distinct_voters(self) -> None:
+        a1 = MockAnalyst("a1", [_signal(source="a1")])
+        a2 = MockAnalyst("a2", [_signal(source="a2")])
+        vote = VoteAnalyst([a1, a2], min_agree_count=3)
+        out = _run(vote.analyze(_ctx()))
+        assert out == []
+
+    def test_concurrent_dispatch_runs_analysts_in_parallel(self) -> None:
+        # Two analysts each sleep 100ms — gather should keep total < 200ms.
+        # A serial implementation would take ~200ms.
+        a1 = MockAnalyst("a1", [_signal(source="a1")], delay_s=0.1)
+        a2 = MockAnalyst("a2", [_signal(source="a2")], delay_s=0.1)
+        vote = VoteAnalyst([a1, a2], min_agree_count=2)
+
+        import time
+
+        t0 = time.perf_counter()
+        out = _run(vote.analyze(_ctx()))
+        elapsed = time.perf_counter() - t0
+        assert len(out) == 1
+        assert elapsed < 0.18, f"expected concurrent dispatch (<180ms); got {elapsed:.3f}s"
+
+    def test_empty_input_returns_empty(self) -> None:
+        a1 = MockAnalyst("a1", signals=[])
+        a2 = MockAnalyst("a2", signals=[])
+        vote = VoteAnalyst([a1, a2], min_agree_count=2)
+        assert _run(vote.analyze(_ctx())) == []
+
+    def test_min_agree_one_keeps_singletons(self) -> None:
+        a1 = MockAnalyst("a1", [_signal(source="a1")])
+        a2 = MockAnalyst("a2", signals=[])
+        vote = VoteAnalyst([a1, a2], min_agree_count=1)
+        out = _run(vote.analyze(_ctx()))
+        assert len(out) == 1
+        assert out[0].meta["votes"] == 1
+
+
+# ---------------------------------------------------------------------------
+# test_router
+# ---------------------------------------------------------------------------
+
+
+class TestRouter:
+    def test_routes_by_regime(self) -> None:
+        rule_a = MockAnalyst("rule", [_signal(source="rule")])
+        llm_a = MockAnalyst("llm:x", [_signal(source="llm:x")])
+        default = MockAnalyst("default", [_signal(source="default")])
+        router = RouterAnalyst(
+            routes={
+                BrooksRegime.STRONG_BULL_TREND: rule_a,
+                BrooksRegime.TIGHT_TRADING_RANGE: llm_a,
+            },
+            default=default,
+        )
+
+        out_bull = _run(router.analyze(_ctx(BrooksRegime.STRONG_BULL_TREND)))
+        assert rule_a.call_count == 1
+        assert llm_a.call_count == 0
+        assert default.call_count == 0
+        assert out_bull[0].meta["routed_by"] == "strong_bull_trend"
+
+        out_tr = _run(router.analyze(_ctx(BrooksRegime.TIGHT_TRADING_RANGE)))
+        assert rule_a.call_count == 1
+        assert llm_a.call_count == 1
+        assert default.call_count == 0
+        assert out_tr[0].meta["routed_by"] == "tight_trading_range"
+
+    def test_unknown_regime_falls_back_to_default(self) -> None:
+        rule_a = MockAnalyst("rule", [_signal(source="rule")])
+        default = MockAnalyst("default", [_signal(source="default")])
+        router = RouterAnalyst(
+            routes={BrooksRegime.STRONG_BULL_TREND: rule_a},
+            default=default,
+        )
+        # CLIMAX is not in routes → default takes over.
+        out = _run(router.analyze(_ctx(BrooksRegime.CLIMAX)))
+        assert rule_a.call_count == 0
+        assert default.call_count == 1
+        assert out[0].meta["routed_by"] == "climax"
+
+    def test_missing_regime_uses_default(self) -> None:
+        rule_a = MockAnalyst("rule", signals=[])
+        default = MockAnalyst("default", [_signal(source="default")])
+        router = RouterAnalyst(
+            routes={BrooksRegime.STRONG_BULL_TREND: rule_a},
+            default=default,
+        )
+        out = _run(router.analyze(_ctx(regime=None)))
+        assert default.call_count == 1
+        assert out[0].meta["routed_by"] == BrooksRegime.UNKNOWN.value
+
+    def test_router_passes_context_through_unchanged(self) -> None:
+        captured = MockAnalyst("captured", [_signal(source="captured")])
+        router = RouterAnalyst(routes={}, default=captured)
+        ctx = _ctx(BrooksRegime.BROAD_TRADING_RANGE)
+        _run(router.analyze(ctx))
+        assert captured.last_ctx is ctx
+
+
+# ---------------------------------------------------------------------------
+# test_critic
+# ---------------------------------------------------------------------------
+
+
+class TestCritic:
+    def test_producer_three_signals_critic_keeps_two(self) -> None:
+        candidates = [
+            _signal(pattern="h2", source="producer", probability=0.6),
+            _signal(pattern="l2", side="short", entry_px=99.0, stop_px=101.0, source="producer", probability=0.55),
+            _signal(pattern="ii", source="producer", probability=0.5),
+        ]
+        critique = [
+            _signal(source="critic", probability=0.85, reasoning="strong h2", meta={"confirms": 0}),
+            _signal(source="critic", probability=0.40, reasoning="weak ii", meta={"confirms": 2}),
+        ]
+        producer = MockAnalyst("producer", candidates)
+        critic = MockAnalyst("critic", critique)
+        ca = CriticAnalyst(producer=producer, critic=critic)
+
+        out = _run(ca.analyze(_ctx()))
+        assert len(out) == 2
+        # First kept came from candidate 0 (h2) with probability lifted to 0.85.
+        assert out[0].pattern == "h2"
+        assert out[0].probability == pytest.approx(0.85)
+        assert out[0].source == "ensemble.critic"
+        assert out[0].meta["producer_source"] == "producer"
+        assert out[0].meta["critic_source"] == "critic"
+        # Second kept came from candidate 2 (ii) with probability cut to 0.40.
+        assert out[1].pattern == "ii"
+        assert out[1].probability == pytest.approx(0.40)
+        # Candidate 1 (l2 short) was rejected — never appears in output.
+        assert all(o.pattern != "l2" for o in out)
+
+    def test_no_candidates_skips_critic_call(self) -> None:
+        producer = MockAnalyst("producer", signals=[])
+        critic = MockAnalyst("critic", signals=[])
+        ca = CriticAnalyst(producer=producer, critic=critic)
+        out = _run(ca.analyze(_ctx()))
+        assert out == []
+        assert producer.call_count == 1
+        assert critic.call_count == 0
+
+    def test_critic_receives_candidates_on_context(self) -> None:
+        candidates = [_signal(source="producer")]
+        producer = MockAnalyst("producer", candidates)
+        critic = MockAnalyst(
+            "critic",
+            [_signal(source="critic", probability=0.9, meta={"confirms": 0})],
+        )
+        ca = CriticAnalyst(producer=producer, critic=critic, critic_prompt_overlay="be strict")
+        _run(ca.analyze(_ctx()))
+        injected = critic.last_ctx
+        assert injected is not None
+        # Producer's candidates land on the context for the critic to read.
+        assert getattr(injected, "candidates")[0].pattern == candidates[0].pattern
+        assert getattr(injected, "critic_overlay") == "be strict"
+
+    def test_invalid_confirms_index_is_dropped(self) -> None:
+        producer = MockAnalyst("producer", [_signal(source="producer")])
+        critic = MockAnalyst(
+            "critic",
+            [
+                _signal(source="critic", probability=0.9, meta={"confirms": -1}),  # rejected sentinel
+                _signal(source="critic", probability=0.9, meta={"confirms": 7}),  # out of range
+            ],
+        )
+        ca = CriticAnalyst(producer=producer, critic=critic)
+        assert _run(ca.analyze(_ctx())) == []
+
+    def test_kept_signal_inherits_candidate_geometry(self) -> None:
+        cand = _signal(
+            entry_px=101.5,
+            stop_px=99.0,
+            target_px=104.0,
+            source="producer",
+            reasoning="bull pullback",
+        )
+        producer = MockAnalyst("producer", [cand])
+        critic = MockAnalyst(
+            "critic",
+            [_signal(source="critic", probability=0.8, reasoning="confirmed", meta={"confirms": 0})],
+        )
+        ca = CriticAnalyst(producer=producer, critic=critic)
+        out = _run(ca.analyze(_ctx()))
+        assert len(out) == 1
+        kept = out[0]
+        # entry/stop/target taken from the producer; probability from the critic.
+        assert kept.entry_px == 101.5
+        assert kept.stop_px == 99.0
+        assert kept.target_px == 104.0
+        assert kept.probability == pytest.approx(0.8)
+        assert "bull pullback" in kept.reasoning
+        assert "confirmed" in kept.reasoning


### PR DESCRIPTION
## Summary
- Three plug-in analysts under `src/brooks/analyst/ensemble.py`, all implementing the `Analyst` Protocol and registered via `AnalystRegistry` as `ensemble.vote` / `ensemble.router` / `ensemble.critic`, so `BrooksStrategy(analyst="ensemble.<name>")` can swap them in directly.
- **VoteAnalyst** fans out to its sub-analysts with `asyncio.gather`, clusters signals by `(pattern, side)` within `signal_bar_idx ±1`, and keeps groups with `>= min_agree_count` distinct voters (weighted-average probability/quality/entry/stop/target; `meta["voters"]`, `meta["votes"]`, `meta["vote_weights"]`).
- **RouterAnalyst** dispatches to a sub-analyst keyed on `ctx.primary.regime.regime`, falls back to `default` for missing/unmapped regimes, and tags each emitted signal with `meta["routed_by"]`.
- **CriticAnalyst** runs a producer, attaches its candidates (+ optional prompt overlay) onto a shallow-copied context, hands the context to the critic, and keeps candidates the critic confirms via `meta["confirms"] = <candidate_idx>` with the critic's adjusted probability.
- Ships `config/brooks/ensemble_router.yaml` with recommended defaults: `rule` for strong trends + climax, LLM for tight ranges, `ensemble.critic` for broad ranges, VLM for breakouts.

## Test plan
- [x] `uv run pytest tests/brooks/test_analyst_ensemble.py` → 20 passed (Vote consensus/disagreement/±1-bar clustering/weights/concurrency; Router routing + default fallback; Critic kept/rejected scenarios).
- [x] `uv run pytest tests/brooks/test_analyst_rule.py tests/brooks/test_analyst_llm.py` → 21 passed (no regression).
- [x] `uv run ruff check src/brooks/analyst/ensemble.py src/brooks/analyst/__init__.py tests/brooks/test_analyst_ensemble.py` → clean.
- [x] Pre-commit hooks (ruff format, yaml, etc.) all pass on commit.

Closes QUA-54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)