### PR TITLE
docs(brooks): sync V2 architecture — README + usage guide (QUA-58)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ make clean_all                         # Remove .pth, runs/, .log files
 2. **Alpha Search** (`src/alpha/`): Multi-market (crypto futures, A-shares) DSL compiler → StackVM bytecode → vectorized evaluation. Market profiles (`MarketType`/`MarketProfile`) configure schema, data loader, field aliases, and LLM persona per market. Strategies: LLM evolution, LLM-guided MCTS (paper: "Navigating the Alpha Jungle"), neural formula (Transformer+REINFORCE), enumeration.
 3. **Market Data** (`src/market_data/`): Multi-source pipeline (Akshare, Baostock, TDX, CCXT/Binance). ClickHouse storage with chunked loading.
 4. **Task Queue** (`src/tasks/`): Celery queues - `backtest`, `default`, `automation`. Redis broker.
+5. **Brooks Strategy Pipeline** (`src/brooks/`): Multi-analyst Brooks price-action framework. Plug-in analyst layer (`rule` / `llm` / `vlm` / `ensemble.{vote,router,critic}`) → unified `Signal` → aggregator → Trader's Equation + EV gate → risk layer (Kelly/Fixed sizer, stop ladder, time stop, portfolio guard) → `BrooksStrategy` (registered as `"brooks"`). Includes eval pipeline (`GoldenDataset` / `EvalRunner` / `Leaderboard`) and paper-trading runner (`src/tasks/brooks_live_task.py`, UI panel at `/brooks-live`). See [docs/brooks/README.md](docs/brooks/README.md) and [docs/brooks/usage.md](docs/brooks/usage.md).
 
 ## Configuration
 
@@ -168,3 +169,4 @@ See [docs/README.md](docs/README.md) for detailed documentation:
 - [Data Pipeline](docs/data-pipeline.md) - Market data sources and storage
 - [Frontend](docs/frontend.md) - React components and state management
 - [Development](docs/development.md) - Setup, testing, deployment
+- [Brooks Price-Action Platform](docs/brooks/README.md) - Multi-analyst Brooks strategy pipeline ([usage recipes](docs/brooks/usage.md))

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,12 @@ Quent is an AI-powered quantitative trading platform for crypto and A-share mark
 | [Data Pipeline](data-pipeline.md) | Market data sources, processors, ClickHouse storage |
 | [Frontend](frontend.md) | React UI architecture, components, state management |
 | [Development](development.md) | Local setup, testing, Docker deployment, configuration |
+| [Brooks Price-Action Platform](brooks/README.md) | Multi-analyst (rule / LLM / VLM / ensemble) Brooks strategy pipeline, eval, leaderboard, paper trading |
+
+### Brooks subdocs
+
+- [Usage recipes](brooks/usage.md) - Eight runnable end-to-end recipes (rule / LLM / VLM / ensemble / leaderboard / paper trading / auto-label)
+- [Taxonomy](brooks/taxonomy.yaml) - Bar / pattern / regime single source of truth
 
 ## Quick Links
 

--- a/docs/brooks/README.md
+++ b/docs/brooks/README.md
@@ -1,30 +1,615 @@
-# Brooks Price-Action Architecture
+# Brooks Price-Action Platform
 
