### PR TITLE
feat(brooks): cross-model Leaderboard + weekly cron (QUA-56)

### DIFF
--- a/config/brooks/leaderboard.yaml
+++ b/config/brooks/leaderboard.yaml
@@ -1,0 +1,43 @@
+# Brooks leaderboard — weekly cross-model regression evaluation.
+#
+# Adding a new model is a one-line change: append a new entry under
+# ``analysts``. Entries are resolved by ``AnalystFactory`` in
+# ``src.brooks.eval.leaderboard``.
+#
+# Analyst types:
+#   - rule                  — deterministic pattern detectors
+#   - llm  (model: <id>)    — LLMAnalyst with the given model id
+#   - vlm  (model: <id>)    — VLMAnalyst (registered in Phase 4.3)
+#   - ensemble.critic       — producer + critic pipeline
+#   - ensemble.vote         — fan-out + consensus
+#   - ensemble.router       — regime-routed analyst
+
+dataset: data/brooks/golden/v1.parquet
+
+analysts:
+  - type: rule
+  - type: llm
+    model: claude-opus-4-7
+  - type: llm
+    model: claude-sonnet-4-6
+  - type: llm
+    model: gpt-4.1
+  - type: llm
+    model: gemini-2.5-pro
+  - type: vlm
+    model: gemini-2.5-pro
+  - type: ensemble.critic
+    label: critic(rule+sonnet)
+    producer: rule
+    critic: llm:claude-sonnet-4-6
+
+# Cron for the Celery beat schedule (weekly, Monday 03:00 UTC).
+schedule: "0 3 * * MON"
+
+output_dir: data/brooks/leaderboards
+history_path: data/brooks/leaderboard.parquet
+max_concurrent: 4
+
+# USD per 1M tokens by model. Overrides DEFAULT_COST_PER_MTOKEN.
+# cost_per_mtoken:
+#   claude-opus-4-7: {input: 15.0, output: 75.0}