-The `src/brooks/` package houses the full Brooks-style trading pipeline —
-features → structure → regime → patterns → analyst → aggregator → Trader's
-Equation → EV gate → risk layer — behind a single public strategy,
-`BrooksStrategy`, registered as `"brooks"` in `StrategyRegistry`.
+Multi-analyst Brooks-style trading framework — pluggable rule / LLM / VLM /
+ensemble analysts feed a unified `Signal` schema into an aggregator → Trader's
+Equation → EV gate → risk layer → execution pipeline. Single public entry
+point: `BrooksStrategy`, registered as `"brooks"` in `StrategyRegistry`.
+
+## Overview
+
+```
+                                    ┌────────────────┐
+bar ─► features ─► structure ─► regime ─► BrooksContext (LTF + HTF snapshots)
+                                                │
+                                                ▼
+                                      ┌─────────────────┐
+                                      │   Analyst       │  rule / llm / vlm
+                                      │  .analyze(ctx)  │  ensemble.{vote,
+                                      └────────┬────────┘  router, critic}
+                                               │
+                                               ▼  list[Signal]
+                                  ┌────────────────────────┐
+                                  │  SignalAggregator      │  confluence_n
+                                  │  → AggregatedDecision  │  conservative entry/stop
+                                  └────────────┬───────────┘
+                                               │
+                                               ▼
+                                  ┌────────────────────────┐
+                                  │  TraderEquation +      │  HitRateTable bucket
+                                  │  EVGate.filter(...)    │  HTF prob multiplier
+                                  └────────────┬───────────┘
+                                               │
+                                               ▼  list[Decision]
+                                  ┌────────────────────────┐
+                                  │  Sizer + StopLadder +  │  Kelly / Fixed / BE-ladder
+                                  │  TimeStop +            │  N-bar invalidation
+                                  │  PortfolioGuard        │  daily-risk / corr cap
+                                  └────────────┬───────────┘
+                                               │
+                                               ▼
+                                       broker stop-entry → fill → manage
+```
+
+Source-of-truth files:
+
+| Concept | File |
+|---------|------|
+| Strategy orchestrator | `src/brooks/strategy.py` |
+| Analyst input        | `src/brooks/context.py` (`BrooksContext`, `TFSnapshot`) |
+| Schemas              | `src/brooks/schema.py` (`Signal`, `Decision`, `Order`) |
+| Pattern detectors    | `src/brooks/patterns/` |
+| Analyst plug-ins     | `src/brooks/analyst/` (`base`, `rule`, `llm`, `vlm`, `ensemble`) |
+| Context renderers    | `src/brooks/render/text.py`, `src/brooks/render/chart.py` |
+| Decision pipeline    | `src/brooks/decision/` (`aggregator`, `trader_equation`, `ev_gate`, `hit_rate`) |
+| Risk layer           | `src/brooks/risk/` (`sizer`, `stop_ladder`, `time_stop`, `portfolio_guard`) |
+| Eval pipeline        | `src/brooks/eval/` (`golden`, `auto_label`, `runner`, `report`, `leaderboard`) |
+| Prompts              | `src/brooks/prompts.py` + `prompts/brooks/` |
+| Live (paper) runner  | `src/tasks/brooks_live_task.py` |
+| Leaderboard task     | `src/tasks/brooks_leaderboard_task.py` |
+| Configs              | `config/brooks/{ensemble_router,leaderboard}.yaml`, `config/llm/registry.yaml` |
+| Taxonomy             | `docs/brooks/taxonomy.yaml` (single source of truth for bar/pattern/regime vocab) |
+
+## Quick Start
+
+Minimum runnable backtest, rule analyst:
+
+```python
+from src.brooks.strategy import BrooksStrategy
+
+strategy = BrooksStrategy(
+    analyst="rule",
+    aggregator_params={"confluence_n": 1},
+    sizer_params={"kind": "kelly"},
+    portfolio_params={"max_daily_risk_pct": 0.03},
+    base_interval="5m",
+    mtf_intervals=["1h"],
+)
+# Plug `strategy` into the standard backtest engine — it implements the
+# Strategy ABC from src/core/base.py and auto-registers under name "brooks".
+```
+
+Switch analyst by changing one argument:
+
+```python
+# Pure rule baseline
+BrooksStrategy(analyst="rule")
+
+# LLM analyst (Anthropic Opus 4.7)
+from src.alpha.llm.providers.anthropic import AnthropicProvider
+
+BrooksStrategy(
+    analyst="llm",
+    analyst_params={
+        "provider": AnthropicProvider(model="claude-opus-4-7"),
+        "model": "claude-opus-4-7",
+    },
+)
+
+# VLM analyst (Gemini 2.5 Pro on rendered chart PNG)
+from src.alpha.llm.providers.gemini import GeminiProvider
+
+BrooksStrategy(
+    analyst="vlm",
+    analyst_params={
+        "provider": GeminiProvider(model="gemini-2.5-pro"),
+        "model": "gemini-2.5-pro",
+    },
+)
+
+# Ensemble — rule produces, LLM critiques (see ensemble.critic below)
+from src.brooks.analyst.base import AnalystRegistry
+from src.brooks.analyst.ensemble import CriticAnalyst
+
+producer = AnalystRegistry.build("rule")
+critic = AnalystRegistry.build(
+    "llm",
+    provider=AnthropicProvider(model="claude-sonnet-4-6"),
+    model="claude-sonnet-4-6",
+)
+BrooksStrategy(
+    analyst="ensemble.critic",
+    analyst_params={"producer": producer, "critic": critic},
+)
+```
+
+Live paper trading is just the same strategy under a Celery task — see
+[Paper Trading](#paper-trading) below.
 
 ## Package Map
 
 | Layer | Module | Purpose |
 |-------|--------|---------|
-| L1 features | `src/brooks/features.py` | Streaming per-bar features + confirmed swings |
-| L2 structure | `src/brooks/structure.py` | Always-in, leg dir/length, micro-channel fits |
-| L3 regime | `src/brooks/regime.py` | 7-state Brooks regime classifier |
-| L3 patterns | `src/brooks/patterns/` | H1..H4 / L1..L4 / H2/L2 / doubles / wedges / micro-channel / MTR / BP / ii-iii / final-flag / measured-move |
-| L4 analyst | `src/brooks/analyst/` | `rule` + `llm:<model>` plug-ins (see below) |
-| L5 decision | `src/brooks/decision/` | Signal aggregator + Trader's Equation + EV gate + hit-rate table |
-| L6 risk | `src/brooks/risk/` | `KellySizer` / `FixedPercentSizer`, `StopLadder`, `TimeStop`, `PortfolioGuard` |
-| Strategy | `src/brooks/strategy.py` | `BrooksStrategy` orchestrator (Phase 3.5) |
-| Context | `src/brooks/context.py` | `BrooksContext` — single analyst input type |
+| L1 features  | `src/brooks/features.py`   | Streaming per-bar features + confirmed swings |
+| L2 structure | `src/brooks/structure.py`  | Always-in, leg dir/length, micro-channel fits |
+| L3 regime    | `src/brooks/regime.py`     | 7-state Brooks regime classifier |
+| L3 patterns  | `src/brooks/patterns/`     | H1..H4 / L1..L4 / H2/L2 / doubles / wedges / micro-channel / MTR / breakout-pullback / ii-iii / final-flag / measured-move |
+| L4 analyst   | `src/brooks/analyst/`      | `rule` / `llm` / `vlm` / `ensemble.{vote,router,critic}` plug-ins |
+| Render       | `src/brooks/render/`       | `text.py` (token-budgeted bar text), `chart.py` (deterministic OHLCV PNG) |
+| Prompts      | `src/brooks/prompts.py` + `prompts/brooks/` | `PromptBundle.load()` / `.load_vlm()` — system + concept manual + few-shot |
+| L5 decision  | `src/brooks/decision/`     | Aggregator + Trader's Equation + EV gate + HitRateTable |
+| L6 risk      | `src/brooks/risk/`         | `KellySizer` / `FixedPercentSizer`, `StopLadder`, `TimeStop`, `PortfolioGuard` |
+| Strategy     | `src/brooks/strategy.py`   | `BrooksStrategy` orchestrator |
+| Context      | `src/brooks/context.py`    | `BrooksContext`, `TFSnapshot`, `AccountSnapshot` |
+| Eval         | `src/brooks/eval/`         | `GoldenDataset`, `AutoLabeler`, `EvalRunner`, `EvalReport`, `Leaderboard` |
+| Tasks        | `src/tasks/brooks_live_task.py`, `src/tasks/brooks_leaderboard_task.py` | Paper-trading runner + weekly leaderboard cron |
+| API          | `src/api/brooks_router.py` | `/brooks-live` REST + WebSocket panel endpoints |
+| UI           | `ui/src/components/BrooksLive/` | Live paper-trading panel (route `/brooks-live`) |
+
+## Analyst Routes
+
+All analysts implement the same Protocol (`src/brooks/analyst/base.py`):
+
+```python
+class Analyst(Protocol):
+    name: str
+    async def analyze(self, ctx: BrooksContext) -> list[Signal]: ...
+```
+
+…and register themselves under a string key in `AnalystRegistry`. The
+strategy resolves the key with `AnalystRegistry.build(name, **params)`.
+Built-in keys: `"rule"`, `"llm"`, `"vlm"`, `"ensemble.vote"`,
+`"ensemble.router"`, `"ensemble.critic"`.
+
+### RuleAnalyst — `analyst="rule"`
+
+Zero LLM calls; runs every detector in `PatternRegistry` once per bar (or a
+filtered subset). Output `source` is `"rule:<detector_name>"`,
+`probability` and `quality` default to `0.5`.
+
+When to use: as a baseline, in regression suites, and as the deterministic
+producer in `ensemble.critic` / `ensemble.router`.
+
+```python
+from src.brooks.analyst.base import AnalystRegistry
+
+a = AnalystRegistry.build(
+    "rule",
+    detector_names=["h2", "l2"],            # default: every registered detector
+    params={"h2": {"max_leg_bars": 12}},     # forwarded to PatternRegistry.build
+    extractor_kwargs={"swing_k": 2, "atr_period": 5},
+    structure_kwargs={"breakout_lookback": 8},
+)
+```
+
+### LLMAnalyst — `analyst="llm"`
+
+Drives a `Provider` (`src.alpha.llm.provider.Provider`) with a versioned
+`PromptBundle` and parses the structured `LLMSignalBatch` response back into
+`Signal` records. Provider, prompts, max_tokens, and cache TTL are all
+injected — there are no hard-coded vendor SDK calls in the analyst itself.
+
+`PromptBundle.load()` reads:
+
+* `prompts/brooks/system_analyst.md` — analyst system prompt
+* `prompts/brooks/concept_manual.md` — Brooks vocabulary (cached as
+  `cache="concept_manual"`)
+* `prompts/brooks/fewshot/analyst_examples.jsonl` — few-shot transcript
+  (cached as `cache="fewshot"`)
+* JSON schema derived from `Decision` via Pydantic — **never** hand-written
+  in the prompt files
+
+Cache hit rate is reported via `Signal.meta["cache_hit"]` and aggregated by
+the eval pipeline.
+
+Supported model ids live in `config/llm/registry.yaml` — currently
+`claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5`, `gpt-4.1`,
+`gpt-4.1-mini`, `gemini-2.5-pro`, `gemini-2.5-flash`.
+
+```python
+from src.alpha.llm.providers.anthropic import AnthropicProvider
+from src.brooks.analyst.base import AnalystRegistry
+
+a = AnalystRegistry.build(
+    "llm",
+    provider=AnthropicProvider(model="claude-opus-4-7"),
+    model="claude-opus-4-7",
+    cache_ttl_seconds=3600,
+    max_tokens=4096,
+    temperature=0.0,
+    context_budget_tokens=2000,
+)
+# a.name == "llm:claude-opus-4-7"
+```
+
+### VLMAnalyst — `analyst="vlm"`
+
+Renders `ctx.primary` as a deterministic OHLCV PNG via
+`src/brooks/render/chart.py`, packs it as an `ImagePart` alongside a compact
+text summary, and asks a multimodal `Provider` for the same
+`LLMSignalBatch` schema (extended with chart `annotations` for re-overlay).
+
+When VLM beats LLM: chart-shape patterns the text prompt struggles with —
+wedges, broad ranges, micro-channels with subtle slope changes,
+breakout-mode transitions. The default `RouterAnalyst` config routes
+`breakout_mode` straight to VLM for that reason.
+
+```python
+from src.alpha.llm.providers.gemini import GeminiProvider
+from src.brooks.analyst.base import AnalystRegistry
+from src.brooks.render.chart import ChartStyle
+
+a = AnalystRegistry.build(
+    "vlm",
+    provider=GeminiProvider(model="gemini-2.5-pro"),
+    model="gemini-2.5-pro",
+    include_htf=True,
+    chart_style=ChartStyle(width=1280, height=720, show_volume=True),
+    context_budget_tokens=1000,    # smaller; chart carries most of the info
+)
+# a.name == "vlm:gemini-2.5-pro"
+```
+
+### Ensemble Analysts
+
+All three live in `src/brooks/analyst/ensemble.py` and wrap one or more
+sub-analysts.
+
+* **`ensemble.vote` (`VoteAnalyst`)** — fan out to N analysts concurrently
+  via `asyncio.gather`, cluster signals by `(pattern, side)` tolerating ±1
+  bar drift on `signal_bar_idx`, keep groups with at least
+  `min_agree_count` distinct voters. Numeric fields are weighted averages
+  (weights default to 1.0 per analyst).
+* **`ensemble.router` (`RouterAnalyst`)** — pick a single sub-analyst based
+  on `ctx.primary.regime.regime`. Each emitted signal is tagged with
+  `meta["routed_by"] = <regime.value>`. Default routes live in
+  `config/brooks/ensemble_router.yaml`:
+
+  ```yaml
+  default: rule
+  routes:
+    strong_bull_trend: rule
+    weak_bull_trend: rule
+    strong_bear_trend: rule
+    weak_bear_trend: rule
+    climax: rule
+    tight_trading_range: "llm:claude-opus-4-7"
+    broad_trading_range: "ensemble.critic"
+    breakout_mode: "vlm:gemini-2.5-pro"
+    unknown: rule
+  ```
+
+* **`ensemble.critic` (`CriticAnalyst`)** — producer/critic pipeline. The
+  producer's signals are stashed on `ctx.candidates`; the critic returns
+  one signal per candidate with `meta["confirms"] = candidate_idx` (or
+  `-1` to reject) plus an adjusted `probability`. Surviving candidates
+  inherit the critic's probability and reasoning under
+  `source="ensemble.critic"`.
+
+Construction goes through `AnalystRegistry.build` with the sub-analysts
+already built, or — for the leaderboard YAML path — through
+`AnalystFactory.build(spec)` which resolves nested specs like
+`"llm:claude-opus-4-7"` into proper analyst instances.
+
+## Signal & Decision Schema
+
+`src/brooks/schema.py` defines the contract every layer shares.
+
+```python
+class Signal(BaseModel):
+    pattern: str
+    side: Literal["long", "short"]
+    signal_bar_idx: int
+    entry_px: float            # gt=0
+    stop_px: float             # gt=0; must differ from entry_px
+    target_px: float | None
+    probability: float         # [0, 1]
+    quality: float             # [0, 1]
+    reasoning: str = ""
+    source: str
+    meta: dict = {}            # latency_ms / input_tokens / output_tokens / cache_hit / model / ...
+
+    @property
+    def one_r(self) -> float:  # |entry - stop|
+```
+
+```python
+class Decision(BaseModel):
+    symbol: str
+    side: Literal["long", "short"]
+    entry_px: float
+    stop_px: float
+    target_px: float
+    quantity: float = 0.0
+    probability: float         # post-TE, post-HTF-multiplier
+    expected_r: float          # E[R] from Trader's Equation
+    regime: str
+    htf_aligned: bool
+    signals: list[Signal]
+    source: str
+    reasoning: str             # "p=… E=… htf=…"
+```
+
+`source` naming convention (used everywhere — eval bucketing,
+leaderboard, persisted hit-rate samples):
+
+* `"rule:h2"`, `"rule:l2"`, `"rule:wedge_long"`, …
+* `"llm:claude-opus-4-7"`, `"llm:gpt-4.1"`, …
+* `"vlm:gemini-2.5-pro"`, …
+* `"ensemble.vote"`, `"ensemble.router"`, `"ensemble.critic"`
+
+## Decision Pipeline Deep-Dive
+
+### SignalAggregator (`src/brooks/decision/aggregator.py`)
+
+Combines raw `Signal`s into a single `AggregatedDecision`. Key parameter:
+`confluence_n` — minimum number of agreeing-side signals to fire (`1` =
+any-of, `≥2` = confluence). The "majority side" wins; ties go long.
+
+Conservative entry/stop rule:
+
+* **long** → `entry = max(s.entry_px)`, `stop = min(s.stop_px)`
+* **short** → `entry = min(s.entry_px)`, `stop = max(s.stop_px)`
+
+i.e. always use the latest breakout price and the tightest stop in the
+agreeing group.
+
+### Trader's Equation (`src/brooks/decision/trader_equation.py`)
+
+```
+E[R] = p * reward_R - (1 - p) * 1.0 - cost_R
+```
+
+* `p` ← `HitRateTable.lookup((pattern, regime, htf_aligned, side))` if the
+  bucket has ≥ `MIN_SUFFICIENT_SAMPLES` (30) rows, else falls back to the
+  analyst-supplied `Signal.probability` prior (default `0.55`).
+* `reward_R` ← `target_px` distance in R units, or `default_reward_r`
+  (default `2.0`) when `target_px is None`.
+* `cost_R` ← fees + slippage in R, default `0.05`.
+* HTF multiplier (Phase 3.5):
+
+  | tag        | adjustment                           |
+  |------------|---------------------------------------|
+  | `aligned`  | `p *= htf_aligned_mult` (default 1.2; capped at `htf_prob_cap=0.95`) |
+  | `conflict` | `p *= htf_conflict_mult` (default 0.8) |
+  | `neutral`/`None` | pass-through                  |
+
+  Multipliers tunable via `te_params={"htf_aligned_mult": ..., "htf_conflict_mult": ..., "htf_prob_cap": ...}`.
+
+### EV Gate (`src/brooks/decision/ev_gate.py`)
+
+Drops every signal whose `E < min_expected_r` (default `0.1`). Survivors
+are promoted to `Decision`s with TE-derived `probability` and `expected_r`
+baked in. This **replaces** the legacy `min_rr` hard threshold — set
+`min_expected_r=0` to disable.
+
+### HitRateTable (`src/brooks/decision/hit_rate.py`)
+
+Parquet-backed lookup at `data/brooks/hit_rate_table.parquet` with columns
+`(pattern, regime, htf_aligned, side, samples, hit_rate_1r, hit_rate_2r, avg_realized_r)`.
+
+Built offline by `scripts/brooks_build_hit_rate.py` from
+`session_logs` rows tagged with `event_type IN ('signal', 'fill_close')`.
+Run with `--dry-run` to materialise an empty table for tests/CI.
+
+## Risk Layer
+
+| Component | File | Defaults |
+|-----------|------|----------|
+| `FixedPercentSizer` | `risk/sizer.py` | `risk_pct=0.005` |
+| `KellySizer`        | `risk/sizer.py` | `max_risk_pct=0.02`, `fraction=0.5` (half-Kelly) |
+| `StopLadder`        | `risk/stop_ladder.py` | `partial_trail_trigger_r=1.5`, `partial_trail_lookback=10`, `use_swing_trail=True` |
+| `TimeStop`          | `risk/time_stop.py` | `max_bars_to_1r=10` |
+| `PortfolioGuard`    | `risk/portfolio_guard.py` | `max_daily_risk_pct=0.03`, `max_symbol_positions=1` |
+
+`KellySizer` formula: `f* = p − (1 − p) / b` where `b = expected_r`. The
+effective risk fraction is `clip(f* * fraction, 0, max_risk_pct)`. Cash
+cap (`available_cash / entry_px`) prevents leveraged sizes on spot.
+
+`StopLadder` walks each position through monotonic upgrades (stops never
+retreat):
+
+```
+initial → break_even (≥ 1R) → partial_trail (≥ trigger R) → swing_trail
+```
+
+`PortfolioGuard.can_open` enforces (1) per-symbol max, (2) aggregate daily
+risk cap, (3) `correlation_groups` (one open position per named group).
+
+## HTF Integration
+
+`TFSnapshot` carries `features` / `structure` / `regime` alongside `bars`,
+so detectors and the EV gate can read HTF state directly without replaying
+the streaming extractors. `BrooksContext` exposes three alignment helpers:
+
+* `ctx.htf_alignment_for(side)` → `"aligned"`, `"conflict"`, or `"neutral"`
+* `ctx.htf_aligned_for(side)` → `bool` alias for `== "aligned"`
+* `ctx.htf_alignment_score(side)` → weighted score in `[-1, 1]` using each
+  HTF's `RegimeSnapshot.confidence` as the weight
+
+The strategy passes the tag through `EVGate.filter(..., htf_alignment=tag)`
+which drives the Trader's Equation probability multiplier described above.
+
+Multi-timeframe is opt-in: pass `mtf_intervals=["1h", "4h"]` and a
+`base_interval` to `BrooksStrategy`. The internal `TimeframeResampler`
+aggregates the live LTF feed into closed HTF bars and runs the same
+extractor/tracker/regime stack on each.
+
+## Evaluation Pipeline
+
+| Module | Class | Purpose |
+|--------|-------|---------|
+| `eval/golden.py`     | `GoldenSample`, `GoldenDataset` | Labeled (bars → expected signal) dataset, parquet/jsonl on disk |
+| `eval/auto_label.py` | `AutoLabeler`                   | Rule + multi-LLM consensus → silver `GoldenSample`s |
+| `eval/runner.py`     | `EvalRunner`, `SampleResult`    | Replay a dataset through one analyst |
+| `eval/report.py`     | `EvalReport`, `BucketMetrics`   | Precision/recall/F1, hit_rate_1r/2r, expected_r vs realized_r, Wilson 95% CI, HTML/JSON/DataFrame |
+| `eval/leaderboard.py`| `LeaderboardConfig`, `AnalystFactory`, `Leaderboard` | Multi-analyst comparison + Pareto chart |
+
+`GoldenSample` schema (parquet rows are flat; `bars` and `meta` are
+JSON-encoded strings for parquet, plain lists/dicts in JSONL):
+
+```
+id, symbol, interval, bars[], target_bar_idx,
+expected_pattern, expected_side, expected_entry, expected_stop, expected_target,
+regime, htf_aligned, source ("human" | "silver"), reasoning, meta
+```
+
+End-to-end:
+
+```bash
+# 1) seed silver labels from raw bars
+python scripts/brooks_label_silver.py \
+    --input data/brooks/raw/btcusdt_5m.parquet \
+    --output data/brooks/silver/btcusdt_5m.parquet \
+    --symbol BTCUSDT --interval 5m \
+    --llm openai:gpt-4.1 --llm anthropic:claude-sonnet-4-6 \
+    --min-agreement 2
+
+# 2) score one analyst against the dataset → HTML / JSON
+python -c "
+import asyncio
+from src.brooks.analyst.base import AnalystRegistry
+from src.brooks.eval.golden import GoldenDataset
+from src.brooks.eval.runner import EvalRunner
+
+async def main():
+    ds = GoldenDataset.load('data/brooks/silver/btcusdt_5m.parquet')
+    runner = EvalRunner(analyst=AnalystRegistry.build('rule'), dataset=ds, max_concurrent=4)
+    report = await runner.run()
+    report.to_html('data/brooks/reports/rule_btc.html')
+    print(report.overall().to_row())
+
+asyncio.run(main())
+"
+```
+
+## Leaderboard
+
+`config/brooks/leaderboard.yaml` enumerates analysts to score weekly.
+Adding a new model is a one-line YAML change; `AnalystFactory` resolves
+each entry into a runnable analyst.
+
+```yaml
+dataset: data/brooks/golden/v1.parquet
+
+analysts:
+  - type: rule
+  - type: llm
+    model: claude-opus-4-7
+  - type: llm
+    model: claude-sonnet-4-6
+  - type: vlm
+    model: gemini-2.5-pro
+  - type: ensemble.critic
+    label: critic(rule+sonnet)
+    producer: rule
+    critic: llm:claude-sonnet-4-6
+
+schedule: "0 3 * * MON"
+output_dir: data/brooks/leaderboards
+history_path: data/brooks/leaderboard.parquet
+max_concurrent: 4
+```
+
+Run locally (offline, deterministic mock provider — no API keys, used in CI):
+
+```bash
+python scripts/brooks_leaderboard.py --config config/brooks/leaderboard.yaml --mock-llm
+```
+
+Run for real:
+
+```bash
+python scripts/brooks_leaderboard.py --config config/brooks/leaderboard.yaml
+# Writes data/brooks/leaderboards/<timestamp>.html and appends one row per
+# analyst to data/brooks/leaderboard.parquet (history log → trend charts).
+```
+
+Weekly cron is wired into Celery beat as `brooks-leaderboard-weekly` and
+runs `src.tasks.brooks_leaderboard_task.run_weekly_leaderboard` every
+Monday 03:00 UTC (see `src/tasks/celery_app.py`).
+
+The HTML report includes an **Overall** table sorted by F1, a **Pareto**
+scatter (F1 vs cost-per-run, USD), and **By regime / By pattern** bucket
+breakdowns with Wilson CIs.
+
+**Adding a new model** — three steps, no code change required for an LLM
+on an already-supported provider:
+
+1. Add the model entry to `config/llm/registry.yaml` (provider, api_id,
+   pricing).
+2. Add `- type: llm\n  model: <id>` to `config/brooks/leaderboard.yaml`.
+3. Optionally add a row to `DEFAULT_COST_PER_MTOKEN` in
+   `src/brooks/eval/leaderboard.py` so the Pareto chart costs are correct
+   (or override per-leaderboard via `cost_per_mtoken:` in YAML).
+
+A new provider family (e.g. Anthropic Bedrock, xAI) needs a `Provider`
+implementation under `src/alpha/llm/providers/` plus a branch in
+`scripts/brooks_leaderboard.py::_real_provider_factory`.
+
+## Paper Trading
+
+Single Celery task: `src.tasks.brooks_live_task.brooks_live_task`. It
+drives a `BrooksStrategy` against a `CcxtRealtimeDataStream` (or any
+injected `DataStream`) and a paper-mode broker built by
+`src.core.live_broker.create_live_broker(mode="paper", ...)`. **Live mode
+is intentionally rejected** — Phase 4.6 is paper-only by design.
+
+Per-bar events surface through the WebSocket event bus and decisions are
+persisted to `session_logs`:
+
+* `regime` updates → WS panel
+* `signal` / `decision` / `equity_update` / `trade_executed`
+* `brooks_decision_outcome` rows → consumed by `brooks_live_close_task`
+
+Daily close (`brooks-live-daily-close` cron, 23:55 local) reads the day's
+`brooks_decision_outcome` rows and appends realized-R samples to
+`data/brooks/hit_rate_samples.parquet`. The main table is rebuilt offline
+by `scripts/brooks_build_hit_rate.py`, closing the feedback loop.
+
+REST + WebSocket surface lives at `/brooks-live` (router in
+`src/api/brooks_router.py`):
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET    | `/brooks-live/analysts`             | List registered analyst names |
+| POST   | `/brooks-live/start`                | Start a session (analyst, params, symbol, interval, exchange, mtf) |
+| POST   | `/brooks-live/{session_id}/stop`    | Cooperative stop signal |
+| POST   | `/brooks-live/{session_id}/switch`  | Hot-swap analyst on a running session |
+| GET    | `/brooks-live/{session_id}/state`   | Snapshot: last regime/signals/decision/equity/trades |
+| GET    | `/brooks-live/sessions`             | List in-process sessions |
+| POST   | `/brooks-live/close-day`            | Trigger the daily close manually |
+| WS     | `/ws/brooks/{session_id}`           | Push regime/signal/decision/equity/trade events |
+
+UI panel: `ui/src/components/BrooksLive/` (route `/brooks-live`).
+Top-level layout is `index.tsx`; sub-panels are `ChartPanel`,
+`AnalystSwitch`, `DecisionLog`, `PnLCard`. The hook
+`useBrooksLive(session_id)` subscribes to the per-session WebSocket.
+
+Cost / frequency control (configured under `BrooksLiveConfig` in
+`src/config/settings.py`, override with `QUANT_BROOKS__*` env vars):
+
+| Setting | Default | Purpose |
+|---------|---------|---------|
+| `default_symbol`               | `"BTC/USDT"` | Initial symbol if `start` request omits one |
+| `default_interval`             | `"5m"`       | Initial bar interval |
+| `default_exchange`             | `"binance"`  | CCXT exchange id |
+| `default_analyst`              | `"rule"`     | Initial analyst name |
+| `initial_cash`/`commission`/`slippage` | `100_000` / `0.0003` / `0.001` | Paper broker params |
+| `llm_min_interval_seconds`     | `60.0`       | Min wall-clock gap per `(symbol, interval)` between LLM/VLM calls |
+| `llm_daily_budget_usd`         | `10.0`       | Soft daily cap (advisory; rate limiter is the hard gate) |
+| `hit_rate_samples_path`        | `data/brooks/hit_rate_samples.parquet` | Daily-close output |
+
+Live `_install_llm_rate_limiter` wraps the analyst's `analyze` so calls
+that arrive within `llm_min_interval_seconds` of the previous call return
+an empty signal list (i.e. "skip this bar") — rule analysts are left
+untouched.
 
 ## Extension Points
 
 ### Add a new Pattern Detector
 
-1. Create a subclass of `PatternDetector` in `src/brooks/patterns/<name>.py`.
-2. Register it with the decorator:
+1. Subclass `PatternDetector` in `src/brooks/patterns/<name>.py`.
+2. Register it:
 
    ```python
    from src.brooks.patterns.base import DetectorContext, PatternDetector, PatternSignal
@@ -32,121 +617,95 @@ Equation → EV gate → risk layer — behind a single public strategy,
 
    @PatternRegistry.register("my_pattern")
    class MyPatternDetector(PatternDetector):
-       def on_bar(self, ctx: DetectorContext) -> Optional[PatternSignal]:
-           ...
+       def on_bar(self, ctx: DetectorContext) -> PatternSignal | None: ...
    ```
 
 3. Import the new module from `src/brooks/patterns/__init__.py` so the
-   decorator actually runs at process start.
-4. The `RuleAnalyst` (`src/brooks/analyst/rule.py`) picks up every registered
-   detector automatically, so no other wiring is needed.
-5. Add a unit test in `tests/brooks/test_patterns_<name>.py`.
+   decorator runs at process start.
+4. The `RuleAnalyst` picks up every registered detector automatically.
+5. Add `tests/brooks/test_patterns_<name>.py` with the synthetic-bars
+   pattern-fixture style (see existing pattern tests).
 
-### Add a new Analyst (Provider)
+### Add a new Analyst
 
-Analysts consume a `BrooksContext` and emit unified `Signal` records.
+```python
+from src.brooks.analyst.base import AnalystRegistry
+from src.brooks.context import BrooksContext
+from src.brooks.schema import Signal
 
-1. Implement the protocol in `src/brooks/analyst/<name>.py`:
+@AnalystRegistry.register("my_analyst")
+class MyAnalyst:
+    name: str  # set by the decorator
+    async def analyze(self, ctx: BrooksContext) -> list[Signal]: ...
+```
 
-   ```python
-   from src.brooks.analyst.base import AnalystRegistry
-   from src.brooks.context import BrooksContext
-   from src.brooks.schema import Signal
-
-   @AnalystRegistry.register("my_analyst")
-   class MyAnalyst:
-       name: str  # set by the decorator
-
-       async def analyze(self, ctx: BrooksContext) -> list[Signal]:
-           ...
-   ```
-
-2. Import it from `src/brooks/analyst/__init__.py` so the registration
-   fires when the strategy package loads.
-3. Selection happens at strategy-construction time:
-
-   ```python
-   BrooksStrategy(analyst="my_analyst", analyst_params={...})
-   ```
-
-The `llm:<model>` shape is a convention followed by
-`LLMAnalyst` (`src/brooks/analyst/llm.py`); other analysts pick any
-string they like.
+Import it from `src/brooks/analyst/__init__.py`. Select via
+`BrooksStrategy(analyst="my_analyst", analyst_params={...})`.
 
 ### Add a new LLM Provider
 
-LLM analysts delegate to a `Provider` from `src.alpha.llm.provider`.
+LLM/VLM analysts delegate to a `Provider` from `src.alpha.llm.provider`.
 
-1. Implement the `Provider` protocol (complete with `cache`, usage, and
-   latency reporting) in a new module under `src/alpha/llm/providers/`.
-2. Register it via whatever factory your deployment uses (see the
-   existing Anthropic / OpenAI providers for reference).
-3. Pass an instance in through `analyst_params`:
+1. Implement the `Provider` protocol (with `cache`, usage, and latency
+   reporting) under `src/alpha/llm/providers/`.
+2. Register the model in `config/llm/registry.yaml`.
+3. Add a branch in `scripts/brooks_leaderboard.py::_real_provider_factory`
+   so leaderboard runs can resolve it.
+4. Pass an instance via `analyst_params`:
 
    ```python
    BrooksStrategy(
-       analyst="llm:my-model",
+       analyst="llm",
        analyst_params={"provider": MyProvider(), "model": "my-model-1"},
    )
    ```
 
-## Higher-Timeframe (HTF) Deep Integration (Phase 3.5)
+### Add a new Ensemble strategy
 
-`TFSnapshot` now carries `features` / `structure` / `regime` alongside
-`bars`, and `BrooksContext` exposes three alignment helpers:
+Same protocol as any other analyst — register under
+`"ensemble.<name>"` and accept its sub-analysts as constructor kwargs.
+For YAML-driven leaderboard support, also add a branch in
+`AnalystFactory.build` (`src/brooks/eval/leaderboard.py`).
 
-* `ctx.htf_alignment_for(side)` → `"aligned"`, `"conflict"`, or
-  `"neutral"` — based on HTF regime trend vs. the candidate side.
-* `ctx.htf_aligned_for(side)` → `bool` alias for `== "aligned"`.
-* `ctx.htf_alignment_score(side)` → weighted score in `[-1, 1]` using
-  each HTF's `RegimeSnapshot.confidence` as the weight.
+### Add a new Regime state
 
-The strategy feeds the tag through `EVGate.filter(..., htf_alignment=tag)`
-which drives the Trader's Equation probability multiplier:
+Regime states are an enum (`BrooksRegime` in `src/brooks/regime.py`) but
+the routing config and taxonomy treat them as the single source of truth:
 
-| Tag | Probability adjustment |
-|-----|------------------------|
-| `"aligned"`  | `p *= 1.2` (hard-capped at `0.95`) |
-| `"conflict"` | `p *= 0.8` |
-| `"neutral"` or `None` | pass-through |
+1. Add the new value to `BrooksRegime` and update `BrooksRegimeClassifier`
+   to set it.
+2. Add a section to `docs/brooks/taxonomy.yaml`.
+3. Optionally add a route in `config/brooks/ensemble_router.yaml`.
 
-The multipliers are tunable via `TraderEquation(htf_aligned_mult=...,
-htf_conflict_mult=..., htf_prob_cap=...)`.
+## Config & Assets
 
-## Entry Point
+| Path | Purpose |
+|------|---------|
+| `config/brooks/ensemble_router.yaml` | Default `RouterAnalyst` regime → analyst map |
+| `config/brooks/leaderboard.yaml`     | Cross-model leaderboard config |
+| `config/llm/registry.yaml`           | Frontier-model registry (provider, api_id, pricing, capability flags) |
+| `prompts/brooks/system_analyst.md`   | LLM analyst system prompt |
+| `prompts/brooks/system_vlm.md`       | VLM analyst system prompt |
+| `prompts/brooks/concept_manual.md`   | Brooks vocabulary (cached prefix) |
+| `prompts/brooks/fewshot/analyst_examples.jsonl` | LLM few-shot transcript |
+| `prompts/brooks/fewshot/vlm_examples.jsonl`     | VLM few-shot transcript |
+| `prompts/brooks/sections/`           | Modular section drafts (intro, trader_equation, common_misreads) |
+| `docs/brooks/taxonomy.yaml`          | Bar / pattern / regime definitions — single source of truth |
 
-```python
-from src.brooks.strategy import BrooksStrategy
+## Testing
 
-strategy = BrooksStrategy(
-    analyst="rule",                  # "rule" | "llm:<model>" | "ensemble.<name>"
-    analyst_params={...},
-    aggregator_params={"confluence_n": 1},
-    te_params={"cost_r": 0.05, "htf_aligned_mult": 1.2},
-    min_expected_r=0.1,
-    sizer_params={"kind": "kelly"},
-    stop_ladder_params={},
-    time_stop_params={},
-    portfolio_params={"max_daily_risk_pct": 0.03},
-    mtf_intervals=["1h"],            # turn on HTF pipeline
-    base_interval="5m",
-)
+```bash
+pytest tests/brooks/                      # whole brooks suite
+pytest tests/brooks/test_analyst_llm.py   # LLM analyst with MockProvider
+pytest tests/brooks/test_leaderboard.py   # leaderboard + AnalystFactory
 ```
 
-The strategy runs each bar through:
+LLM/VLM tests use a `MockProvider` (see
+`scripts/brooks_leaderboard.py::_mock_provider_factory` for the same
+pattern) so the suite has zero network and zero API-key requirements.
 
-```
-bar → features → structure → regime
-                                ↓
-                        BrooksContext (primary + HTF snapshots)
-                                ↓
-                        Analyst.analyze() → Signals
-                                ↓
-                        SignalAggregator.resolve()
-                                ↓
-                        EVGate.filter(htf_alignment=ctx.htf_alignment_for(side))
-                                ↓
-                        Sizer.size() + PortfolioGuard.can_open()
-                                ↓
-                        submit stop-entry; manage via StopLadder/TimeStop
-```
+## Further Reading
+
+* [Usage recipes](usage.md) — eight runnable end-to-end recipes
+* [Taxonomy](taxonomy.yaml) — bar / pattern / regime reference
+* `prompts/brooks/concept_manual.md` — Brooks vocabulary used by analysts

--- a/docs/brooks/usage.md
+++ b/docs/brooks/usage.md
@@ -1,0 +1,309 @@
+# Brooks Usage Recipes
+
+Eight runnable recipes — copy/paste into a script or a notebook in the repo
+root. Every example uses real APIs from `src/brooks/` and `src/alpha/llm/`;
+unverified parameters are not invented. For the architecture overview see
+[README.md](README.md).
+
+## Recipe 1 — Backtest with the rule analyst
+
+零 LLM 调用，纯 Brooks 模式检测器作为基线。`BrooksStrategy` 注册名为
+`"brooks"`，可以被 `StrategyRegistry` 取到，也可以直接构造。
+
+```python
+from src.brooks.strategy import BrooksStrategy
+
+strategy = BrooksStrategy(
+    analyst="rule",
+    aggregator_params={"confluence_n": 1},
+    te_params={"cost_r": 0.05},
+    min_expected_r=0.1,
+    sizer_params={"kind": "kelly", "max_risk_pct": 0.02, "fraction": 0.5},
+    stop_ladder_params={"partial_trail_trigger_r": 1.5},
+    time_stop_params={"max_bars_to_1r": 10},
+    portfolio_params={"max_daily_risk_pct": 0.03, "max_symbol_positions": 1},
+    base_interval="5m",
+    mtf_intervals=["1h"],     # 打开 HTF 流水线
+)
+# Strategy 实现了 src/core/base.py:Strategy ABC，直接接到回测 engine 即可：
+# engine.set_strategy(strategy); engine.run(...)
+```
+
+## Recipe 2 — LLM Analyst (Claude Opus 4.7)
+
+用 Anthropic Opus 4.7 做语言模型分析师。Provider 实例由调用方注入，
+PromptBundle 默认从 `prompts/brooks/` 加载，concept_manual + few-shot
+会被 provider 走 prompt cache。
+
+```python
+from src.alpha.llm.providers.anthropic import AnthropicProvider
+from src.brooks.strategy import BrooksStrategy
+
+provider = AnthropicProvider(model="claude-opus-4-7")
+
+strategy = BrooksStrategy(
+    analyst="llm",
+    analyst_params={
+        "provider": provider,
+        "model": "claude-opus-4-7",
+        "cache_ttl_seconds": 3600,
+        "max_tokens": 4096,
+        "temperature": 0.0,
+        "context_budget_tokens": 2000,    # 渲染 LTF/HTF bars 的 token 预算
+    },
+    base_interval="5m",
+    mtf_intervals=["1h", "4h"],
+)
+
+# Signal.source 会是 "llm:claude-opus-4-7"；
+# Signal.meta 携带 latency_ms / input_tokens / output_tokens / cache_hit / model。
+```
+
+## Recipe 3 — VLMAnalyst with Gemini 2.5 Pro
+
+用渲染好的 OHLCV PNG 喂给多模态模型，适合形态偏图像（楔形 / 微通道
+/ breakout-mode 转换）的场景。
+
+```python
+from src.alpha.llm.providers.gemini import GeminiProvider
+from src.brooks.render.chart import ChartStyle
+from src.brooks.strategy import BrooksStrategy
+
+provider = GeminiProvider(model="gemini-2.5-pro")
+
+strategy = BrooksStrategy(
+    analyst="vlm",
+    analyst_params={
+        "provider": provider,
+        "model": "gemini-2.5-pro",
+        "include_htf": True,           # 在主图右上角嵌入 HTF inset
+        "chart_style": ChartStyle(
+            width=1280,
+            height=720,
+            show_volume=True,
+            show_swing_markers=True,
+        ),
+        "context_budget_tokens": 1000,  # 文本预算偏小，主信息走图
+    },
+)
+# Signal.source 会是 "vlm:gemini-2.5-pro"；
+# Signal.meta["annotations"] 携带 VLM 返回的 box / line overlay，
+# 可以喂回 render_annotated() 二次成图（用于 eval 报告或 golden review）。
+```
+
+## Recipe 4 — Ensemble Critic（Rule 出信号 + LLM 复核）
+
+Producer 出候选，critic 决定保留/拒绝并调整 probability。LLM 调用次数
+= 候选数（不是每根 bar 一次），成本可控。
+
+```python
+from src.alpha.llm.providers.anthropic import AnthropicProvider
+from src.brooks.analyst.base import AnalystRegistry
+from src.brooks.strategy import BrooksStrategy
+
+producer = AnalystRegistry.build("rule")          # 零成本生成候选
+critic = AnalystRegistry.build(
+    "llm",
+    provider=AnthropicProvider(model="claude-sonnet-4-6"),
+    model="claude-sonnet-4-6",
+)
+
+strategy = BrooksStrategy(
+    analyst="ensemble.critic",
+    analyst_params={
+        "producer": producer,
+        "critic": critic,
+        "critic_prompt_overlay": (
+            "You are reviewing rule-engine candidates. For each candidate "
+            "set meta.confirms = idx if you endorse, -1 to reject."
+        ),
+    },
+)
+# 通过 source="ensemble.critic" 与 meta["producer_source"] / meta["critic_source"]
+# 可以追溯每个最终信号的来源。
+```
+
+## Recipe 5 — Add a custom Pattern Detector
+
+新检测器自动被 `RuleAnalyst` 拾起 — 不需要改任何分发代码。
+
+```python
+# src/brooks/patterns/my_breakout.py
+from typing import Optional
+
+from src.brooks.patterns.base import DetectorContext, PatternDetector, PatternSignal
+from src.brooks.patterns.registry import PatternRegistry
+
+
+@PatternRegistry.register("my_breakout")
+class MyBreakoutDetector(PatternDetector):
+    """触发条件：当前 bar 收阳且突破最近 N 根 bar 的最高价。"""
+
+    def __init__(self, lookback: int = 10) -> None:
+        self.lookback = lookback
+
+    def on_bar(self, ctx: DetectorContext) -> Optional[PatternSignal]:
+        feats = ctx.recent_features
+        if len(feats) <= self.lookback:
+            return None
+        cur = feats[-1]
+        prior = feats[-1 - self.lookback : -1]
+        prior_high = max(f.high for f in prior)
+        if cur.is_bull and cur.close > prior_high:
+            return PatternSignal(
+                detector="my_breakout",
+                side="long",
+                signal_bar_idx=cur.bar_idx,
+                entry_px=cur.high + 1e-6,
+                stop_px=cur.low,
+                timestamp_ns=cur.timestamp_ns,
+                reason=f"close>{prior_high:.2f}",
+            )
+        return None
+```
+
+然后从 `src/brooks/patterns/__init__.py` 加一行 `from src.brooks.patterns
+import my_breakout  # noqa: F401`，注册装饰器才会运行。`RuleAnalyst` 在
+默认参数下会自动覆盖到新检测器。
+
+## Recipe 6 — Run the Leaderboard locally
+
+端到端：加载 golden dataset → 跑全部 analysts → 写 HTML + parquet 历史。
+`--mock-llm` 用确定性的内嵌 MockProvider，CI 里跑也不需要 API key。
+
+```bash
+# 离线 / CI 烟测（不走任何网络，也不读取 API key）
+python scripts/brooks_leaderboard.py \
+    --config config/brooks/leaderboard.yaml \
+    --mock-llm \
+    --no-persist
+
+# 真正跑（按需设置 ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY）
+python scripts/brooks_leaderboard.py --config config/brooks/leaderboard.yaml
+
+# 输出：
+#   data/brooks/leaderboards/<timestamp>.html  ← 含 Pareto 散点 + bucket 表
+#   data/brooks/leaderboard.parquet            ← 一行/分析师追加
+```
+
+代码内调用同样可行：
+
+```python
+import asyncio
+from src.brooks.eval.golden import GoldenDataset
+from src.brooks.eval.leaderboard import AnalystFactory, Leaderboard, LeaderboardConfig
+
+async def main():
+    cfg = LeaderboardConfig.load("config/brooks/leaderboard.yaml")
+    dataset = GoldenDataset.load(cfg.dataset)
+    factory = AnalystFactory(provider_factory=...)   # see _real_provider_factory in scripts/
+    board = Leaderboard(cfg, factory=factory)
+    entries = await board.run_all(dataset)
+    board.to_html(cfg.output_dir / "latest.html")
+    board.persist()
+    for e in entries:
+        print(e.analyst_name, "F1=", e.f1_pattern, "cost=$", e.cost_per_run_usd)
+
+asyncio.run(main())
+```
+
+## Recipe 7 — Start a paper-trading session and view the UI
+
+启动方式有两种：直接调 Celery 任务，或走 `/brooks-live` REST。两者最终都
+会把 session 注册到 `BrooksLiveRegistry`，UI panel 通过
+`/ws/brooks/{session_id}` 订阅事件。
+
+```bash
+# 1) 起后端 + worker（含 brooks 任务自动注册到 celery_app.imports）
+./dev_local.sh up
+
+# 2) REST 启一个 session
+curl -X POST http://localhost:8000/brooks-live/start \
+    -H "content-type: application/json" \
+    -d '{
+          "symbol": "BTC/USDT",
+          "interval": "5m",
+          "exchange": "binance",
+          "analyst": "rule",
+          "mode": "paper",
+          "mtf_intervals": ["1h"]
+        }'
+# → {"session_id": "...", "task_id": "..."}
+
+# 3) 浏览器打开 http://localhost:5173/brooks-live （dev）或 http://localhost/brooks-live （prod）
+#    UI: ChartPanel + AnalystSwitch + DecisionLog + PnLCard
+#    底层 hook: ui/src/hooks/useBrooksLive.ts
+```
+
+切换分析师不需要重启 session（`SwitchRequest` 仅接 `analyst` 名，参数走启动时的 `analyst_params`）：
+
+```bash
+curl -X POST http://localhost:8000/brooks-live/<session_id>/switch \
+    -H "content-type: application/json" \
+    -d '{"analyst": "rule"}'
+```
+
+成本控制（环境变量）：
+
+```bash
+QUANT_BROOKS__LLM_MIN_INTERVAL_SECONDS=60        # LLM/VLM 每对 (symbol,interval) 最小调用间隔
+QUANT_BROOKS__LLM_DAILY_BUDGET_USD=10            # 软日预算（咨询用，rate limit 是硬门槛）
+QUANT_BROOKS__INITIAL_CASH=100000
+QUANT_BROOKS__COMMISSION=0.0003
+```
+
+⚠️ **仅 paper**：`brooks_live_task` 在收到 `mode != "paper"` 时会
+`raise ValueError`。`create_live_broker(mode="live")` 同样被禁用 —
+真实下单是 out-of-scope。
+
+## Recipe 8 — Auto-label a silver dataset
+
+把一段历史 OHLCV 拿来，跑 rule + N 个 LLM 求共识，写出 silver
+`GoldenSample`。每根 bar 至多产出 1 条样本，至少 `--min-agreement` 个
+分析师对 `(pattern, side)` 一致才会保留。
+
+```bash
+# 输入文件需要列：timestamp_ns, open, high, low, close, volume
+python scripts/brooks_label_silver.py \
+    --input data/brooks/raw/btcusdt_5m.parquet \
+    --output data/brooks/silver/btcusdt_5m.parquet \
+    --symbol BTCUSDT --interval 5m \
+    --llm openai:gpt-4.1 \
+    --llm anthropic:claude-sonnet-4-6 \
+    --min-agreement 2 \
+    --max-concurrent 4 \
+    --entry-tolerance 0.005 \
+    --min-bars 20
+
+# Dry-run（只统计，不写文件，便于调参）
+python scripts/brooks_label_silver.py \
+    --input data/brooks/raw/sample.jsonl \
+    --symbol BTC --interval 5m \
+    --min-agreement 1 \
+    --dry-run
+```
+
+代码内调用：
+
+```python
+import asyncio
+from src.brooks.analyst.base import AnalystRegistry
+from src.brooks.context import Bar
+from src.brooks.eval.auto_label import AutoLabeler
+from src.brooks.eval.golden import GoldenDataset
+
+bars = [Bar(timestamp_ns=..., open=..., high=..., low=..., close=..., volume=...) for _ in range(...)]
+
+labeler = AutoLabeler(
+    rule_analyst=AnalystRegistry.build("rule"),
+    llm_analysts=[],            # 全 rule 也行（min_agreement=1）
+    min_agreement=1,
+    min_bars_for_label=20,
+)
+samples = asyncio.run(labeler.label(bars=bars, symbol="BTCUSDT", interval="5m"))
+GoldenDataset.from_samples(samples).save("data/brooks/silver/manual.parquet")
+```
+
+把 silver 文件喂回 leaderboard / EvalRunner 即可获得跨模型对比数据 —
+完整闭环：raw bars → silver labels → eval → leaderboard → live → 反馈回
+`hit_rate_table` → 影响新 EV gate 决策。


### PR DESCRIPTION
## Summary
- Rewrite `docs/brooks/README.md` to cover the full V2 platform: analyst routes (rule / llm / vlm / ensemble.{vote,router,critic}), Signal/Decision schema, decision pipeline (Aggregator + Trader's Equation + EV Gate + HitRateTable), risk layer, HTF integration, eval pipeline, leaderboard (config + cron + new-model steps), paper trading (Celery task + REST/WS + UI panel + cost controls + paper-only constraint), extension points, config & assets, and testing.
- New `docs/brooks/usage.md` with eight runnable recipes (rule backtest, Claude Opus 4.7 LLM, Gemini 2.5 Pro VLM, ensemble.critic, custom pattern detector, leaderboard CLI, paper-trading start + UI, silver auto-label).
- Surface entry points from `docs/README.md` and root `CLAUDE.md`.

All code examples verified against current `src/brooks/`, `src/alpha/llm/providers/`, `config/`, `scripts/`, `src/api/brooks_router.py`, and `src/tasks/brooks_*.py` — no source changes, no new dependencies. Closes [QUA-58].

## Test plan
- [ ] Visual review of `docs/brooks/README.md` rendering on GitHub
- [ ] Visual review of `docs/brooks/usage.md` rendering on GitHub
- [ ] Spot-check at least one recipe (e.g. Recipe 1 rule backtest) imports cleanly: \`python -c "from src.brooks.strategy import BrooksStrategy"\`
- [ ] Confirm new doc links in `docs/README.md` and `CLAUDE.md` resolve