--- a/scripts/brooks_leaderboard.py
+++ b/scripts/brooks_leaderboard.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""CLI entry for the Brooks cross-analyst leaderboard.
+
+Usage:
+
+    python scripts/brooks_leaderboard.py --config config/brooks/leaderboard.yaml
+    python scripts/brooks_leaderboard.py --config ... --mock-llm       # CI / offline
+
+Writes ``<output_dir>/<timestamp>.html`` and appends one parquet row per
+analyst to ``<history_path>``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Allow "python scripts/brooks_leaderboard.py" from repo root.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.brooks.eval.golden import GoldenDataset  # noqa: E402
+from src.brooks.eval.leaderboard import (  # noqa: E402
+    AnalystFactory,
+    Leaderboard,
+    LeaderboardConfig,
+)
+
+logger = logging.getLogger("brooks.leaderboard.cli")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else "")
+    p.add_argument("--config", required=True, type=Path, help="Path to leaderboard.yaml")
+    p.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Override output HTML path. Defaults to <output_dir>/<timestamp>.html.",
+    )
+    p.add_argument(
+        "--mock-llm",
+        action="store_true",
+        help="Use a deterministic in-process MockProvider for every LLM/VLM analyst "
+        "(no network, no API keys). Required in CI and for smoke tests.",
+    )
+    p.add_argument(
+        "--no-persist",
+        action="store_true",
+        help="Do not append to the history parquet log.",
+    )
+    p.add_argument(
+        "--dataset",
+        type=Path,
+        default=None,
+        help="Override dataset path from the config file.",
+    )
+    p.add_argument("--verbose", "-v", action="store_true")
+    return p
+
+
+def _mock_provider_factory():
+    """Return a callable ``model_id -> MockProvider`` that synthesises a
+    plausible ``LLMSignalBatch`` response.
+
+    The signal echoes the most common (pattern, side) in the golden set
+    — "h2" / "long" — with stable cost metadata, enough to drive the
+    eval pipeline end-to-end without calling any real LLM.
+    """
+    from src.alpha.llm.provider import Response, Usage
+    from src.brooks.analyst.llm import LLMSignalBatch
+    from src.brooks.schema import Signal
+
+    class _MockProvider:
+        def __init__(self, model: str) -> None:
+            self.name = f"mock:{model}"
+            self._model = model
+
+        async def complete(self, messages, schema, cache=None, seed=None, max_tokens=4096, temperature=0.0):
+            parsed = schema(
+                reasoning=f"mock-{self._model}",
+                signals=[
+                    Signal(
+                        pattern="h2",
+                        side="long",
+                        signal_bar_idx=0,
+                        entry_px=100.0,
+                        stop_px=99.0,
+                        target_px=102.0,
+                        probability=0.55,
+                        quality=0.6,
+                        source=f"llm:{self._model}",
+                    )
+                ],
+            ) if schema is LLMSignalBatch else schema()
+            return Response(
+                parsed=parsed,
+                raw={"mock": True},
+                usage=Usage(input_tokens=100, output_tokens=40),
+                latency_ms=8.0,
+                model=self._model,
+                cache_hit=False,
+            )
+
+    return lambda model_id: _MockProvider(model_id)
+
+
+def _real_provider_factory():
+    """Pick a real provider by model-id prefix (claude → Anthropic, gpt → OpenAI,
+    gemini → Gemini). Raises if the matching API key env var is not set."""
+
+    def factory(model: str):
+        m = model.lower()
+        if m.startswith("claude"):
+            from src.alpha.llm.providers.anthropic import AnthropicProvider
+            return AnthropicProvider(model=model)
+        if m.startswith("gpt"):
+            from src.alpha.llm.providers.openai import OpenAIProvider
+            return OpenAIProvider(model=model)
+        if m.startswith("gemini"):
+            from src.alpha.llm.providers.gemini import GeminiProvider
+            return GeminiProvider(model=model)
+        raise ValueError(f"no provider mapping for model id: {model!r}")
+
+    return factory
+
+
+async def _run(args: argparse.Namespace) -> int:
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    cfg = LeaderboardConfig.load(args.config)
+    if args.dataset is not None:
+        cfg.dataset = args.dataset
+
+    if not cfg.dataset.exists():
+        logger.error("dataset not found: %s", cfg.dataset)
+        return 2
+
+    dataset = GoldenDataset.load(cfg.dataset)
+    logger.info("loaded %d golden samples from %s", len(dataset), cfg.dataset)
+    if len(dataset) == 0:
+        logger.error("dataset is empty; nothing to evaluate")
+        return 2
+
+    provider_factory = _mock_provider_factory() if args.mock_llm else _real_provider_factory()
+    factory = AnalystFactory(provider_factory=provider_factory)
+    board = Leaderboard(cfg, factory=factory)
+
+    entries = await board.run_all(dataset)
+    logger.info("scored %d analyst(s)", len(entries))
+
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    out_path = args.output if args.output is not None else cfg.output_dir / f"{ts}.html"
+    board.to_html(out_path)
+    logger.info("wrote leaderboard HTML → %s", out_path)
+
+    if not args.no_persist:
+        path = board.persist()
+        logger.info("appended history → %s", path)
+
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        return asyncio.run(_run(args))
+    except KeyboardInterrupt:
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/brooks/eval/leaderboard.py
+++ b/src/brooks/eval/leaderboard.py
@@ -1,0 +1,625 @@
+"""Cross-analyst leaderboard over a Brooks :class:`GoldenDataset`.
+
+The leaderboard reuses :class:`EvalRunner` / :class:`EvalReport` to score
+each configured analyst (rule / LLM / VLM / ensemble.*) against the same
+golden dataset, then renders a single HTML page that lets us compare
+quality, cost, and per-bucket behaviour side by side.
+
+Config is a YAML file (see ``config/brooks/leaderboard.yaml``) so adding
+a new model is a one-line change — the :class:`AnalystFactory` resolves
+``{type: llm, model: ...}`` or ``{type: ensemble.critic, ...}`` specs
+into ready-to-run :class:`Analyst` instances.
+
+Results are persisted to a parquet log on every run so weekly history
+can be queried for trend charts.
+"""
+
+from __future__ import annotations
+
+import base64
+import html
+import io
+import json
+import logging
+import math
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+from src.brooks.analyst.base import Analyst, AnalystRegistry
+from src.brooks.analyst.ensemble import CriticAnalyst, RouterAnalyst, VoteAnalyst
+from src.brooks.eval.golden import GoldenDataset
+from src.brooks.eval.report import EvalReport
+from src.brooks.eval.runner import EvalRunner
+
+__all__ = [
+    "AnalystSpec",
+    "LeaderboardConfig",
+    "LeaderboardEntry",
+    "Leaderboard",
+    "AnalystFactory",
+    "DEFAULT_COST_PER_MTOKEN",
+]
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Cost model
+# ---------------------------------------------------------------------------
+
+
+DEFAULT_COST_PER_MTOKEN: Dict[str, Dict[str, float]] = {
+    "claude-opus-4-7": {"input": 15.0, "output": 75.0},
+    "claude-opus-4": {"input": 15.0, "output": 75.0},
+    "claude-sonnet-4-6": {"input": 3.0, "output": 15.0},
+    "claude-sonnet-4": {"input": 3.0, "output": 15.0},
+    "claude-haiku-4-5": {"input": 1.0, "output": 5.0},
+    "gpt-4.1": {"input": 2.0, "output": 8.0},
+    "gpt-4o": {"input": 2.5, "output": 10.0},
+    "gemini-2.5-pro": {"input": 1.25, "output": 10.0},
+    "gemini-2.5-flash": {"input": 0.3, "output": 2.5},
+}
+
+
+def _cost_per_run(model: str, avg_in: float, avg_out: float, table: Dict[str, Dict[str, float]]) -> float:
+    """USD per call for the given model and average token usage."""
+    rates = table.get(model)
+    if not rates:
+        return 0.0
+    return (avg_in * float(rates.get("input", 0.0)) + avg_out * float(rates.get("output", 0.0))) / 1_000_000.0
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AnalystSpec:
+    """One analyst entry in ``leaderboard.yaml``."""
+
+    type: str
+    model: Optional[str] = None
+    label: Optional[str] = None
+    # Ensemble / nested analyst specs — values are strings ("llm:claude-opus-4-7")
+    # or nested spec dicts.
+    params: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, raw: Dict[str, Any]) -> "AnalystSpec":
+        if "type" not in raw:
+            raise ValueError(f"AnalystSpec missing 'type': {raw!r}")
+        known = {"type", "model", "label"}
+        params = {k: v for k, v in raw.items() if k not in known}
+        return cls(
+            type=str(raw["type"]),
+            model=raw.get("model"),
+            label=raw.get("label"),
+            params=params,
+        )
+
+    def display_name(self) -> str:
+        if self.label:
+            return self.label
+        if self.model:
+            return f"{self.type}:{self.model}"
+        return self.type
+
+
+@dataclass
+class LeaderboardConfig:
+    """Loaded ``leaderboard.yaml``."""
+
+    dataset: Path
+    analysts: List[AnalystSpec]
+    output_dir: Path = Path("data/brooks/leaderboards")
+    history_path: Path = Path("data/brooks/leaderboard.parquet")
+    max_concurrent: int = 4
+    schedule: Optional[str] = None
+    # Default cost table — YAML can override per model via ``cost_per_mtoken``.
+    cost_per_mtoken: Dict[str, Dict[str, float]] = field(
+        default_factory=lambda: {k: dict(v) for k, v in DEFAULT_COST_PER_MTOKEN.items()}
+    )
+
+    @classmethod
+    def load(cls, path: Path | str) -> "LeaderboardConfig":
+        import yaml
+
+        raw = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            raise ValueError(f"leaderboard config must be a YAML mapping, got {type(raw).__name__}")
+        return cls.from_dict(raw)
+
+    @classmethod
+    def from_dict(cls, raw: Dict[str, Any]) -> "LeaderboardConfig":
+        if "dataset" not in raw:
+            raise ValueError("leaderboard config missing 'dataset'")
+        analyst_specs = [AnalystSpec.from_dict(a) for a in raw.get("analysts", [])]
+        if not analyst_specs:
+            raise ValueError("leaderboard config must list at least one analyst")
+        cost_table = dict(DEFAULT_COST_PER_MTOKEN)
+        for model, rates in (raw.get("cost_per_mtoken") or {}).items():
+            cost_table[model] = dict(rates)
+        return cls(
+            dataset=Path(raw["dataset"]),
+            analysts=analyst_specs,
+            output_dir=Path(raw.get("output_dir", "data/brooks/leaderboards")),
+            history_path=Path(raw.get("history_path", "data/brooks/leaderboard.parquet")),
+            max_concurrent=int(raw.get("max_concurrent", 4)),
+            schedule=raw.get("schedule"),
+            cost_per_mtoken=cost_table,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Analyst factory
+# ---------------------------------------------------------------------------
+
+
+ProviderFactory = Callable[[str], Any]
+
+
+class AnalystFactory:
+    """Resolve :class:`AnalystSpec` → ready :class:`Analyst` instance.
+
+    LLM/VLM specs require a ``provider_factory`` — a callable that
+    returns a :class:`Provider` for a given model id. Leaving it as
+    ``None`` means LLM/VLM specs will raise; this keeps pure-rule
+    leaderboards runnable without any provider wiring.
+    """
+
+    def __init__(self, provider_factory: Optional[ProviderFactory] = None) -> None:
+        self._provider_factory = provider_factory
+
+    def build(self, spec: AnalystSpec) -> Analyst:
+        t = spec.type
+        if t == "rule":
+            return AnalystRegistry.build("rule", **spec.params)
+        if t == "llm":
+            return self._build_llm(spec, analyst_name="llm")
+        if t == "vlm":
+            # VLM analysts are optional — only instantiate if registered.
+            if "vlm" in AnalystRegistry.all():
+                return self._build_llm(spec, analyst_name="vlm")
+            raise KeyError("VLM analyst is not registered in this build")
+        if t == "ensemble.critic":
+            producer = self._build_nested(spec.params.get("producer"))
+            critic = self._build_nested(spec.params.get("critic"))
+            overlay = spec.params.get("critic_prompt_overlay")
+            return CriticAnalyst(producer=producer, critic=critic, critic_prompt_overlay=overlay)
+        if t == "ensemble.vote":
+            analysts = [self._build_nested(a) for a in spec.params.get("analysts", [])]
+            weights = spec.params.get("weights")
+            return VoteAnalyst(
+                analysts=analysts,
+                weights=weights,
+                min_agree_count=int(spec.params.get("min_agree_count", 2)),
+            )
+        if t == "ensemble.router":
+            from src.brooks.regime import BrooksRegime
+
+            routes_raw = spec.params.get("routes", {}) or {}
+            routes = {BrooksRegime(k): self._build_nested(v) for k, v in routes_raw.items()}
+            default = self._build_nested(spec.params.get("default"))
+            return RouterAnalyst(routes=routes, default=default)
+        raise ValueError(f"Unsupported analyst type: {t!r}")
+
+    def _build_llm(self, spec: AnalystSpec, *, analyst_name: str) -> Analyst:
+        if self._provider_factory is None:
+            raise RuntimeError(
+                f"{analyst_name}:{spec.model} requires a provider_factory; "
+                "pass provider_factory=... to AnalystFactory or Leaderboard"
+            )
+        if not spec.model:
+            raise ValueError(f"{analyst_name} spec must include 'model'")
+        provider = self._provider_factory(spec.model)
+        kwargs = dict(spec.params)
+        kwargs.pop("provider", None)
+        return AnalystRegistry.build(analyst_name, provider=provider, model=spec.model, **kwargs)
+
+    def _build_nested(self, raw: Any) -> Analyst:
+        """Accept either a string ``"llm:claude-opus-4-7"`` or a full spec dict."""
+        if raw is None:
+            raise ValueError("ensemble analyst missing nested analyst spec")
+        if isinstance(raw, str):
+            if ":" in raw:
+                head, _, tail = raw.partition(":")
+                return self.build(AnalystSpec(type=head, model=tail))
+            return self.build(AnalystSpec(type=raw))
+        if isinstance(raw, dict):
+            return self.build(AnalystSpec.from_dict(raw))
+        raise TypeError(f"unsupported nested analyst spec: {type(raw).__name__}")
+
+
+# ---------------------------------------------------------------------------
+# Entry / Leaderboard
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LeaderboardEntry:
+    """One analyst's score on the leaderboard."""
+
+    model_id: str
+    analyst_name: str
+    run_at: datetime
+    # Overall quality
+    f1_pattern: float
+    hit_rate_1r: float
+    expected_r_mean: float
+    side_accuracy: float = 0.0
+    pattern_precision: float = 0.0
+    pattern_recall: float = 0.0
+    samples: int = 0
+    # Cost
+    avg_latency_ms: float = 0.0
+    avg_input_tokens: float = 0.0
+    avg_output_tokens: float = 0.0
+    cache_hit_rate: float = 0.0
+    cost_per_run_usd: float = 0.0
+    # Bucket breakdowns
+    by_regime: Dict[str, Dict[str, float]] = field(default_factory=dict)
+    by_pattern: Dict[str, Dict[str, float]] = field(default_factory=dict)
+    # Optional error string if this analyst failed to run
+    error: Optional[str] = None
+
+    def to_row(self) -> dict:
+        d = asdict(self)
+        d["run_at"] = self.run_at.isoformat()
+        d["by_regime"] = json.dumps(self.by_regime)
+        d["by_pattern"] = json.dumps(self.by_pattern)
+        return d
+
+
+class Leaderboard:
+    """Run every configured analyst and produce a comparison report."""
+
+    def __init__(
+        self,
+        config: LeaderboardConfig,
+        factory: Optional[AnalystFactory] = None,
+    ) -> None:
+        self._config = config
+        self._factory = factory or AnalystFactory()
+        self._entries: List[LeaderboardEntry] = []
+        self._reports: Dict[str, EvalReport] = {}
+
+    @property
+    def config(self) -> LeaderboardConfig:
+        return self._config
+
+    @property
+    def entries(self) -> List[LeaderboardEntry]:
+        return list(self._entries)
+
+    async def run_all(self, dataset: GoldenDataset) -> List[LeaderboardEntry]:
+        """Score every configured analyst; skip ones that fail to build/run."""
+        if len(dataset) == 0:
+            raise ValueError("Leaderboard.run_all: dataset is empty")
+
+        self._entries.clear()
+        self._reports.clear()
+
+        for spec in self._config.analysts:
+            entry = await self._run_one(spec, dataset)
+            self._entries.append(entry)
+        return list(self._entries)
+
+    async def _run_one(self, spec: AnalystSpec, dataset: GoldenDataset) -> LeaderboardEntry:
+        display = spec.display_name()
+        now = datetime.now(timezone.utc)
+        try:
+            analyst = self._factory.build(spec)
+        except Exception as exc:  # build failure — record but do not abort
+            logger.warning("Leaderboard: failed to build %s: %s", display, exc)
+            return LeaderboardEntry(
+                model_id=display,
+                analyst_name=display,
+                run_at=now,
+                f1_pattern=0.0,
+                hit_rate_1r=0.0,
+                expected_r_mean=0.0,
+                error=f"build_failed: {type(exc).__name__}: {exc}",
+            )
+        try:
+            runner = EvalRunner(
+                analyst=analyst,
+                dataset=dataset,
+                max_concurrent=self._config.max_concurrent,
+            )
+            report = await runner.run()
+        except Exception as exc:  # run failure — record and continue
+            logger.warning("Leaderboard: %s failed during run: %s", display, exc)
+            return LeaderboardEntry(
+                model_id=spec.model or display,
+                analyst_name=getattr(analyst, "name", display),
+                run_at=now,
+                f1_pattern=0.0,
+                hit_rate_1r=0.0,
+                expected_r_mean=0.0,
+                error=f"run_failed: {type(exc).__name__}: {exc}",
+            )
+
+        self._reports[display] = report
+        return self._entry_from_report(spec, analyst, report, now)
+
+    def _entry_from_report(
+        self,
+        spec: AnalystSpec,
+        analyst: Analyst,
+        report: EvalReport,
+        run_at: datetime,
+    ) -> LeaderboardEntry:
+        overall = report.overall()
+        cost = report.cost_summary()
+        samples = max(1, cost.get("samples", 0))
+        avg_in = cost.get("total_input_tokens", 0) / samples
+        avg_out = cost.get("total_output_tokens", 0) / samples
+        model_key = spec.model or ""
+        cost_per_run = _cost_per_run(model_key, avg_in, avg_out, self._config.cost_per_mtoken)
+
+        def _bucket_dict(dim: str) -> Dict[str, Dict[str, float]]:
+            return {
+                b.value: {
+                    "samples": b.samples,
+                    "pattern_f1": b.pattern_f1,
+                    "hit_rate_1r": b.hit_rate_1r,
+                    "avg_realized_r": b.avg_realized_r,
+                }
+                for b in report.bucket_metrics(dim)
+            }
+
+        return LeaderboardEntry(
+            model_id=spec.model or spec.display_name(),
+            analyst_name=getattr(analyst, "name", spec.display_name()),
+            run_at=run_at,
+            f1_pattern=overall.pattern_f1,
+            hit_rate_1r=overall.hit_rate_1r,
+            expected_r_mean=overall.avg_realized_r,
+            side_accuracy=overall.side_accuracy,
+            pattern_precision=overall.pattern_precision,
+            pattern_recall=overall.pattern_recall,
+            samples=overall.samples,
+            avg_latency_ms=cost.get("avg_latency_ms", 0.0),
+            avg_input_tokens=avg_in,
+            avg_output_tokens=avg_out,
+            cache_hit_rate=cost.get("cache_hit_rate", 0.0),
+            cost_per_run_usd=cost_per_run,
+            by_regime=_bucket_dict("regime"),
+            by_pattern=_bucket_dict("pattern"),
+        )
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
+    def persist(self, db_path: Optional[Path] = None) -> Path:
+        """Append current entries to the history parquet log.
+
+        The log is append-only: each weekly run adds one row per analyst
+        so :meth:`load_history` can produce trend charts over time.
+        """
+        if not self._entries:
+            raise ValueError("Leaderboard.persist: no entries to persist; call run_all first")
+        import pandas as pd
+
+        path = Path(db_path) if db_path is not None else self._config.history_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        new_rows = pd.DataFrame([e.to_row() for e in self._entries])
+        if path.exists():
+            prior = pd.read_parquet(path)
+            combined = pd.concat([prior, new_rows], ignore_index=True)
+        else:
+            combined = new_rows
+        combined.to_parquet(path, index=False)
+        return path
+
+    @classmethod
+    def load_history(cls, db_path: Path):
+        """Return the full history as a ``pandas.DataFrame`` (empty if absent)."""
+        import pandas as pd
+
+        p = Path(db_path)
+        if not p.exists():
+            return pd.DataFrame()
+        return pd.read_parquet(p)
+
+    # ------------------------------------------------------------------
+    # HTML rendering
+    # ------------------------------------------------------------------
+
+    def to_html(self, path: Optional[Path] = None) -> str:
+        if not self._entries:
+            raise ValueError("Leaderboard.to_html: no entries; call run_all first")
+
+        sections: List[str] = []
+        run_at = datetime.now(timezone.utc).isoformat()
+        sections.append(_render_header(len(self._entries), run_at, self._config))
+        sections.append(_render_overall_table(self._entries))
+        pareto = _render_pareto(self._entries)
+        if pareto:
+            sections.append(pareto)
+        sections.append(_render_bucket_section("By regime", "regime", self._entries, lambda e: e.by_regime))
+        sections.append(_render_bucket_section("By pattern", "pattern", self._entries, lambda e: e.by_pattern))
+        sections.append(_render_cost_table(self._entries))
+
+        doc = _HTML_TEMPLATE.format(
+            title=html.escape("Brooks Leaderboard"),
+            body="\n".join(sections),
+        )
+        if path is not None:
+            out = Path(path)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(doc, encoding="utf-8")
+        return doc
+
+
+# ---------------------------------------------------------------------------
+# HTML rendering helpers
+# ---------------------------------------------------------------------------
+
+
+_HTML_TEMPLATE = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{title}</title>
+<style>
+body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; margin: 24px; color: #1f2933; }}
+h1 {{ font-size: 1.5rem; margin-bottom: 0.2rem; }}
+h2 {{ font-size: 1.1rem; margin-top: 1.8rem; border-bottom: 1px solid #d9e2ec; padding-bottom: 4px; }}
+table {{ border-collapse: collapse; margin: 0.5rem 0 1.5rem; font-size: 0.85rem; }}
+th, td {{ border: 1px solid #cbd5e0; padding: 4px 10px; text-align: right; }}
+th:first-child, td:first-child {{ text-align: left; font-weight: 500; }}
+tr:nth-child(even) {{ background: #f7fafc; }}
+tr.err td {{ color: #b91c1c; }}
+.muted {{ color: #627d98; font-size: 0.8rem; }}
+.pareto img {{ max-width: 720px; border: 1px solid #d9e2ec; border-radius: 4px; }}
+</style>
+</head>
+<body>
+{body}
+</body>
+</html>
+"""
+
+
+def _render_header(n: int, run_at: str, config: LeaderboardConfig) -> str:
+    return (
+        "<h1>Brooks Leaderboard</h1>"
+        f"<p class='muted'>run at {html.escape(run_at)} · analysts: {n} · "
+        f"dataset: {html.escape(str(config.dataset))}</p>"
+    )
+
+
+def _render_overall_table(entries: List[LeaderboardEntry]) -> str:
+    headers = [
+        "analyst",
+        "samples",
+        "F1",
+        "precision",
+        "recall",
+        "side",
+        "hit-1R",
+        "avg R",
+        "latency",
+        "cost/run",
+    ]
+    rows = []
+    ranked = sorted(entries, key=lambda e: (-(e.f1_pattern or 0.0), -(e.hit_rate_1r or 0.0)))
+    for e in ranked:
+        err_class = " class='err'" if e.error else ""
+        rows.append(
+            f"<tr{err_class}>"
+            f"<td>{html.escape(e.analyst_name)}</td>"
+            f"<td>{e.samples}</td>"
+            f"<td>{_pct(e.f1_pattern)}</td>"
+            f"<td>{_pct(e.pattern_precision)}</td>"
+            f"<td>{_pct(e.pattern_recall)}</td>"
+            f"<td>{_pct(e.side_accuracy)}</td>"
+            f"<td>{_pct(e.hit_rate_1r)}</td>"
+            f"<td>{e.expected_r_mean:.2f}</td>"
+            f"<td>{e.avg_latency_ms:.1f} ms</td>"
+            f"<td>${e.cost_per_run_usd:.5f}</td>"
+            "</tr>"
+        )
+    body = "<thead><tr>" + "".join(f"<th>{h}</th>" for h in headers) + "</tr></thead>"
+    body += "<tbody>" + "\n".join(rows) + "</tbody>"
+    errs = [e for e in entries if e.error]
+    extra = ""
+    if errs:
+        extra = (
+            "<p class='muted'>errors: "
+            + ", ".join(f"{html.escape(e.analyst_name)} — {html.escape(e.error or '')}" for e in errs)
+            + "</p>"
+        )
+    return f"<h2>Overall</h2><table>{body}</table>{extra}"
+
+
+def _render_cost_table(entries: List[LeaderboardEntry]) -> str:
+    headers = ["analyst", "avg in tokens", "avg out tokens", "cache hit", "latency", "cost/run"]
+    rows = []
+    for e in sorted(entries, key=lambda e: e.cost_per_run_usd):
+        rows.append(
+            "<tr>"
+            f"<td>{html.escape(e.analyst_name)}</td>"
+            f"<td>{e.avg_input_tokens:.0f}</td>"
+            f"<td>{e.avg_output_tokens:.0f}</td>"
+            f"<td>{_pct(e.cache_hit_rate)}</td>"
+            f"<td>{e.avg_latency_ms:.1f} ms</td>"
+            f"<td>${e.cost_per_run_usd:.5f}</td>"
+            "</tr>"
+        )
+    body = "<thead><tr>" + "".join(f"<th>{h}</th>" for h in headers) + "</tr></thead>"
+    body += "<tbody>" + "\n".join(rows) + "</tbody>"
+    return f"<h2>Cost</h2><table>{body}</table>"
+
+
+def _render_bucket_section(
+    title: str,
+    dim: str,
+    entries: List[LeaderboardEntry],
+    getter: Callable[[LeaderboardEntry], Dict[str, Dict[str, float]]],
+) -> str:
+    values = sorted({v for e in entries for v in getter(e).keys()})
+    if not values:
+        return f"<h2>{html.escape(title)}</h2><p class='muted'>no data</p>"
+    header = "<tr><th>analyst</th>" + "".join(f"<th>{html.escape(v)}</th>" for v in values) + "</tr>"
+    rows = []
+    for e in entries:
+        cells = []
+        bd = getter(e)
+        for v in values:
+            m = bd.get(v)
+            if m is None:
+                cells.append("<td>—</td>")
+            else:
+                cells.append(f"<td>{_pct(m.get('pattern_f1', 0.0))}</td>")
+        rows.append(f"<tr><td>{html.escape(e.analyst_name)}</td>{''.join(cells)}</tr>")
+    body = f"<thead>{header}</thead><tbody>{''.join(rows)}</tbody>"
+    return f"<h2>{html.escape(title)} — F1 by bucket</h2><table>{body}</table>"
+
+
+def _render_pareto(entries: List[LeaderboardEntry]) -> str:
+    """Scatter plot of F1 vs cost-per-run; base64 PNG inline."""
+    points = [(e.cost_per_run_usd, e.f1_pattern, e.analyst_name) for e in entries if e.error is None]
+    if not points:
+        return ""
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except Exception as exc:  # pragma: no cover - matplotlib is a hard dep, but don't break HTML
+        logger.warning("leaderboard: matplotlib unavailable (%s), skipping Pareto chart", exc)
+        return ""
+
+    fig, ax = plt.subplots(figsize=(7.2, 4.2))
+    xs = [p[0] for p in points]
+    ys = [p[1] for p in points]
+    ax.scatter(xs, ys, s=60, c="#2b6cb0", edgecolors="#1a365d")
+    for x, y, name in points:
+        ax.annotate(name, (x, y), textcoords="offset points", xytext=(6, 4), fontsize=8)
+    ax.set_xlabel("Cost per run (USD)")
+    ax.set_ylabel("Pattern F1")
+    ax.set_title("Quality / Cost Pareto")
+    ax.grid(True, linestyle="--", alpha=0.4)
+    if any(x > 0 for x in xs):
+        ax.set_xscale("symlog", linthresh=max(1e-6, min(x for x in xs if x > 0) / 2))
+
+    buf = io.BytesIO()
+    fig.tight_layout()
+    fig.savefig(buf, format="png", dpi=140)
+    plt.close(fig)
+    b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+    return (
+        f"<h2>Pareto (quality vs cost)</h2><p class='pareto'><img src='data:image/png;base64,{b64}' alt='pareto'></p>"
+    )
+
+
+def _pct(x: Optional[float]) -> str:
+    if x is None or (isinstance(x, float) and math.isnan(x)):
+        return "—"
+    return f"{x * 100:.1f}%"

--- a/src/tasks/brooks_leaderboard_task.py
+++ b/src/tasks/brooks_leaderboard_task.py
@@ -1,0 +1,117 @@
+"""Weekly cross-model leaderboard Celery task.
+
+Runs every Monday 03:00 UTC by default (see the beat schedule in
+``src.tasks.celery_app``). Each run scores every analyst in the YAML
+config against the golden dataset, writes an HTML report under the
+config's ``output_dir``, and appends one parquet row per analyst to
+the history log for trend queries.
+
+LLM/VLM providers are resolved from model ids via
+``_real_provider_factory``. The task never falls back to the mock
+provider silently — callers that need offline runs should use
+``scripts/brooks_leaderboard.py --mock-llm`` instead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from loguru import logger
+
+from src.brooks.eval.golden import GoldenDataset
+from src.brooks.eval.leaderboard import (
+    AnalystFactory,
+    Leaderboard,
+    LeaderboardConfig,
+)
+from src.tasks.celery_app import app
+
+__all__ = ["run_weekly_leaderboard"]
+
+
+DEFAULT_CONFIG_PATH = Path("config/brooks/leaderboard.yaml")
+
+
+def _provider_factory():
+    def factory(model: str):
+        m = model.lower()
+        if m.startswith("claude"):
+            from src.alpha.llm.providers.anthropic import AnthropicProvider
+
+            return AnthropicProvider(model=model)
+        if m.startswith("gpt"):
+            from src.alpha.llm.providers.openai import OpenAIProvider
+
+            return OpenAIProvider(model=model)
+        if m.startswith("gemini"):
+            from src.alpha.llm.providers.gemini import GeminiProvider
+
+            return GeminiProvider(model=model)
+        raise ValueError(f"no provider mapping for model id: {model!r}")
+
+    return factory
+
+
+async def _execute(config_path: Path, output_override: Optional[Path]) -> Dict[str, Any]:
+    cfg = LeaderboardConfig.load(config_path)
+    dataset = GoldenDataset.load(cfg.dataset)
+    if len(dataset) == 0:
+        raise RuntimeError(f"leaderboard dataset is empty: {cfg.dataset}")
+
+    factory = AnalystFactory(provider_factory=_provider_factory())
+    board = Leaderboard(cfg, factory=factory)
+    entries = await board.run_all(dataset)
+
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    out_path = output_override or (cfg.output_dir / f"{ts}.html")
+    board.to_html(out_path)
+    history_path = board.persist()
+
+    return {
+        "status": "ok",
+        "analysts": len(entries),
+        "errors": [e.analyst_name for e in entries if e.error],
+        "samples": entries[0].samples if entries else 0,
+        "html": str(out_path),
+        "history": str(history_path),
+        "run_at": ts,
+    }
+
+
+@app.task(
+    name="src.tasks.brooks_leaderboard_task.run_weekly_leaderboard",
+    bind=True,
+    soft_time_limit=3600,
+    time_limit=5400,
+    autoretry_for=(ConnectionError, TimeoutError),
+    retry_backoff=True,
+    retry_backoff_max=600,
+    retry_jitter=True,
+    max_retries=2,
+)
+def run_weekly_leaderboard(
+    self,
+    config_path: Optional[str] = None,
+    output_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Entry point for the weekly cron.
+
+    Parameters
+    ----------
+    config_path:
+        Override for ``config/brooks/leaderboard.yaml``.
+    output_path:
+        Override for the HTML output path. When absent, defaults to
+        ``<cfg.output_dir>/<timestamp>.html``.
+    """
+    cfg_path = Path(config_path) if config_path else DEFAULT_CONFIG_PATH
+    out_path = Path(output_path) if output_path else None
+    logger.info("brooks_leaderboard: start config={} output={}", cfg_path, out_path)
+    try:
+        return asyncio.run(_execute(cfg_path, out_path))
+    except Exception as exc:
+        logger.exception("brooks_leaderboard: failed: {}", exc)
+        raise

--- a/src/tasks/celery_app.py
+++ b/src/tasks/celery_app.py
@@ -51,6 +51,7 @@ app.conf.update(
         "src.tasks.crypto_tasks.*": {"queue": "automation"},
         "src.tasks.alpha_dlq.*": {"queue": "alpha_dlq"},
         "src.tasks.brooks_live_task.*": {"queue": "automation"},
+        "src.tasks.brooks_leaderboard_task.*": {"queue": "automation"},
     },
     # Queues
     task_queues=(
@@ -71,6 +72,12 @@ app.conf.update(
             "schedule": crontab(hour=23, minute=55),
             "options": {"queue": "automation"},
         },
+        "brooks-leaderboard-weekly": {
+            "task": "src.tasks.brooks_leaderboard_task.run_weekly_leaderboard",
+            # Weekly on Monday 03:00 UTC — matches leaderboard.yaml `schedule`.
+            "schedule": crontab(hour=3, minute=0, day_of_week="mon"),
+            "options": {"queue": "automation"},
+        },
     },
     # Explicit imports for task discovery
     imports=[
@@ -80,6 +87,7 @@ app.conf.update(
         "src.tasks.crypto_tasks",
         "src.tasks.alpha_dlq",
         "src.tasks.brooks_live_task",
+        "src.tasks.brooks_leaderboard_task",
     ],
 )
 

--- a/tests/brooks/test_leaderboard.py
+++ b/tests/brooks/test_leaderboard.py
@@ -1,0 +1,525 @@
+"""Tests for the cross-model leaderboard (Phase 4.5)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, List, Optional
+
+import pandas as pd
+import pytest
+
+from src.alpha.llm.cache import CacheSpec
+from src.alpha.llm.provider import Message, Response, Usage
+from src.brooks.analyst.base import Analyst, AnalystRegistry
+from src.brooks.context import Bar, BrooksContext
+from src.brooks.eval.golden import GoldenDataset, GoldenSample
+from src.brooks.eval.leaderboard import (
+    AnalystFactory,
+    AnalystSpec,
+    Leaderboard,
+    LeaderboardConfig,
+    _cost_per_run,
+)
+from src.brooks.prompts import PromptBundle
+from src.brooks.schema import Signal
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _bar(i: int, close: float = 100.0) -> Bar:
+    return Bar(
+        timestamp_ns=1_700_000_000_000_000_000 + i * 60_000_000_000,
+        open=close,
+        high=close + 0.5,
+        low=close - 0.5,
+        close=close,
+        volume=1.0,
+    )
+
+
+def _sample(
+    sample_id: str,
+    *,
+    regime: str = "weak_bull_trend",
+    expected_pattern: str = "h2",
+    entry: float = 100.0,
+    stop: float = 99.0,
+    future_hit_2r: bool = False,
+) -> GoldenSample:
+    ctx = [_bar(i) for i in range(5)]
+    if future_hit_2r:
+        future = [_bar(5, close=100.2), _bar(6, close=102.5)]
+    else:
+        future = [_bar(5, close=100.2), _bar(6, close=100.4)]
+    future = [
+        Bar(
+            timestamp_ns=b.timestamp_ns,
+            open=b.open,
+            high=(102.5 if i == 1 and future_hit_2r else b.close + 0.3),
+            low=b.low,
+            close=b.close,
+            volume=b.volume,
+        )
+        for i, b in enumerate(future)
+    ]
+    return GoldenSample(
+        id=sample_id,
+        symbol=sample_id,
+        interval="5m",
+        bars=ctx + future,
+        target_bar_idx=4,
+        expected_pattern=expected_pattern,
+        expected_side="long",
+        expected_entry=entry,
+        expected_stop=stop,
+        expected_target=102.0,
+        regime=regime,
+        htf_aligned=True,
+        source="human",
+    )
+
+
+@pytest.fixture
+def small_dataset() -> GoldenDataset:
+    return GoldenDataset.from_samples(
+        [
+            _sample("one", regime="weak_bull_trend", future_hit_2r=True),
+            _sample("two", regime="strong_bull_trend", future_hit_2r=True),
+            _sample("three", regime="weak_bull_trend", expected_pattern="wedge"),
+        ]
+    )
+
+
+@pytest.fixture
+def stub_prompts() -> PromptBundle:
+    return PromptBundle(
+        system_text="SYSTEM",
+        concept_manual="MANUAL",
+        fewshot=[],
+        schema_description="SCHEMA",
+    )
+
+
+@dataclass
+class _RecordingMockProvider:
+    """In-process Provider that returns a deterministic ``LLMSignalBatch``."""
+
+    model: str = "mock-model"
+    signals: List[Signal] = field(default_factory=list)
+    usage: Usage = field(default_factory=lambda: Usage(input_tokens=80, output_tokens=30))
+    latency_ms: float = 9.0
+    name: str = "mock"
+    cache_hit: bool = False
+    call_count: int = 0
+
+    async def complete(
+        self,
+        messages: list[Message],
+        schema: type,
+        cache: Optional[CacheSpec] = None,
+        seed: Optional[int] = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.0,
+    ) -> Response[Any]:
+        self.call_count += 1
+        parsed = schema(reasoning="r", signals=list(self.signals))
+        return Response(
+            parsed=parsed,
+            raw={"mock": True},
+            usage=self.usage,
+            latency_ms=self.latency_ms,
+            model=self.model,
+            cache_hit=self.cache_hit,
+        )
+
+
+def _mock_signal() -> Signal:
+    return Signal(
+        pattern="h2",
+        side="long",
+        signal_bar_idx=4,
+        entry_px=100.0,
+        stop_px=99.0,
+        target_px=102.0,
+        probability=0.55,
+        quality=0.6,
+        source="llm:placeholder",
+    )
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# LeaderboardConfig loading
+# ---------------------------------------------------------------------------
+
+
+def test_config_from_dict_parses_analyst_list(tmp_path):
+    raw = {
+        "dataset": str(tmp_path / "ds.parquet"),
+        "analysts": [
+            {"type": "rule"},
+            {"type": "llm", "model": "claude-opus-4-7"},
+            {"type": "ensemble.critic", "producer": "rule", "critic": "llm:claude-sonnet-4-6"},
+        ],
+        "output_dir": str(tmp_path / "out"),
+        "history_path": str(tmp_path / "hist.parquet"),
+        "max_concurrent": 2,
+    }
+    cfg = LeaderboardConfig.from_dict(raw)
+    assert cfg.dataset == Path(str(tmp_path / "ds.parquet"))
+    assert cfg.output_dir == Path(str(tmp_path / "out"))
+    assert cfg.max_concurrent == 2
+    assert [a.type for a in cfg.analysts] == ["rule", "llm", "ensemble.critic"]
+    critic_spec = cfg.analysts[2]
+    assert critic_spec.params["producer"] == "rule"
+    assert critic_spec.params["critic"] == "llm:claude-sonnet-4-6"
+
+
+def test_config_raises_when_dataset_missing():
+    with pytest.raises(ValueError):
+        LeaderboardConfig.from_dict({"analysts": [{"type": "rule"}]})
+
+
+def test_config_raises_when_no_analysts():
+    with pytest.raises(ValueError):
+        LeaderboardConfig.from_dict({"dataset": "x", "analysts": []})
+
+
+def test_config_load_reads_yaml_file(tmp_path):
+    yaml_text = "dataset: data/ds.parquet\nanalysts:\n  - {type: rule}\n  - {type: llm, model: claude-opus-4-7}\n"
+    p = tmp_path / "leaderboard.yaml"
+    p.write_text(yaml_text)
+    cfg = LeaderboardConfig.load(p)
+    assert len(cfg.analysts) == 2
+    assert cfg.analysts[1].model == "claude-opus-4-7"
+
+
+# ---------------------------------------------------------------------------
+# AnalystFactory
+# ---------------------------------------------------------------------------
+
+
+def test_factory_builds_rule_analyst():
+    factory = AnalystFactory()
+    analyst = factory.build(AnalystSpec(type="rule"))
+    assert analyst.name == "rule"
+
+
+def test_factory_builds_llm_analyst_via_provider_factory(stub_prompts):
+    created: List[str] = []
+
+    def provider_factory(model: str):
+        created.append(model)
+        return _RecordingMockProvider(model=model)
+
+    factory = AnalystFactory(provider_factory=provider_factory)
+    spec = AnalystSpec(type="llm", model="claude-opus-4-7", params={"prompts": stub_prompts})
+    analyst = factory.build(spec)
+    assert analyst.name == "llm:claude-opus-4-7"
+    assert created == ["claude-opus-4-7"]
+
+
+def test_factory_llm_without_provider_factory_raises():
+    factory = AnalystFactory()
+    with pytest.raises(RuntimeError):
+        factory.build(AnalystSpec(type="llm", model="claude-opus-4-7"))
+
+
+def test_factory_builds_ensemble_critic(stub_prompts):
+    def provider_factory(model: str):
+        return _RecordingMockProvider(model=model)
+
+    factory = AnalystFactory(provider_factory=provider_factory)
+    spec = AnalystSpec(
+        type="ensemble.critic",
+        params={
+            "producer": "rule",
+            "critic": {"type": "llm", "model": "claude-sonnet-4-6", "prompts": stub_prompts},
+        },
+    )
+    analyst = factory.build(spec)
+    assert analyst.name == "ensemble.critic"
+
+
+def test_factory_vlm_without_registration_raises():
+    # VLM analyst isn't registered in this codebase yet (Phase 4.3 dep).
+    # The factory should surface that clearly rather than silently fall back.
+    assert "vlm" not in AnalystRegistry.all()
+
+    def pf(_m):
+        return _RecordingMockProvider()
+
+    factory = AnalystFactory(provider_factory=pf)
+    with pytest.raises(KeyError):
+        factory.build(AnalystSpec(type="vlm", model="gemini-2.5-pro"))
+
+
+def test_factory_unknown_type_raises():
+    factory = AnalystFactory()
+    with pytest.raises(ValueError):
+        factory.build(AnalystSpec(type="quantum-magic"))
+
+
+# ---------------------------------------------------------------------------
+# Fixed analyst for deterministic Leaderboard runs
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FixedAnalyst:
+    name: str
+    output: List[Signal]
+
+    async def analyze(self, ctx: BrooksContext) -> List[Signal]:
+        return list(self.output)
+
+
+class _FixedFactory(AnalystFactory):
+    """Bypass registry — map AnalystSpec by ``display_name`` to a fixed analyst."""
+
+    def __init__(self, mapping: dict[str, Analyst]) -> None:
+        super().__init__()
+        self._mapping = mapping
+
+    def build(self, spec: AnalystSpec) -> Analyst:
+        key = spec.display_name()
+        if key not in self._mapping:
+            raise KeyError(f"no fixed analyst for {key}")
+        return self._mapping[key]
+
+
+# ---------------------------------------------------------------------------
+# Leaderboard.run_all / metrics
+# ---------------------------------------------------------------------------
+
+
+def test_run_all_produces_entries_per_analyst(small_dataset):
+    cfg = LeaderboardConfig(
+        dataset=Path("unused"),
+        analysts=[
+            AnalystSpec(type="rule", label="A"),
+            AnalystSpec(type="llm", model="mock-m", label="B"),
+        ],
+    )
+    fixed = _FixedFactory(
+        {
+            "A": _FixedAnalyst(name="A", output=[_mock_signal()]),
+            "B": _FixedAnalyst(name="B", output=[]),
+        }
+    )
+    board = Leaderboard(cfg, factory=fixed)
+
+    entries = _run(board.run_all(small_dataset))
+    assert len(entries) == 2
+    by_name = {e.analyst_name: e for e in entries}
+    assert by_name["A"].samples == len(small_dataset)
+    assert by_name["A"].f1_pattern > 0  # at least one pattern match
+    assert by_name["B"].f1_pattern == 0  # analyst emits nothing
+    # regime bucket key must be populated from the dataset
+    assert "weak_bull_trend" in by_name["A"].by_regime
+    assert "strong_bull_trend" in by_name["A"].by_regime
+
+
+def test_run_all_captures_build_errors_without_aborting(small_dataset):
+    cfg = LeaderboardConfig(
+        dataset=Path("unused"),
+        analysts=[
+            AnalystSpec(type="rule", label="A"),
+            AnalystSpec(type="llm", model="needs-provider", label="missing"),
+        ],
+    )
+    fixed = _FixedFactory({"A": _FixedAnalyst(name="A", output=[])})
+    # "missing" is not in the fixed map → raises KeyError → recorded as error.
+    board = Leaderboard(cfg, factory=fixed)
+
+    entries = _run(board.run_all(small_dataset))
+    assert len(entries) == 2
+    err_entry = next(e for e in entries if e.analyst_name == "missing")
+    assert err_entry.error is not None
+    assert err_entry.f1_pattern == 0.0
+
+
+def test_run_all_empty_dataset_raises():
+    cfg = LeaderboardConfig(
+        dataset=Path("unused"),
+        analysts=[AnalystSpec(type="rule", label="only")],
+    )
+    board = Leaderboard(cfg, factory=_FixedFactory({"only": _FixedAnalyst(name="only", output=[])}))
+    with pytest.raises(ValueError):
+        _run(board.run_all(GoldenDataset.from_samples([])))
+
+
+# ---------------------------------------------------------------------------
+# Cost calculation
+# ---------------------------------------------------------------------------
+
+
+def test_cost_per_run_uses_model_rates():
+    table = {"claude-opus-4-7": {"input": 15.0, "output": 75.0}}
+    # 1000 input + 500 output → 1000/1e6 * 15 + 500/1e6 * 75 = 0.015 + 0.0375 = 0.0525
+    cost = _cost_per_run("claude-opus-4-7", 1000, 500, table)
+    assert cost == pytest.approx(0.0525)
+
+
+def test_cost_per_run_unknown_model_returns_zero():
+    assert _cost_per_run("unknown-model", 1000, 500, {}) == 0.0
+
+
+def test_entry_includes_cost_for_known_model(small_dataset, stub_prompts):
+    from src.brooks.analyst.llm import LLMAnalyst
+
+    provider = _RecordingMockProvider(model="claude-opus-4-7")
+    analyst = LLMAnalyst(provider=provider, model="claude-opus-4-7", prompts=stub_prompts)
+    # Wire the LLMAnalyst to emit a matching signal so pattern_match is True.
+    # We override via a thin wrapper so the MockProvider's token usage drives
+    # the cost calculation.
+    provider.signals = [_mock_signal()]
+
+    cfg = LeaderboardConfig(
+        dataset=Path("unused"),
+        analysts=[AnalystSpec(type="llm", model="claude-opus-4-7")],
+    )
+    fixed = _FixedFactory({"llm:claude-opus-4-7": analyst})
+    board = Leaderboard(cfg, factory=fixed)
+    entries = _run(board.run_all(small_dataset))
+    entry = entries[0]
+    # avg_input_tokens should be set; cost > 0 because the default table knows the model.
+    assert entry.avg_input_tokens > 0
+    assert entry.cost_per_run_usd > 0
+
+
+# ---------------------------------------------------------------------------
+# HTML rendering
+# ---------------------------------------------------------------------------
+
+
+def test_to_html_writes_self_contained_document(small_dataset, tmp_path):
+    cfg = LeaderboardConfig(
+        dataset=Path("unused"),
+        analysts=[AnalystSpec(type="rule", label="A")],
+    )
+    board = Leaderboard(cfg, factory=_FixedFactory({"A": _FixedAnalyst(name="A", output=[_mock_signal()])}))
+    _run(board.run_all(small_dataset))
+
+    out = tmp_path / "lb.html"
+    doc = board.to_html(out)
+    assert out.exists()
+    assert "<html" in doc
+    assert "Brooks Leaderboard" in doc
+    assert "By regime" in doc or "regime" in doc.lower()
+
+
+def test_to_html_before_run_raises():
+    cfg = LeaderboardConfig(dataset=Path("x"), analysts=[AnalystSpec(type="rule")])
+    board = Leaderboard(cfg)
+    with pytest.raises(ValueError):
+        board.to_html()
+
+
+# ---------------------------------------------------------------------------
+# Persistence / history
+# ---------------------------------------------------------------------------
+
+
+def test_persist_appends_and_load_history_reads_rows(small_dataset, tmp_path):
+    cfg = LeaderboardConfig(
+        dataset=Path("unused"),
+        analysts=[AnalystSpec(type="rule", label="A"), AnalystSpec(type="rule", label="B")],
+        history_path=tmp_path / "hist.parquet",
+    )
+    factory = _FixedFactory(
+        {
+            "A": _FixedAnalyst(name="A", output=[_mock_signal()]),
+            "B": _FixedAnalyst(name="B", output=[]),
+        }
+    )
+
+    # First run → creates the file with two rows
+    board1 = Leaderboard(cfg, factory=factory)
+    _run(board1.run_all(small_dataset))
+    path = board1.persist()
+    assert path.exists()
+
+    df = Leaderboard.load_history(path)
+    assert len(df) == 2
+    assert set(df["analyst_name"]) == {"A", "B"}
+
+    # Second run → appends another two rows
+    board2 = Leaderboard(cfg, factory=factory)
+    _run(board2.run_all(small_dataset))
+    board2.persist()
+    df2 = Leaderboard.load_history(path)
+    assert len(df2) == 4
+
+
+def test_persist_before_run_raises(tmp_path):
+    cfg = LeaderboardConfig(
+        dataset=Path("unused"),
+        analysts=[AnalystSpec(type="rule")],
+        history_path=tmp_path / "hist.parquet",
+    )
+    board = Leaderboard(cfg)
+    with pytest.raises(ValueError):
+        board.persist()
+
+
+def test_load_history_missing_file_returns_empty(tmp_path):
+    df = Leaderboard.load_history(tmp_path / "does-not-exist.parquet")
+    assert isinstance(df, pd.DataFrame)
+    assert df.empty
+
+
+def test_entry_to_row_encodes_buckets_as_json_strings(small_dataset):
+    cfg = LeaderboardConfig(
+        dataset=Path("unused"),
+        analysts=[AnalystSpec(type="rule", label="A")],
+    )
+    factory = _FixedFactory({"A": _FixedAnalyst(name="A", output=[_mock_signal()])})
+    board = Leaderboard(cfg, factory=factory)
+    entry = _run(board.run_all(small_dataset))[0]
+    row = entry.to_row()
+    # Buckets must be JSON strings so parquet can store them as scalars.
+    assert isinstance(row["by_regime"], str)
+    parsed = json.loads(row["by_regime"])
+    assert "weak_bull_trend" in parsed
+    assert isinstance(row["run_at"], str)  # datetime.isoformat()
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke test (mock-llm path)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_mock_llm_runs_end_to_end(tmp_path, small_dataset):
+    """Smoke test for ``scripts/brooks_leaderboard.py --mock-llm``.
+
+    Uses a rule analyst (no provider needed) to keep the test self-contained
+    while still exercising the config loader + HTML writer + persistence.
+    """
+    dataset_path = tmp_path / "ds.parquet"
+    small_dataset.save(dataset_path)
+
+    cfg_path = tmp_path / "leaderboard.yaml"
+    cfg_path.write_text(
+        "dataset: {ds}\nanalysts:\n  - {{type: rule}}\noutput_dir: {out}\nhistory_path: {hist}\n".format(
+            ds=dataset_path,
+            out=tmp_path / "out",
+            hist=tmp_path / "hist.parquet",
+        )
+    )
+
+    from scripts.brooks_leaderboard import main  # type: ignore
+
+    out_html = tmp_path / "run.html"
+    rc = main(["--config", str(cfg_path), "--output", str(out_html), "--mock-llm"])
+    assert rc == 0
+    assert out_html.exists()
+    assert (tmp_path / "hist.parquet").exists()


### PR DESCRIPTION
## Summary
- New `src/brooks/eval/leaderboard.py` — `Leaderboard` / `LeaderboardEntry` / `LeaderboardConfig` / `AnalystFactory` that reuse `EvalRunner` + `EvalReport` to score every configured analyst (rule / LLM / VLM / ensemble.*) against the golden dataset and render a side-by-side HTML report.
- `config/brooks/leaderboard.yaml` — candidate analyst list (adding a new model is a one-line change).
- `scripts/brooks_leaderboard.py` — CLI entry with `--mock-llm` for offline / CI runs.
- `src/tasks/brooks_leaderboard_task.py` — Celery task on the `automation` queue; beat schedule wired in `celery_app.py` for every Monday 03:00 UTC.
- History is persisted as an append-only parquet so trends can be queried; Pareto chart (quality vs cost-per-run) is embedded in the HTML as a base64 PNG.
- 23 new tests in `tests/brooks/test_leaderboard.py` cover config loading, factory branches, run_all metrics, error capture, persistence round-trip, HTML rendering, and a CLI smoke test.

## Test plan
- [x] `uv run pytest tests/brooks/test_leaderboard.py` — 23 passed
- [x] `uv run pytest tests/brooks/test_eval_runner.py tests/brooks/test_eval_report.py tests/brooks/test_analyst_*.py` — 68 passed (no regressions)
- [x] CLI smoke: `scripts/brooks_leaderboard.py --config ... --mock-llm` writes HTML + appends parquet row
- [x] `from src.tasks.celery_app import app; import src.tasks.brooks_leaderboard_task` shows the task is registered and routed to the `automation` queue with the `brooks-leaderboard-weekly` beat entry

Closes QUA-56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)