### PR TITLE
feat(studio): ChartLayer protocol + 6 core layers + LayerToggle (QUA-63)

### DIFF
--- a/ui/src/features/studio/__tests__/decisionsLayer.test.ts
+++ b/ui/src/features/studio/__tests__/decisionsLayer.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const markersByPlugin = new Map<unknown, unknown[]>();
+
+vi.mock('lightweight-charts', () => ({
+  LineStyle: { Solid: 0, Dotted: 1, Dashed: 2 },
+  createSeriesMarkers: vi.fn((series: unknown, initial: unknown[] = []) => {
+    const handle = {
+      _series: series,
+      setMarkers: vi.fn((m: unknown[]) => markersByPlugin.set(handle, m)),
+      detach: vi.fn(),
+    };
+    markersByPlugin.set(handle, initial);
+    return handle;
+  }),
+}));
+
+import {
+  buildDecisionMarkers,
+  collectDecisions,
+  decisionColor,
+  decisionsInWindow,
+  decisionsLayer,
+} from '../layers/decisions';
+import { makeLayerCtx } from './mockChart';
+import { makeTimeline } from './fixtures';
+import type { Decision } from '../types';
+
+const longDecision = (): Decision => ({
+  side: 'long',
+  entry_px: 100,
+  stop_px: 95,
+  target_px: 110,
+  quantity: 1,
+  probability: 0.6,
+  expected_r: 1.5,
+  regime: 'strong_bull_trend',
+  pattern: 'BO',
+  source: 'rule',
+});
+
+describe('decisions layer', () => {
+  it('maps side to colour', () => {
+    expect(decisionColor('long')).toBe('#26A69A');
+    expect(decisionColor('short')).toBe('#EF5350');
+  });
+
+  it('collects decisions only up to currentBarIdx', () => {
+    const tl = makeTimeline(5);
+    tl.events[1].decision = longDecision();
+    tl.events[3].decision = longDecision();
+    expect(collectDecisions(tl, 2).length).toBe(1);
+    expect(collectDecisions(tl, 4).length).toBe(2);
+  });
+
+  it('emits markers for each visible decision', () => {
+    const tl = makeTimeline(3);
+    tl.events[0].decision = longDecision();
+    tl.events[2].decision = longDecision();
+    expect(buildDecisionMarkers(tl, 2).length).toBe(2);
+  });
+
+  it('only includes decisions within ± window for priceLine windowing', () => {
+    const tl = makeTimeline(20);
+    tl.events[1].decision = longDecision();
+    tl.events[10].decision = longDecision();
+    tl.events[15].decision = longDecision();
+    // currentBarIdx = 12, window 5 → only bar 10 (15 is past 12 → excluded)
+    const inWin = decisionsInWindow(tl, 12, 5);
+    expect(inWin.map((d) => d.bar_idx)).toEqual([10]);
+  });
+
+  it('draws entry/stop/target priceLines for in-window decisions and clears them on scrub', () => {
+    const { ctx, primarySeries } = makeLayerCtx();
+    const handle = decisionsLayer.mount(ctx);
+
+    const tl = makeTimeline(10);
+    tl.events[5].decision = longDecision();
+
+    handle.update(tl, 5);
+    // entry + stop + target = 3 lines
+    expect(primarySeries.priceLines.length).toBe(3);
+
+    // far away → window excludes it
+    handle.update(tl, 50); // currentBarIdx clamped doesn't matter; we passed raw
+    expect(primarySeries.priceLines.length).toBe(0);
+
+    handle.unmount();
+  });
+
+  it('skips target priceLine when target is null', () => {
+    const { ctx, primarySeries } = makeLayerCtx();
+    const handle = decisionsLayer.mount(ctx);
+
+    const tl = makeTimeline(3);
+    tl.events[1].decision = { ...longDecision(), target_px: null };
+    handle.update(tl, 1);
+    expect(primarySeries.priceLines.length).toBe(2); // entry + stop only
+
+    handle.unmount();
+  });
+});

--- a/ui/src/features/studio/__tests__/emaLayer.test.ts
+++ b/ui/src/features/studio/__tests__/emaLayer.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('lightweight-charts', () => ({
+  LineSeries: { type: 'Line', isBuiltIn: true, defaultOptions: {} },
+}));
+
+import { buildEmaSeriesData, ema20Layer, ema200Layer, readEmaField } from '../layers/ema';
+import { makeLayerCtx } from './mockChart';
+import { makeTimeline } from './fixtures';
+
+describe('ema layer', () => {
+  it('reads numeric ema fields and skips junk', () => {
+    expect(readEmaField({ ema20: 100.5 } as never, 'ema20')).toBe(100.5);
+    expect(readEmaField({ ema20: 'oops' } as never, 'ema20')).toBeNull();
+    expect(readEmaField(null, 'ema20')).toBeNull();
+    expect(readEmaField(undefined, 'ema20')).toBeNull();
+  });
+
+  it('skips bars without an ema value rather than dropping the whole series', () => {
+    const tl = makeTimeline(4);
+    (tl.events[0].features as unknown as Record<string, number>) = { ema20: 100 } as never;
+    (tl.events[2].features as unknown as Record<string, number>) = { ema20: 102 } as never;
+    // events[1] and events[3] left without ema20 — should not appear
+
+    const data = buildEmaSeriesData(tl, 'ema20');
+    expect(data.map((d) => d.value)).toEqual([100, 102]);
+  });
+
+  it('mounts ema20 by default and ema200 hidden by default', () => {
+    expect(ema20Layer.defaultVisible).toBe(true);
+    expect(ema200Layer.defaultVisible).toBe(false);
+  });
+
+  it('writes line data on update and removes the series on unmount', () => {
+    const { ctx, chart } = makeLayerCtx();
+    const handle = ema20Layer.mount(ctx);
+    expect(chart.added.length).toBe(1);
+    expect(chart.added[0].type).toBe('Line');
+
+    const tl = makeTimeline(2);
+    (tl.events[0].features as unknown as Record<string, number>) = { ema20: 100 } as never;
+    (tl.events[1].features as unknown as Record<string, number>) = { ema20: 101 } as never;
+    handle.update(tl, 1);
+    expect(chart.added[0].data).toHaveLength(2);
+
+    handle.unmount();
+    expect(chart.removed).toContain(chart.added[0]);
+  });
+});

--- a/ui/src/features/studio/__tests__/fillsLayer.test.ts
+++ b/ui/src/features/studio/__tests__/fillsLayer.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const markersByPlugin = new Map<unknown, unknown[]>();
+const detached: unknown[] = [];
+
+vi.mock('lightweight-charts', () => ({
+  createSeriesMarkers: vi.fn((series: unknown, initial: unknown[] = []) => {
+    const handle = {
+      _series: series,
+      setMarkers: vi.fn((m: unknown[]) => markersByPlugin.set(handle, m)),
+      detach: vi.fn(() => detached.push(handle)),
+    };
+    markersByPlugin.set(handle, initial);
+    return handle;
+  }),
+}));
+
+import { buildFillMarkers, fillsLayer, isBuyFill } from '../layers/fills';
+import { makeLayerCtx } from './mockChart';
+import { makeTimeline } from './fixtures';
+
+describe('fills layer', () => {
+  it('classifies buy/cover as buy and sell/short as sell', () => {
+    expect(isBuyFill('buy')).toBe(true);
+    expect(isBuyFill('buy_to_cover')).toBe(true);
+    expect(isBuyFill('sell')).toBe(false);
+    expect(isBuyFill('sell_short')).toBe(false);
+  });
+
+  it('emits one marker per past fill, none for future bars', () => {
+    const tl = makeTimeline(4);
+    tl.events[1].fill = { side: 'buy', qty: 1, price: 100, reason: 'entry' };
+    tl.events[3].fill = { side: 'sell', qty: 1, price: 105, reason: 'tp' };
+
+    expect(buildFillMarkers(tl, 2).length).toBe(1);
+    expect(buildFillMarkers(tl, 3).length).toBe(2);
+  });
+
+  it('mounts, updates markers, and detaches on unmount', () => {
+    const { ctx } = makeLayerCtx();
+    const handle = fillsLayer.mount(ctx);
+
+    const tl = makeTimeline(2);
+    tl.events[1].fill = { side: 'buy', qty: 1, price: 100, reason: 'entry' };
+    handle.update(tl, 1);
+
+    const lastMarkers = [...markersByPlugin.values()].pop() as unknown[];
+    expect(lastMarkers.length).toBe(1);
+
+    handle.unmount();
+    expect(detached.length).toBeGreaterThan(0);
+  });
+});

--- a/ui/src/features/studio/__tests__/mockChart.ts
+++ b/ui/src/features/studio/__tests__/mockChart.ts
@@ -1,0 +1,97 @@
+/**
+ * Tiny mock of the lightweight-charts API surface that ChartLayer
+ * implementations use. jsdom can't render canvas, so we just record calls
+ * to the methods our layers actually invoke and let tests assert on them.
+ */
+
+import { vi } from 'vitest';
+import type { LayerCtx } from '../layers/types';
+
+export interface MockSeries {
+  type: string;
+  options: Record<string, unknown>;
+  data: unknown[];
+  setData: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  setMarkers: ReturnType<typeof vi.fn>;
+  markers: unknown[];
+  priceLines: { id: number; opts: Record<string, unknown> }[];
+  createPriceLine: ReturnType<typeof vi.fn>;
+  removePriceLine: ReturnType<typeof vi.fn>;
+}
+
+export interface MockChart {
+  added: MockSeries[];
+  removed: MockSeries[];
+  priceScales: Record<string, Record<string, unknown>>;
+  addSeries: ReturnType<typeof vi.fn>;
+  removeSeries: ReturnType<typeof vi.fn>;
+  priceScale: ReturnType<typeof vi.fn>;
+}
+
+function makeSeries(type: string, options: Record<string, unknown>): MockSeries {
+  let plId = 0;
+  const series: MockSeries = {
+    type,
+    options,
+    data: [],
+    setData: vi.fn((d: unknown[]) => {
+      series.data = d;
+    }),
+    update: vi.fn(),
+    setMarkers: vi.fn((markers: unknown[]) => {
+      series.markers = markers;
+    }),
+    markers: [],
+    priceLines: [],
+    createPriceLine: vi.fn((opts: Record<string, unknown>) => {
+      const handle = { id: ++plId, opts };
+      series.priceLines.push(handle);
+      return handle;
+    }),
+    removePriceLine: vi.fn((handle: { id: number }) => {
+      series.priceLines = series.priceLines.filter((p) => p.id !== handle.id);
+    }),
+  };
+  return series;
+}
+
+export function createMockChart(): MockChart {
+  const added: MockSeries[] = [];
+  const removed: MockSeries[] = [];
+  const priceScales: Record<string, Record<string, unknown>> = {};
+
+  const chart: MockChart = {
+    added,
+    removed,
+    priceScales,
+    addSeries: vi.fn((definition: unknown, options: Record<string, unknown> = {}) => {
+      const def = definition as { type?: string; isBuiltIn?: boolean };
+      const series = makeSeries(def.type ?? 'unknown', options);
+      added.push(series);
+      return series;
+    }),
+    removeSeries: vi.fn((s: MockSeries) => {
+      removed.push(s);
+    }),
+    priceScale: vi.fn((id: string) => ({
+      applyOptions: (opts: Record<string, unknown>) => {
+        priceScales[id] = { ...(priceScales[id] ?? {}), ...opts };
+      },
+    })),
+  };
+  return chart;
+}
+
+export function makeLayerCtx(): { ctx: LayerCtx; chart: MockChart; primarySeries: MockSeries } {
+  const chart = createMockChart();
+  const primarySeries = makeSeries('Candlestick', {});
+  // primarySeries is created externally in real code; record-only for tests.
+  const ctx: LayerCtx = {
+    // Cast: our mock implements the exact slice of the API our layers touch.
+    chart: chart as unknown as LayerCtx['chart'],
+    primarySeries: primarySeries as unknown as LayerCtx['primarySeries'],
+    theme: 'dark',
+  };
+  return { ctx, chart, primarySeries };
+}

--- a/ui/src/features/studio/__tests__/regimeLayer.test.ts
+++ b/ui/src/features/studio/__tests__/regimeLayer.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('lightweight-charts', () => ({
+  HistogramSeries: { type: 'Histogram', isBuiltIn: true, defaultOptions: {} },
+}));
+
+import { regimeColorOf, regimeLayer } from '../layers/regime';
+import { makeLayerCtx } from './mockChart';
+import { makeTimeline } from './fixtures';
+
+describe('regime layer', () => {
+  it('has a stable id and a default-on toggle', () => {
+    expect(regimeLayer.id).toBe('regime');
+    expect(regimeLayer.defaultVisible).toBe(true);
+  });
+
+  it('returns the configured color for known regimes and falls back otherwise', () => {
+    expect(regimeColorOf('strong_bull_trend')).toContain('rgba(38, 166, 154');
+    expect(regimeColorOf(undefined)).toBeTypeOf('string');
+    expect(regimeColorOf('something-unknown')).toBeTypeOf('string');
+  });
+
+  it('mounts a histogram overlay and writes a colored band per bar', () => {
+    const { ctx, chart } = makeLayerCtx();
+    const handle = regimeLayer.mount(ctx);
+    expect(chart.added.length).toBe(1);
+    expect(chart.added[0].type).toBe('Histogram');
+    expect(chart.added[0].options).toMatchObject({
+      priceScaleId: 'regime-band',
+      priceLineVisible: false,
+      lastValueVisible: false,
+    });
+
+    const tl = makeTimeline(3);
+    tl.events[0].regime = { name: 'strong_bull_trend', confidence: 0.9, reasons: [] };
+    tl.events[2].regime = { name: 'climax', confidence: 0.7, reasons: [] };
+
+    handle.update(tl, 2);
+    const data = chart.added[0].data as { color: string }[];
+    expect(data).toHaveLength(3);
+    expect(data[0].color).toContain('rgba(38, 166, 154');
+    expect(data[2].color).toContain('rgba(255, 152, 0');
+  });
+
+  it('removes its series on unmount', () => {
+    const { ctx, chart } = makeLayerCtx();
+    const handle = regimeLayer.mount(ctx);
+    handle.unmount();
+    expect(chart.removed.length).toBe(1);
+  });
+});

--- a/ui/src/features/studio/__tests__/registry.test.ts
+++ b/ui/src/features/studio/__tests__/registry.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('lightweight-charts', () => ({
+  HistogramSeries: { type: 'Histogram', isBuiltIn: true, defaultOptions: {} },
+  LineSeries: { type: 'Line', isBuiltIn: true, defaultOptions: {} },
+  LineStyle: { Solid: 0, Dotted: 1, Dashed: 2 },
+  createSeriesMarkers: vi.fn(() => ({
+    setMarkers: vi.fn(),
+    detach: vi.fn(),
+  })),
+}));
+
+import { DEFAULT_VISIBLE, LAYERS, findLayer } from '../layers/registry';
+
+describe('layer registry', () => {
+  it('exposes the six core layers (with EMA split)', () => {
+    expect(LAYERS.map((l) => l.id)).toEqual([
+      'regime',
+      'swings',
+      'ema20',
+      'ema200',
+      'signals',
+      'decisions',
+      'fills',
+    ]);
+  });
+
+  it('default-visible omits ema200', () => {
+    expect(DEFAULT_VISIBLE.has('ema200')).toBe(false);
+    expect(DEFAULT_VISIBLE.has('ema20')).toBe(true);
+    expect(DEFAULT_VISIBLE.has('regime')).toBe(true);
+  });
+
+  it('layer ids are unique', () => {
+    const ids = LAYERS.map((l) => l.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('findLayer resolves by id', () => {
+    expect(findLayer('regime')?.name).toBe('Regime band');
+    expect(findLayer('does-not-exist')).toBeUndefined();
+  });
+});

--- a/ui/src/features/studio/__tests__/signalsLayer.test.ts
+++ b/ui/src/features/studio/__tests__/signalsLayer.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const markersByPlugin = new Map<unknown, unknown[]>();
+const detached: unknown[] = [];
+
+vi.mock('lightweight-charts', () => ({
+  LineStyle: { Solid: 0, Dotted: 1, Dashed: 2 },
+  createSeriesMarkers: vi.fn((series: unknown, initial: unknown[] = []) => {
+    const handle = {
+      _series: series,
+      setMarkers: vi.fn((m: unknown[]) => markersByPlugin.set(handle, m)),
+      detach: vi.fn(() => detached.push(handle)),
+    };
+    markersByPlugin.set(handle, initial);
+    return handle;
+  }),
+}));
+
+import { buildSignalMarkers, collectSignals, signalColor, signalsLayer } from '../layers/signals';
+import { makeLayerCtx } from './mockChart';
+import { makeTimeline } from './fixtures';
+import type { Signal } from '../types';
+
+describe('signals layer', () => {
+  it('maps side to color', () => {
+    expect(signalColor('long')).toBe('#26A69A');
+    expect(signalColor('short')).toBe('#EF5350');
+  });
+
+  it('hides signals from future bars (no info leak)', () => {
+    const tl = makeTimeline(4);
+    tl.events[1].signals = [{ id: 'a', pattern: 'bar1', side: 'long' } as Signal];
+    tl.events[3].signals = [{ id: 'b', pattern: 'bar3', side: 'short' } as Signal];
+
+    expect(collectSignals(tl, 2).map((s) => s.signal.id)).toEqual(['a']);
+    expect(collectSignals(tl, 3).map((s) => s.signal.id)).toEqual(['a', 'b']);
+  });
+
+  it('emits one marker per past signal', () => {
+    const tl = makeTimeline(3);
+    tl.events[1].signals = [
+      { id: 'a', pattern: 'p1', side: 'long' } as Signal,
+      { id: 'b', pattern: 'p2', side: 'short' } as Signal,
+    ];
+    expect(buildSignalMarkers(tl, 2).length).toBe(2);
+  });
+
+  it('mounts and draws entry/stop priceLines for the current bar signal', () => {
+    const { ctx, primarySeries } = makeLayerCtx();
+    const handle = signalsLayer.mount(ctx);
+
+    const tl = makeTimeline(3);
+    tl.events[2].signals = [
+      { id: 'a', pattern: 'wedge', side: 'long', entry_px: 105, stop_px: 100 } as Signal,
+    ];
+    handle.update(tl, 2);
+
+    expect(primarySeries.priceLines.length).toBe(2);
+    expect(primarySeries.priceLines.map((p) => p.opts.price).sort()).toEqual([100, 105]);
+
+    // Scrub away from bar 2 — those lines should clear.
+    handle.update(tl, 1);
+    expect(primarySeries.priceLines.length).toBe(0);
+
+    handle.unmount();
+    expect(detached.length).toBeGreaterThan(0);
+  });
+});

--- a/ui/src/features/studio/__tests__/swingsLayer.test.ts
+++ b/ui/src/features/studio/__tests__/swingsLayer.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const markersByPlugin = new Map<unknown, unknown[]>();
+const detached: unknown[] = [];
+
+vi.mock('lightweight-charts', () => ({
+  createSeriesMarkers: vi.fn((series: unknown, initial: unknown[] = []) => {
+    const handle = {
+      _series: series,
+      setMarkers: vi.fn((m: unknown[]) => markersByPlugin.set(handle, m)),
+      detach: vi.fn(() => detached.push(handle)),
+    };
+    markersByPlugin.set(handle, initial);
+    return handle;
+  }),
+}));
+
+import { buildSwingMarkers, isHighSwing, swingsLayer } from '../layers/swings';
+import { makeLayerCtx } from './mockChart';
+import { makeTimeline } from './fixtures';
+
+describe('swings layer', () => {
+  it('classifies high vs low by kind name', () => {
+    expect(isHighSwing('hh')).toBe(false); // depends only on /high/
+    expect(isHighSwing('higher_high')).toBe(true);
+    expect(isHighSwing('low')).toBe(false);
+  });
+
+  it('only emits markers for swings whose idx <= currentBarIdx', () => {
+    const tl = makeTimeline(5);
+    // bar 1: only the first swing is known
+    tl.events[1].structure = {
+      always_in: 'long',
+      confirmed_swings: [{ idx: 1, kind: 'low', price: 99 }],
+    };
+    // bar 4: cumulative snapshot includes a future-leaking idx 4 entry
+    tl.events[4].structure = {
+      always_in: 'long',
+      confirmed_swings: [
+        { idx: 1, kind: 'low', price: 99 },
+        { idx: 3, kind: 'high', price: 105 },
+        { idx: 4, kind: 'high', price: 107 },
+      ],
+    };
+
+    const past = buildSwingMarkers(tl, 2);
+    expect(past.length).toBe(1);
+    expect(past[0].id).toBe('swing-1-low');
+
+    const present = buildSwingMarkers(tl, 4);
+    expect(present.length).toBe(3);
+
+    // scrubbing back to bar 3 takes the latest snapshot ≤ 3 (which is the
+    // bar-1 snapshot), so we still see only the first swing — and the
+    // future-idx swing from bar 4 is filtered even if present in scope.
+    const between = buildSwingMarkers(tl, 3);
+    expect(between.length).toBe(1);
+  });
+
+  it('mounts a marker plugin, updates markers, and detaches on unmount', () => {
+    const { ctx } = makeLayerCtx();
+    const handle = swingsLayer.mount(ctx);
+
+    const tl = makeTimeline(3);
+    tl.events[2].structure = {
+      always_in: 'long',
+      confirmed_swings: [
+        { idx: 0, kind: 'low', price: 99 },
+        { idx: 2, kind: 'high', price: 102 },
+      ],
+    };
+    handle.update(tl, 2);
+    const lastMarkers = [...markersByPlugin.values()].pop() as unknown[];
+    expect(lastMarkers.length).toBe(2);
+
+    handle.unmount();
+    expect(detached.length).toBeGreaterThan(0);
+  });
+});

--- a/ui/src/features/studio/__tests__/useLayerRegistry.test.tsx
+++ b/ui/src/features/studio/__tests__/useLayerRegistry.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * Verify the registry hook mounts a layer when its id enters
+ * `visibleLayers`, calls `update` on data changes, and unmounts when the
+ * id leaves the set. We feed the hook a tiny synthetic layer so we can
+ * assert directly on the lifecycle calls — no chart instance needed.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { ChartLayer, LayerCtx } from '../layers/types';
+import type { SessionTimeline } from '../types';
+import { makeTimeline } from './fixtures';
+
+vi.mock('../layers/registry', () => {
+  const lifecycle = {
+    mount: vi.fn(),
+    update: vi.fn(),
+    unmount: vi.fn(),
+  };
+  const fakeLayer: ChartLayer = {
+    id: 'fake',
+    name: 'Fake',
+    swatch: '#fff',
+    defaultVisible: false,
+    mount(_ctx: LayerCtx) {
+      void _ctx;
+      lifecycle.mount();
+      return {
+        update: (...args: unknown[]) => lifecycle.update(...args),
+        unmount: () => lifecycle.unmount(),
+      };
+    },
+  };
+  return {
+    LAYERS: [fakeLayer],
+    DEFAULT_VISIBLE: new Set<string>(),
+    findLayer: (id: string) => (id === 'fake' ? fakeLayer : undefined),
+    __lifecycle: lifecycle,
+  };
+});
+
+import { useLayerRegistry } from '../hooks/useLayerRegistry';
+import * as registry from '../layers/registry';
+
+const lifecycle = (registry as unknown as { __lifecycle: { mount: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn>; unmount: ReturnType<typeof vi.fn> } }).__lifecycle;
+
+const fakeCtx = { chart: {}, primarySeries: {}, theme: 'dark' } as unknown as LayerCtx;
+
+describe('useLayerRegistry', () => {
+  it('mounts when ctx + visibleLayers contains the id; unmounts when removed', () => {
+    lifecycle.mount.mockClear();
+    lifecycle.update.mockClear();
+    lifecycle.unmount.mockClear();
+
+    const tl: SessionTimeline = makeTimeline(2);
+    const visible = new Set<string>(['fake']);
+
+    const { rerender, unmount } = renderHook(
+      ({ ctx, vis, idx }: { ctx: LayerCtx | null; vis: Set<string>; idx: number }) =>
+        useLayerRegistry(ctx, tl, idx, vis),
+      { initialProps: { ctx: fakeCtx, vis: visible, idx: 0 } },
+    );
+    expect(lifecycle.mount).toHaveBeenCalledTimes(1);
+    expect(lifecycle.update).toHaveBeenCalled();
+
+    // Move the cursor — should re-call update.
+    lifecycle.update.mockClear();
+    rerender({ ctx: fakeCtx, vis: visible, idx: 1 });
+    expect(lifecycle.update).toHaveBeenCalled();
+
+    // Hide the layer — should unmount.
+    rerender({ ctx: fakeCtx, vis: new Set<string>(), idx: 1 });
+    expect(lifecycle.unmount).toHaveBeenCalledTimes(1);
+
+    unmount();
+  });
+});

--- a/ui/src/features/studio/__tests__/visibleLayersStore.test.ts
+++ b/ui/src/features/studio/__tests__/visibleLayersStore.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+// jsdom in this project ships an empty `localStorage` shim. Provide an
+// in-memory replacement before the store module is imported so its module-load
+// `readVisibleLayersFromStorage` call sees a working API.
+function installLocalStorage() {
+  const map = new Map<string, string>();
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+      setItem: (k: string, v: string) => map.set(k, String(v)),
+      removeItem: (k: string) => map.delete(k),
+      clear: () => map.clear(),
+      key: (i: number) => [...map.keys()][i] ?? null,
+      get length() {
+        return map.size;
+      },
+    },
+  });
+}
+installLocalStorage();
+
+const { LAYERS_STORAGE_KEY, hasStoredVisibleLayers, useStudioStore } = await import('../store');
+
+const reset = () => useStudioStore.getState().actions.reset();
+
+function clearStudioStorage() {
+  try {
+    window.localStorage.removeItem(LAYERS_STORAGE_KEY);
+  } catch {
+    /* jsdom variants without write support — non-fatal for tests */
+  }
+}
+
+beforeEach(() => {
+  clearStudioStorage();
+  reset();
+});
+
+afterEach(() => {
+  clearStudioStorage();
+  reset();
+});
+
+describe('visibleLayers store', () => {
+  it('starts empty when no localStorage entry exists', () => {
+    expect(useStudioStore.getState().visibleLayers.size).toBe(0);
+    expect(hasStoredVisibleLayers()).toBe(false);
+  });
+
+  it('toggleLayer adds and removes ids and persists to localStorage', () => {
+    const { actions } = useStudioStore.getState();
+    actions.toggleLayer('regime');
+    expect(useStudioStore.getState().visibleLayers.has('regime')).toBe(true);
+    expect(JSON.parse(window.localStorage.getItem(LAYERS_STORAGE_KEY) ?? '[]')).toEqual([
+      'regime',
+    ]);
+
+    actions.toggleLayer('regime');
+    expect(useStudioStore.getState().visibleLayers.has('regime')).toBe(false);
+    expect(JSON.parse(window.localStorage.getItem(LAYERS_STORAGE_KEY) ?? '[]')).toEqual([]);
+  });
+
+  it('setVisibleLayers replaces the entire set and persists', () => {
+    const { actions } = useStudioStore.getState();
+    actions.setVisibleLayers(['regime', 'swings', 'fills']);
+    expect([...useStudioStore.getState().visibleLayers].sort()).toEqual([
+      'fills',
+      'regime',
+      'swings',
+    ]);
+    expect(hasStoredVisibleLayers()).toBe(true);
+  });
+
+  it('rejects malformed localStorage payloads silently', () => {
+    window.localStorage.setItem(LAYERS_STORAGE_KEY, 'not-json');
+    // Forcing a fresh read by toggling something — the read happens at module load
+    // so we exercise the helper directly:
+    expect(hasStoredVisibleLayers()).toBe(false);
+  });
+});

--- a/ui/src/features/studio/components/BrooksStudioPage.tsx
+++ b/ui/src/features/studio/components/BrooksStudioPage.tsx
@@ -18,6 +18,7 @@ import {
 import { ChartCanvas } from './chart/ChartCanvas';
 import { TimelineScrubber } from './timeline/TimelineScrubber';
 import { PlaybackControls } from './timeline/PlaybackControls';
+import { LayerToggle } from './timeline/LayerToggle';
 
 export default function BrooksStudioPage() {
   const { sessionId } = useParams<{ sessionId: string }>();
@@ -54,6 +55,9 @@ export default function BrooksStudioPage() {
 
       <div className="relative min-h-0 flex-1 overflow-hidden rounded-xl border border-border/70 bg-[#0e1116]">
         <ChartCanvas />
+        <div className="pointer-events-auto absolute right-3 top-3 z-10">
+          <LayerToggle />
+        </div>
         {loading && !timeline && (
           <div className="absolute inset-0 flex items-center justify-center bg-black/30 text-xs text-muted-foreground">
             Loading timeline…

--- a/ui/src/features/studio/components/chart/ChartCanvas.tsx
+++ b/ui/src/features/studio/components/chart/ChartCanvas.tsx
@@ -1,16 +1,15 @@
 /**
- * ChartCanvas — bare lightweight-charts candlestick container.
+ * ChartCanvas — bare lightweight-charts candlestick container with the
+ * pluggable layer registry mounted on top.
  *
- * Owns the `IChartApi` instance via `useEffect(create / cleanup)` and
- * surfaces it through a layer-registry callback so future S3 layers can
- * mount additional series/markers/primitives without touching this file.
- *
- * The chart re-uses ResizeObserver for parent-size tracking. Live bar
- * updates use `series.update()` (single-bar diff) when the new bar shares
- * the same timestamp as the last point, otherwise we append.
+ * Owns the `IChartApi` instance via `useEffect(create / cleanup)` and surfaces
+ * it through `useLayerRegistry` so every registered layer mounts onto the
+ * same chart. Live bar updates use `series.update()` (single-bar diff) when
+ * the new bar shares the same timestamp as the last point, otherwise we
+ * append.
  */
 
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   ColorType,
   CandlestickSeries,
@@ -22,22 +21,14 @@ import {
   type UTCTimestamp,
 } from 'lightweight-charts';
 import type { Bar } from '../../types';
-import { useEffectiveBarIdx, useStudioActions, useTimelineState } from '../../store';
-
-export interface ChartLayerCtx {
-  chart: IChartApi;
-  primarySeries: ISeriesApi<'Candlestick'>;
-}
-
-interface ChartCanvasProps {
-  /**
-   * Optional callback invoked once after chart mount and after every
-   * tear-down, so future S3 layer plugins can attach extra series /
-   * markers / primitives. Returning a cleanup function from this
-   * registry hook is mandatory.
-   */
-  onChartReady?: (ctx: ChartLayerCtx) => () => void;
-}
+import {
+  useEffectiveBarIdx,
+  useStudioActions,
+  useTimelineState,
+  useVisibleLayers,
+} from '../../store';
+import { useLayerRegistry } from '../../hooks/useLayerRegistry';
+import type { LayerCtx } from '../../layers/types';
 
 const THEME = {
   background: '#0e1116',
@@ -62,18 +53,23 @@ function toCandlestickData(bars: Bar[]): CandlestickData<UTCTimestamp>[] {
   return out;
 }
 
-export function ChartCanvas({ onChartReady }: ChartCanvasProps) {
+export function ChartCanvas() {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const chartRef = useRef<IChartApi | null>(null);
   const seriesRef = useRef<ISeriesApi<'Candlestick'> | null>(null);
   const lastBarCountRef = useRef(0);
   const fittedRef = useRef(false);
 
+  const [layerCtx, setLayerCtx] = useState<LayerCtx | null>(null);
+
   const timeline = useTimelineState();
   const currentBarIdx = useEffectiveBarIdx();
+  const visibleLayers = useVisibleLayers();
   const { setHoveredBar } = useStudioActions();
 
   const candles = useMemo(() => (timeline ? toCandlestickData(timeline.bars) : []), [timeline]);
+
+  useLayerRegistry(layerCtx, timeline, currentBarIdx, visibleLayers);
 
   // Mount chart once.
   useEffect(() => {
@@ -115,7 +111,7 @@ export function ChartCanvas({ onChartReady }: ChartCanvasProps) {
     });
     ro.observe(container);
 
-    const subscription = chart.subscribeCrosshairMove((param) => {
+    chart.subscribeCrosshairMove((param) => {
       if (!param.time || !timeline) {
         setHoveredBar(null);
         return;
@@ -127,15 +123,11 @@ export function ChartCanvas({ onChartReady }: ChartCanvasProps) {
       setHoveredBar(idx >= 0 ? idx : null);
     });
 
-    let cleanupLayers: (() => void) | undefined;
-    if (onChartReady) {
-      cleanupLayers = onChartReady({ chart, primarySeries: series });
-    }
+    setLayerCtx({ chart, primarySeries: series, theme: 'dark' });
 
     return () => {
-      cleanupLayers?.();
+      setLayerCtx(null);
       ro.disconnect();
-      subscription;
       chart.remove();
       chartRef.current = null;
       seriesRef.current = null;

--- a/ui/src/features/studio/components/timeline/LayerToggle.tsx
+++ b/ui/src/features/studio/components/timeline/LayerToggle.tsx
@@ -1,0 +1,98 @@
+/**
+ * LayerToggle — checkbox panel for the registered chart layers.
+ *
+ * On first mount, if the user has no localStorage entry yet, we seed the
+ * store from `DEFAULT_VISIBLE` (the union of layers whose `defaultVisible`
+ * is `true`). After that the store is the source of truth and every toggle
+ * is mirrored to localStorage by the store action.
+ *
+ * Adding a new layer to `LAYERS` makes it appear here automatically — no
+ * edits required.
+ */
+
+import { useEffect, useState } from 'react';
+import { ChevronLeft, Layers } from 'lucide-react';
+import { Button } from '../../../../components/ui/button';
+import {
+  hasStoredVisibleLayers,
+  useStudioActions,
+  useVisibleLayers,
+} from '../../store';
+import { DEFAULT_VISIBLE, LAYERS } from '../../layers/registry';
+
+export function LayerToggle() {
+  const visible = useVisibleLayers();
+  const { setVisibleLayers, toggleLayer } = useStudioActions();
+  const [collapsed, setCollapsed] = useState(false);
+
+  // First-time hydrate: if the user has no stored preference, seed defaults.
+  useEffect(() => {
+    if (hasStoredVisibleLayers()) return;
+    setVisibleLayers(DEFAULT_VISIBLE);
+    // intentionally one-shot at mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (collapsed) {
+    return (
+      <Button
+        variant="secondary"
+        size="icon"
+        onClick={() => setCollapsed(false)}
+        title="Show layers"
+        aria-label="Show layers"
+        data-testid="layer-toggle-expand"
+      >
+        <Layers className="size-4" />
+      </Button>
+    );
+  }
+
+  return (
+    <div
+      className="flex flex-col gap-1.5 rounded-md border border-border/70 bg-card/70 p-2 text-xs shadow-sm"
+      data-testid="layer-toggle"
+    >
+      <div className="flex items-center justify-between gap-2 pb-1">
+        <span className="flex items-center gap-1.5 font-medium text-foreground">
+          <Layers className="size-3.5" /> Layers
+        </span>
+        <button
+          type="button"
+          onClick={() => setCollapsed(true)}
+          className="rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+          aria-label="Collapse layers"
+          title="Collapse"
+        >
+          <ChevronLeft className="size-3.5" />
+        </button>
+      </div>
+      <div className="flex flex-col gap-1">
+        {LAYERS.map((layer) => {
+          const isOn = visible.has(layer.id);
+          return (
+            <label
+              key={layer.id}
+              className="flex cursor-pointer items-center gap-2 rounded px-1 py-1 hover:bg-accent/50"
+            >
+              <input
+                type="checkbox"
+                checked={isOn}
+                onChange={() => toggleLayer(layer.id)}
+                className="size-3.5 cursor-pointer accent-primary"
+                aria-label={`Toggle layer ${layer.name}`}
+                data-testid={`layer-toggle-${layer.id}`}
+              />
+              <span
+                aria-hidden
+                className="size-2.5 rounded-sm"
+                style={{ backgroundColor: layer.swatch }}
+              />
+              <span className="text-foreground">{layer.name}</span>
+            </label>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/features/studio/hooks/useLayerRegistry.ts
+++ b/ui/src/features/studio/hooks/useLayerRegistry.ts
@@ -1,59 +1,84 @@
 /**
- * Layer registry stub for Phase S3.
+ * Bridges the registered chart layers (`layers/registry.ts`) to the
+ * lightweight-charts instance owned by `ChartCanvas`.
  *
- * S2 ships only the bare candle chart. The registry plug point exists now
- * so `ChartCanvas` doesn't need re-shaping later: S3 will populate the
- * `LAYERS` array and pass each layer's `mount()` through this hook.
+ * Mount/unmount cycle:
+ *   - When a layer's `id` enters `visibleLayers`, we call `layer.mount()`
+ *     against the chart context and keep the returned handle.
+ *   - When it leaves, we call `handle.unmount()` and drop the handle.
+ *   - On every timeline / currentBarIdx change, we call `update()` on every
+ *     mounted handle.
+ *
+ * The chart context (`LayerCtx`) is allowed to be null while the canvas is
+ * still booting; in that state the hook does nothing.
  */
 
-import { useEffect } from 'react';
-import type { IChartApi, ISeriesApi } from 'lightweight-charts';
+import { useEffect, useRef } from 'react';
+import type { LayerCtx, LayerHandle } from '../layers/types';
+import { LAYERS, findLayer } from '../layers/registry';
 import type { SessionTimeline } from '../types';
 
-export interface LayerCtx {
-  chart: IChartApi;
-  primarySeries: ISeriesApi<'Candlestick'>;
-  theme: 'dark' | 'light';
-}
-
-export interface LayerHandle {
-  update: (timeline: SessionTimeline, currentBarIdx: number) => void;
-  unmount: () => void;
-}
-
-export interface ChartLayer {
-  id: string;
-  name: string;
-  defaultVisible: boolean;
-  mount: (ctx: LayerCtx) => LayerHandle;
-}
-
-/**
- * S2 ships an empty registry. S3 will fill this in with regime / swings /
- * ema / signals / decisions / fills layers.
- */
-export const LAYERS: readonly ChartLayer[] = [];
-
-/**
- * Mount any registered layers onto the given chart instance and update them
- * whenever timeline / currentBarIdx change. Currently a no-op (empty
- * registry); kept here so `ChartCanvas` can call it unconditionally.
- */
 export function useLayerRegistry(
   ctx: LayerCtx | null,
   timeline: SessionTimeline | null,
   currentBarIdx: number,
+  visibleLayers: ReadonlySet<string>,
 ) {
+  // Map of layer id → mounted handle. Persists across renders so we can
+  // diff mount/unmount across visibility changes.
+  const handlesRef = useRef<Map<string, LayerHandle>>(new Map());
+
+  // Mount / unmount on visibility change.
   useEffect(() => {
     if (!ctx) return;
-    const handles = LAYERS.map((layer) => ({ layer, handle: layer.mount(ctx) }));
+    const handles = handlesRef.current;
+
+    // Add newly visible layers.
+    for (const layer of LAYERS) {
+      if (visibleLayers.has(layer.id) && !handles.has(layer.id)) {
+        handles.set(layer.id, layer.mount(ctx));
+      }
+    }
+    // Remove no-longer-visible layers.
+    for (const id of [...handles.keys()]) {
+      if (!visibleLayers.has(id)) {
+        const handle = handles.get(id);
+        try {
+          handle?.unmount();
+        } catch {
+          // already torn down — ignore
+        }
+        handles.delete(id);
+      }
+    }
+
+    // After mount/unmount, push the current data into newly mounted layers
+    // so they don't wait until the next data tick to render.
+    if (timeline) {
+      for (const [id, handle] of handles.entries()) {
+        if (!findLayer(id)) continue;
+        try {
+          handle.update(timeline, currentBarIdx);
+        } catch (e) {
+          console.error(`[layers] update failed for "${id}"`, e);
+        }
+      }
+    }
+  }, [ctx, visibleLayers, timeline, currentBarIdx]);
+
+  // Tear everything down when the canvas remounts or unmounts.
+  useEffect(() => {
+    // Capture the live Map; ref identity may change before cleanup runs.
+    const handles = handlesRef.current;
     return () => {
-      for (const { handle } of handles) handle.unmount();
+      for (const handle of handles.values()) {
+        try {
+          handle.unmount();
+        } catch {
+          // chart already disposed
+        }
+      }
+      handles.clear();
     };
   }, [ctx]);
-
-  useEffect(() => {
-    if (!ctx || !timeline) return;
-    // S3: iterate through visible layers and call .update().
-  }, [ctx, timeline, currentBarIdx]);
 }

--- a/ui/src/features/studio/layers/decisions.ts
+++ b/ui/src/features/studio/layers/decisions.ts
@@ -1,0 +1,158 @@
+/**
+ * Decisions layer — solid in-bar arrows for accepted Brooks decisions, plus
+ * entry / stop / target price lines for any decision within
+ * `currentBarIdx ± WINDOW`. Outside the window the lines are removed so a
+ * busy chart doesn't drown in horizontals.
+ */
+
+import {
+  LineStyle,
+  createSeriesMarkers,
+  type IPriceLine,
+  type ISeriesMarkersPluginApi,
+  type SeriesMarker,
+  type Time,
+  type UTCTimestamp,
+} from 'lightweight-charts';
+import type { ChartLayer, LayerCtx, LayerHandle } from './types';
+import type { Decision, SessionTimeline } from '../types';
+
+const LONG_COLOR = '#26A69A';
+const SHORT_COLOR = '#EF5350';
+const ENTRY_COLOR = '#FFCA28';
+const STOP_COLOR = '#EF5350';
+const TARGET_COLOR = '#26A69A';
+
+const PRICE_LINE_WINDOW = 5;
+
+export function decisionColor(side: Decision['side']): string {
+  return side === 'long' ? LONG_COLOR : SHORT_COLOR;
+}
+
+function timeForBar(timeline: SessionTimeline, idx: number): UTCTimestamp | null {
+  const bar = timeline.bars[idx];
+  if (!bar) return null;
+  return Math.floor(bar.timestamp_ns / 1_000_000_000) as UTCTimestamp;
+}
+
+export interface BuiltDecision {
+  decision: Decision;
+  bar_idx: number;
+}
+
+export function collectDecisions(
+  timeline: SessionTimeline,
+  currentBarIdx: number,
+): BuiltDecision[] {
+  const out: BuiltDecision[] = [];
+  for (const ev of timeline.events) {
+    if (ev.bar_idx > currentBarIdx) continue;
+    if (!ev.decision) continue;
+    out.push({ decision: ev.decision, bar_idx: ev.bar_idx });
+  }
+  return out;
+}
+
+export function buildDecisionMarkers(
+  timeline: SessionTimeline,
+  currentBarIdx: number,
+): SeriesMarker<Time>[] {
+  const out: SeriesMarker<Time>[] = [];
+  for (const { decision, bar_idx } of collectDecisions(timeline, currentBarIdx)) {
+    const t = timeForBar(timeline, bar_idx);
+    if (t === null) continue;
+    out.push({
+      time: t as Time,
+      position: 'inBar',
+      shape: decision.side === 'long' ? 'arrowUp' : 'arrowDown',
+      color: decisionColor(decision.side),
+      text: `${decision.side.toUpperCase()} ${decision.pattern}`,
+      size: 2,
+      id: `dec-${bar_idx}`,
+    });
+  }
+  out.sort((a, b) => (a.time as number) - (b.time as number));
+  return out;
+}
+
+export function decisionsInWindow(
+  timeline: SessionTimeline,
+  currentBarIdx: number,
+  window: number = PRICE_LINE_WINDOW,
+): BuiltDecision[] {
+  const lo = Math.max(0, currentBarIdx - window);
+  const hi = currentBarIdx + window;
+  const out: BuiltDecision[] = [];
+  for (const ev of timeline.events) {
+    if (!ev.decision) continue;
+    if (ev.bar_idx < lo || ev.bar_idx > hi) continue;
+    if (ev.bar_idx > currentBarIdx) continue; // never leak the future
+    out.push({ decision: ev.decision, bar_idx: ev.bar_idx });
+  }
+  return out;
+}
+
+export const decisionsLayer: ChartLayer = {
+  id: 'decisions',
+  name: 'Decisions',
+  swatch: LONG_COLOR,
+  defaultVisible: true,
+
+  mount(ctx: LayerCtx): LayerHandle {
+    let plugin: ISeriesMarkersPluginApi<Time> | null = createSeriesMarkers(
+      ctx.primarySeries,
+      [],
+    );
+    let priceLines: IPriceLine[] = [];
+
+    const clearLines = () => {
+      for (const pl of priceLines) {
+        try {
+          ctx.primarySeries.removePriceLine(pl);
+        } catch {
+          // series may already be detached
+        }
+      }
+      priceLines = [];
+    };
+
+    const addLine = (price: number, color: string, title: string) => {
+      priceLines.push(
+        ctx.primarySeries.createPriceLine({
+          price,
+          color,
+          lineWidth: 1,
+          lineStyle: LineStyle.Solid,
+          axisLabelVisible: true,
+          title,
+        }),
+      );
+    };
+
+    return {
+      update(timeline, currentBarIdx) {
+        if (!plugin) return;
+        plugin.setMarkers(buildDecisionMarkers(timeline, currentBarIdx));
+
+        clearLines();
+        for (const { decision, bar_idx } of decisionsInWindow(timeline, currentBarIdx)) {
+          addLine(decision.entry_px, ENTRY_COLOR, `entry @${bar_idx}`);
+          addLine(decision.stop_px, STOP_COLOR, `stop @${bar_idx}`);
+          if (decision.target_px != null) {
+            addLine(decision.target_px, TARGET_COLOR, `target @${bar_idx}`);
+          }
+        }
+      },
+      unmount() {
+        clearLines();
+        try {
+          plugin?.detach();
+        } catch {
+          // chart already disposed
+        }
+        plugin = null;
+      },
+    };
+  },
+};
+

--- a/ui/src/features/studio/layers/ema.ts
+++ b/ui/src/features/studio/layers/ema.ts
@@ -1,0 +1,107 @@
+/**
+ * EMA layer — EMA20 / EMA200 lines pulled from `event.features.ema20|ema200`.
+ *
+ * Both fields are optional (`FeaturesView` doesn't declare them but the
+ * backend may emit them as raw numbers); the layer silently skips bars where
+ * the value is missing. EMA200 commonly isn't computed for short sessions —
+ * it's defaulted off in the toggle panel.
+ */
+
+import {
+  LineSeries,
+  type ISeriesApi,
+  type LineData,
+  type UTCTimestamp,
+} from 'lightweight-charts';
+import type { ChartLayer, LayerCtx, LayerHandle } from './types';
+import type { SessionTimeline } from '../types';
+
+const EMA20_COLOR = '#FB8C00';
+const EMA200_COLOR = '#9C27B0';
+
+export function readEmaField(
+  features: SessionTimeline['events'][number]['features'] | null | undefined,
+  key: string,
+): number | null {
+  if (!features) return null;
+  const v = (features as unknown as Record<string, unknown>)[key];
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+
+export function buildEmaSeriesData(
+  timeline: SessionTimeline,
+  key: string,
+): LineData<UTCTimestamp>[] {
+  const eventByBar = new Map<number, SessionTimeline['events'][number]>();
+  for (const ev of timeline.events) eventByBar.set(ev.bar_idx, ev);
+
+  const seen = new Set<number>();
+  const out: LineData<UTCTimestamp>[] = [];
+  for (let i = 0; i < timeline.bars.length; i++) {
+    const ev = eventByBar.get(i);
+    const v = readEmaField(ev?.features, key);
+    if (v === null) continue;
+    const t = Math.floor(timeline.bars[i].timestamp_ns / 1_000_000_000);
+    if (seen.has(t)) continue;
+    seen.add(t);
+    out.push({ time: t as UTCTimestamp, value: v });
+  }
+  out.sort((a, b) => (a.time as number) - (b.time as number));
+  return out;
+}
+
+function makeEmaLayer(opts: {
+  id: string;
+  name: string;
+  field: string;
+  color: string;
+  defaultVisible: boolean;
+}): ChartLayer {
+  return {
+    id: opts.id,
+    name: opts.name,
+    swatch: opts.color,
+    defaultVisible: opts.defaultVisible,
+
+    mount(ctx: LayerCtx): LayerHandle {
+      let series: ISeriesApi<'Line'> | null = ctx.chart.addSeries(LineSeries, {
+        color: opts.color,
+        lineWidth: 2,
+        priceLineVisible: false,
+        lastValueVisible: false,
+        crosshairMarkerVisible: false,
+      });
+
+      return {
+        update(timeline) {
+          if (!series) return;
+          series.setData(buildEmaSeriesData(timeline, opts.field));
+        },
+        unmount() {
+          try {
+            if (series) ctx.chart.removeSeries(series);
+          } catch {
+            // chart already disposed
+          }
+          series = null;
+        },
+      };
+    },
+  };
+}
+
+export const ema20Layer = makeEmaLayer({
+  id: 'ema20',
+  name: 'EMA 20',
+  field: 'ema20',
+  color: EMA20_COLOR,
+  defaultVisible: true,
+});
+
+export const ema200Layer = makeEmaLayer({
+  id: 'ema200',
+  name: 'EMA 200',
+  field: 'ema200',
+  color: EMA200_COLOR,
+  defaultVisible: false,
+});

--- a/ui/src/features/studio/layers/fills.ts
+++ b/ui/src/features/studio/layers/fills.ts
@@ -1,0 +1,86 @@
+/**
+ * Fills layer — diamond-style markers for actual order fills.
+ *
+ * `buy` / `buy_to_cover` → green ▲ above bar.
+ * `sell` / `sell_short`  → red ▼ below bar.
+ * Marker text shows the fill price for quick read-off.
+ */
+
+import {
+  createSeriesMarkers,
+  type ISeriesMarkersPluginApi,
+  type SeriesMarker,
+  type Time,
+  type UTCTimestamp,
+} from 'lightweight-charts';
+import type { ChartLayer, LayerCtx, LayerHandle } from './types';
+import type { FillView, SessionTimeline } from '../types';
+
+const BUY_COLOR = '#26A69A';
+const SELL_COLOR = '#EF5350';
+
+const BUY_SIDES: ReadonlySet<FillView['side']> = new Set(['buy', 'buy_to_cover']);
+
+export function isBuyFill(side: FillView['side']): boolean {
+  return BUY_SIDES.has(side);
+}
+
+function timeForBar(timeline: SessionTimeline, idx: number): UTCTimestamp | null {
+  const bar = timeline.bars[idx];
+  if (!bar) return null;
+  return Math.floor(bar.timestamp_ns / 1_000_000_000) as UTCTimestamp;
+}
+
+export function buildFillMarkers(
+  timeline: SessionTimeline,
+  currentBarIdx: number,
+): SeriesMarker<Time>[] {
+  const out: SeriesMarker<Time>[] = [];
+  for (const ev of timeline.events) {
+    if (ev.bar_idx > currentBarIdx) continue;
+    if (!ev.fill) continue;
+    const t = timeForBar(timeline, ev.bar_idx);
+    if (t === null) continue;
+    const buy = isBuyFill(ev.fill.side);
+    out.push({
+      time: t as Time,
+      position: buy ? 'aboveBar' : 'belowBar',
+      shape: buy ? 'arrowUp' : 'arrowDown',
+      color: buy ? BUY_COLOR : SELL_COLOR,
+      text: `◆ ${ev.fill.price.toFixed(2)}`,
+      size: 1,
+      id: `fill-${ev.bar_idx}-${ev.fill.side}`,
+    });
+  }
+  out.sort((a, b) => (a.time as number) - (b.time as number));
+  return out;
+}
+
+export const fillsLayer: ChartLayer = {
+  id: 'fills',
+  name: 'Fills',
+  swatch: BUY_COLOR,
+  defaultVisible: true,
+
+  mount(ctx: LayerCtx): LayerHandle {
+    let plugin: ISeriesMarkersPluginApi<Time> | null = createSeriesMarkers(
+      ctx.primarySeries,
+      [],
+    );
+
+    return {
+      update(timeline, currentBarIdx) {
+        if (!plugin) return;
+        plugin.setMarkers(buildFillMarkers(timeline, currentBarIdx));
+      },
+      unmount() {
+        try {
+          plugin?.detach();
+        } catch {
+          // chart already disposed
+        }
+        plugin = null;
+      },
+    };
+  },
+};

--- a/ui/src/features/studio/layers/regime.ts
+++ b/ui/src/features/studio/layers/regime.ts
@@ -1,0 +1,86 @@
+/**
+ * Regime layer — bottom 5% color band coloured per-bar by `event.regime.name`.
+ *
+ * Implemented as a HistogramSeries on its own overlay price scale so it
+ * occupies a thin strip beneath the candles without disturbing the price axis.
+ */
+
+import {
+  HistogramSeries,
+  type HistogramData,
+  type ISeriesApi,
+  type UTCTimestamp,
+} from 'lightweight-charts';
+import type { ChartLayer, LayerCtx, LayerHandle } from './types';
+import type { SessionTimeline } from '../types';
+
+const REGIME_COLORS: Record<string, string> = {
+  strong_bull_trend: 'rgba(38, 166, 154, 0.45)',
+  weak_bull_trend: 'rgba(38, 166, 154, 0.22)',
+  strong_bear_trend: 'rgba(239, 83, 80, 0.45)',
+  weak_bear_trend: 'rgba(239, 83, 80, 0.22)',
+  tight_tr: 'rgba(120, 120, 120, 0.30)',
+  broad_tr: 'rgba(120, 120, 120, 0.18)',
+  climax: 'rgba(255, 152, 0, 0.55)',
+  channel: 'rgba(96, 165, 250, 0.35)',
+  pullback: 'rgba(180, 180, 180, 0.20)',
+};
+const REGIME_FALLBACK = 'rgba(80, 80, 80, 0.10)';
+
+export function regimeColorOf(name: string | undefined | null): string {
+  if (!name) return REGIME_FALLBACK;
+  return REGIME_COLORS[name] ?? REGIME_FALLBACK;
+}
+
+const PRICE_SCALE_ID = 'regime-band';
+
+export const regimeLayer: ChartLayer = {
+  id: 'regime',
+  name: 'Regime band',
+  swatch: REGIME_COLORS.strong_bull_trend,
+  defaultVisible: true,
+
+  mount(ctx: LayerCtx): LayerHandle {
+    const { chart } = ctx;
+    const series: ISeriesApi<'Histogram'> = chart.addSeries(HistogramSeries, {
+      priceScaleId: PRICE_SCALE_ID,
+      priceLineVisible: false,
+      lastValueVisible: false,
+      base: 0,
+    });
+    chart.priceScale(PRICE_SCALE_ID).applyOptions({
+      scaleMargins: { top: 0.95, bottom: 0 },
+    });
+
+    return {
+      update(timeline: SessionTimeline) {
+        const eventByBar = new Map<number, string | null | undefined>();
+        for (const ev of timeline.events) {
+          eventByBar.set(ev.bar_idx, ev.regime?.name);
+        }
+        const seen = new Set<number>();
+        const data: HistogramData<UTCTimestamp>[] = [];
+        for (let i = 0; i < timeline.bars.length; i++) {
+          const bar = timeline.bars[i];
+          const t = Math.floor(bar.timestamp_ns / 1_000_000_000);
+          if (seen.has(t)) continue;
+          seen.add(t);
+          data.push({
+            time: t as UTCTimestamp,
+            value: 1,
+            color: regimeColorOf(eventByBar.get(i)),
+          });
+        }
+        data.sort((a, b) => (a.time as number) - (b.time as number));
+        series.setData(data);
+      },
+      unmount() {
+        try {
+          chart.removeSeries(series);
+        } catch {
+          // chart already disposed
+        }
+      },
+    };
+  },
+};

--- a/ui/src/features/studio/layers/registry.ts
+++ b/ui/src/features/studio/layers/registry.ts
@@ -1,0 +1,38 @@
+/**
+ * Registry of every chart layer Brooks Studio knows about.
+ *
+ * Order is the order they appear in the `LayerToggle` panel and the order
+ * they mount onto the chart. Adding a new layer = export a `ChartLayer`
+ * from a sibling file and append it here.
+ *
+ * Phase S5 will append: channelsLayer, stopAdjLayer, htfOverlayLayer,
+ * reasoningLayer.
+ */
+
+import type { ChartLayer } from './types';
+import { regimeLayer } from './regime';
+import { swingsLayer } from './swings';
+import { ema20Layer, ema200Layer } from './ema';
+import { signalsLayer } from './signals';
+import { decisionsLayer } from './decisions';
+import { fillsLayer } from './fills';
+
+export const LAYERS: readonly ChartLayer[] = [
+  regimeLayer,
+  swingsLayer,
+  ema20Layer,
+  ema200Layer,
+  signalsLayer,
+  decisionsLayer,
+  fillsLayer,
+];
+
+export const DEFAULT_VISIBLE: ReadonlySet<string> = new Set(
+  LAYERS.filter((l) => l.defaultVisible).map((l) => l.id),
+);
+
+export function findLayer(id: string): ChartLayer | undefined {
+  return LAYERS.find((l) => l.id === id);
+}
+
+export type { ChartLayer, LayerCtx, LayerHandle } from './types';

--- a/ui/src/features/studio/layers/signals.ts
+++ b/ui/src/features/studio/layers/signals.ts
@@ -1,0 +1,159 @@
+/**
+ * Signals layer — circle markers for every detector signal up to (and
+ * including) the current bar, plus entry / stop price lines for any signals
+ * landing on the current bar.
+ *
+ * Future-info safety: signals from `bar_idx > currentBarIdx` are filtered out
+ * before render, so scrubbing back hides them.
+ */
+
+import {
+  LineStyle,
+  createSeriesMarkers,
+  type IPriceLine,
+  type ISeriesMarkersPluginApi,
+  type SeriesMarker,
+  type Time,
+  type UTCTimestamp,
+} from 'lightweight-charts';
+import type { ChartLayer, LayerCtx, LayerHandle } from './types';
+import type { SessionTimeline, Signal } from '../types';
+
+const LONG_COLOR = '#26A69A';
+const SHORT_COLOR = '#EF5350';
+const NEUTRAL_COLOR = '#90A4AE';
+const ENTRY_LINE_COLOR = '#FFD54F';
+const STOP_LINE_COLOR = '#EF5350';
+
+export function signalColor(side: Signal['side']): string {
+  if (side === 'long') return LONG_COLOR;
+  if (side === 'short') return SHORT_COLOR;
+  return NEUTRAL_COLOR;
+}
+
+function timeForBar(timeline: SessionTimeline, idx: number): UTCTimestamp | null {
+  const bar = timeline.bars[idx];
+  if (!bar) return null;
+  return Math.floor(bar.timestamp_ns / 1_000_000_000) as UTCTimestamp;
+}
+
+function readSignalPrice(sig: Signal, key: string): number | null {
+  const v = (sig as Record<string, unknown>)[key];
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+
+export interface BuiltSignal {
+  signal: Signal;
+  bar_idx: number;
+}
+
+export function collectSignals(
+  timeline: SessionTimeline,
+  currentBarIdx: number,
+): BuiltSignal[] {
+  const out: BuiltSignal[] = [];
+  for (const ev of timeline.events) {
+    if (ev.bar_idx > currentBarIdx) continue;
+    if (!ev.signals?.length) continue;
+    for (const s of ev.signals) {
+      out.push({ signal: s, bar_idx: ev.bar_idx });
+    }
+  }
+  return out;
+}
+
+export function buildSignalMarkers(
+  timeline: SessionTimeline,
+  currentBarIdx: number,
+): SeriesMarker<Time>[] {
+  const out: SeriesMarker<Time>[] = [];
+  for (const { signal, bar_idx } of collectSignals(timeline, currentBarIdx)) {
+    const t = timeForBar(timeline, bar_idx);
+    if (t === null) continue;
+    out.push({
+      time: t as Time,
+      position: signal.side === 'short' ? 'aboveBar' : 'belowBar',
+      shape: 'circle',
+      color: signalColor(signal.side),
+      text: signal.pattern ?? signal.source ?? '✦',
+      size: 1,
+      id: signal.id ?? `sig-${bar_idx}-${signal.pattern ?? 'x'}`,
+    });
+  }
+  out.sort((a, b) => (a.time as number) - (b.time as number));
+  return out;
+}
+
+export const signalsLayer: ChartLayer = {
+  id: 'signals',
+  name: 'Signals',
+  swatch: LONG_COLOR,
+  defaultVisible: true,
+
+  mount(ctx: LayerCtx): LayerHandle {
+    let plugin: ISeriesMarkersPluginApi<Time> | null = createSeriesMarkers(
+      ctx.primarySeries,
+      [],
+    );
+    let priceLines: IPriceLine[] = [];
+
+    const clearLines = () => {
+      for (const pl of priceLines) {
+        try {
+          ctx.primarySeries.removePriceLine(pl);
+        } catch {
+          // series may already be detached
+        }
+      }
+      priceLines = [];
+    };
+
+    return {
+      update(timeline, currentBarIdx) {
+        if (!plugin) return;
+        plugin.setMarkers(buildSignalMarkers(timeline, currentBarIdx));
+
+        clearLines();
+        const ev = timeline.events.find((e) => e.bar_idx === currentBarIdx);
+        if (!ev?.signals?.length) return;
+        for (const sig of ev.signals) {
+          const entry = readSignalPrice(sig, 'entry_px') ?? readSignalPrice(sig, 'entry');
+          const stop = readSignalPrice(sig, 'stop_px') ?? readSignalPrice(sig, 'stop');
+          if (entry !== null) {
+            priceLines.push(
+              ctx.primarySeries.createPriceLine({
+                price: entry,
+                color: ENTRY_LINE_COLOR,
+                lineWidth: 1,
+                lineStyle: LineStyle.Dotted,
+                axisLabelVisible: true,
+                title: `entry ${sig.pattern ?? ''}`,
+              }),
+            );
+          }
+          if (stop !== null) {
+            priceLines.push(
+              ctx.primarySeries.createPriceLine({
+                price: stop,
+                color: STOP_LINE_COLOR,
+                lineWidth: 1,
+                lineStyle: LineStyle.Dotted,
+                axisLabelVisible: true,
+                title: `stop ${sig.pattern ?? ''}`,
+              }),
+            );
+          }
+        }
+      },
+      unmount() {
+        clearLines();
+        try {
+          plugin?.detach();
+        } catch {
+          // chart already disposed
+        }
+        plugin = null;
+      },
+    };
+  },
+};

--- a/ui/src/features/studio/layers/swings.ts
+++ b/ui/src/features/studio/layers/swings.ts
@@ -1,0 +1,97 @@
+/**
+ * Swings layer — ▲▼ markers for confirmed swing high/low points.
+ *
+ * Reads `event.structure.confirmed_swings` from the most recent event at or
+ * before `currentBarIdx`. The Brooks pipeline accumulates this list, so the
+ * latest event has every swing visible up to that bar.
+ */
+
+import {
+  createSeriesMarkers,
+  type ISeriesMarkersPluginApi,
+  type SeriesMarker,
+  type Time,
+  type UTCTimestamp,
+} from 'lightweight-charts';
+import type { ChartLayer, LayerCtx, LayerHandle } from './types';
+import type { SessionTimeline, SwingPoint } from '../types';
+
+const HIGH_COLOR = '#EF5350';
+const LOW_COLOR = '#26A69A';
+
+export function isHighSwing(kind: string): boolean {
+  return /high/i.test(kind);
+}
+
+function timeForBar(timeline: SessionTimeline, idx: number): UTCTimestamp | null {
+  const bar = timeline.bars[idx];
+  if (!bar) return null;
+  return Math.floor(bar.timestamp_ns / 1_000_000_000) as UTCTimestamp;
+}
+
+function latestStructureSwings(
+  timeline: SessionTimeline,
+  currentBarIdx: number,
+): SwingPoint[] {
+  for (let i = Math.min(currentBarIdx, timeline.events.length - 1); i >= 0; i--) {
+    const ev = timeline.events[i];
+    if (ev?.structure?.confirmed_swings?.length) {
+      return ev.structure.confirmed_swings;
+    }
+  }
+  return [];
+}
+
+export function buildSwingMarkers(
+  timeline: SessionTimeline,
+  currentBarIdx: number,
+): SeriesMarker<Time>[] {
+  const swings = latestStructureSwings(timeline, currentBarIdx);
+  const out: SeriesMarker<Time>[] = [];
+  for (const s of swings) {
+    if (s.idx > currentBarIdx) continue;
+    const t = timeForBar(timeline, s.idx);
+    if (t === null) continue;
+    const high = isHighSwing(s.kind);
+    out.push({
+      time: t as Time,
+      position: high ? 'aboveBar' : 'belowBar',
+      shape: high ? 'arrowDown' : 'arrowUp',
+      color: high ? HIGH_COLOR : LOW_COLOR,
+      text: `#${s.idx}`,
+      size: 1,
+      id: `swing-${s.idx}-${s.kind}`,
+    });
+  }
+  out.sort((a, b) => (a.time as number) - (b.time as number));
+  return out;
+}
+
+export const swingsLayer: ChartLayer = {
+  id: 'swings',
+  name: 'Swings',
+  swatch: LOW_COLOR,
+  defaultVisible: true,
+
+  mount(ctx: LayerCtx): LayerHandle {
+    let plugin: ISeriesMarkersPluginApi<Time> | null = createSeriesMarkers(
+      ctx.primarySeries,
+      [],
+    );
+
+    return {
+      update(timeline, currentBarIdx) {
+        if (!plugin) return;
+        plugin.setMarkers(buildSwingMarkers(timeline, currentBarIdx));
+      },
+      unmount() {
+        try {
+          plugin?.detach();
+        } catch {
+          // chart already disposed
+        }
+        plugin = null;
+      },
+    };
+  },
+};

--- a/ui/src/features/studio/layers/types.ts
+++ b/ui/src/features/studio/layers/types.ts
@@ -1,0 +1,31 @@
+/**
+ * ChartLayer protocol — every overlay (regime band, swings, ema, signals,
+ * decisions, fills, …) implements this so they can be mounted, updated, and
+ * unmounted uniformly. New layers plug in by exporting one and adding it to
+ * `LAYERS` in `./registry.ts`.
+ */
+
+import type { IChartApi, ISeriesApi } from 'lightweight-charts';
+import type { SessionTimeline } from '../types';
+
+export interface LayerCtx {
+  chart: IChartApi;
+  primarySeries: ISeriesApi<'Candlestick'>;
+  htfSeries?: ISeriesApi<'Candlestick'>;
+  theme: 'dark' | 'light';
+}
+
+export interface LayerHandle {
+  /** Re-render based on full timeline + cursor; layer decides diff strategy. */
+  update(timeline: SessionTimeline, currentBarIdx: number): void;
+  unmount(): void;
+}
+
+export interface ChartLayer {
+  id: string;
+  name: string;
+  /** Small color sample for the toggle panel (CSS color). */
+  swatch: string;
+  defaultVisible: boolean;
+  mount(ctx: LayerCtx): LayerHandle;
+}

--- a/ui/src/features/studio/store.ts
+++ b/ui/src/features/studio/store.ts
@@ -11,6 +11,30 @@ import type { BarEvent, PlayState, SessionTimeline, StudioMode, StudioSpeed } fr
 
 export const LIVE_TAIL = -1;
 
+export const LAYERS_STORAGE_KEY = 'brooks-studio-layers';
+
+function readVisibleLayersFromStorage(): Set<string> | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(LAYERS_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return null;
+    return new Set(parsed.filter((x): x is string => typeof x === 'string'));
+  } catch {
+    return null;
+  }
+}
+
+function writeVisibleLayersToStorage(set: Set<string>): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(LAYERS_STORAGE_KEY, JSON.stringify([...set]));
+  } catch {
+    // storage may be full / unavailable — non-fatal
+  }
+}
+
 export interface StudioState {
   timeline: SessionTimeline | null;
   loading: boolean;
@@ -21,6 +45,8 @@ export interface StudioState {
   playState: PlayState;
   speed: StudioSpeed;
   hoveredBarIdx: number | null;
+
+  visibleLayers: Set<string>;
 }
 
 export interface StudioActions {
@@ -39,10 +65,18 @@ export interface StudioActions {
   setHoveredBar: (idx: number | null) => void;
 
   applyLiveEvent: (ev: BarEvent) => void;
+
+  setVisibleLayers: (ids: Iterable<string>) => void;
+  toggleLayer: (id: string) => void;
+
   reset: () => void;
 }
 
 export type StudioStore = StudioState & { actions: StudioActions };
+
+function initialVisibleLayers(): Set<string> {
+  return readVisibleLayersFromStorage() ?? new Set<string>();
+}
 
 const INITIAL: StudioState = {
   timeline: null,
@@ -53,6 +87,7 @@ const INITIAL: StudioState = {
   playState: 'paused',
   speed: 1,
   hoveredBarIdx: null,
+  visibleLayers: initialVisibleLayers(),
 };
 
 const SPEED_LADDER: StudioSpeed[] = [1, 2, 5, 10];
@@ -149,9 +184,33 @@ export const useStudioStore = create<StudioStore>()((set, get) => ({
       });
     },
 
-    reset: () => set({ ...INITIAL }),
+    setVisibleLayers: (ids) => {
+      const next = new Set(ids);
+      writeVisibleLayersToStorage(next);
+      set({ visibleLayers: next });
+    },
+
+    toggleLayer: (id) => {
+      const { visibleLayers } = get();
+      const next = new Set(visibleLayers);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      writeVisibleLayersToStorage(next);
+      set({ visibleLayers: next });
+    },
+
+    reset: () => set({ ...INITIAL, visibleLayers: initialVisibleLayers() }),
   },
 }));
+
+/**
+ * Returns true if the studio's visibleLayers came from a fresh init (no
+ * localStorage entry yet). UI code uses this to decide whether to seed the
+ * store with registry-provided defaults.
+ */
+export function hasStoredVisibleLayers(): boolean {
+  return readVisibleLayersFromStorage() !== null;
+}
 
 // Selectors
 export const useStudioActions = () => useStudioStore((s) => s.actions);
@@ -163,6 +222,7 @@ export const useStudioMode = () => useStudioStore((s) => s.mode);
 export const useStudioPlayState = () => useStudioStore((s) => s.playState);
 export const useStudioSpeed = () => useStudioStore((s) => s.speed);
 export const useHoveredBarIdx = () => useStudioStore((s) => s.hoveredBarIdx);
+export const useVisibleLayers = () => useStudioStore((s) => s.visibleLayers);
 
 /** Effective bar index resolving the `LIVE_TAIL` sentinel against the current timeline. */
 export const useEffectiveBarIdx = (): number => {


### PR DESCRIPTION
## Summary
Brooks Studio Phase S3: introduce a pluggable layer system and ship the first
six chart overlays so the candle chart finally carries strategy annotations.

- **`layers/`** — `ChartLayer` interface + `LAYERS` registry, one file per layer.
  - `regime.ts` — bottom 5% color band, per-bar coloured by `event.regime.name`
  - `swings.ts` — ▲▼ markers for confirmed swings (≤ currentBarIdx, no future leak)
  - `ema.ts` — EMA20 (default-on) / EMA200 (default-off) lines from `features.ema*`
  - `signals.ts` — circle markers + entry/stop priceLines on the current bar
  - `decisions.ts` — solid in-bar arrows + entry/stop/target priceLines (± 5 bar window)
  - `fills.ts` — buy/sell markers labelled with fill price
- **`store.ts`** — `visibleLayers: Set<string>` persisted to `localStorage["brooks-studio-layers"]`
  with `toggleLayer` / `setVisibleLayers` actions.
- **`LayerToggle.tsx`** — collapsible right-side checkbox panel; new layers
  appear automatically by virtue of being in `LAYERS`.
- **`useLayerRegistry`** — diffs `visibleLayers`, mounts/unmounts layer handles
  against the chart context, fans `update(timeline, idx)` to all mounted layers.
- **`ChartCanvas`** — exposes the chart context as state and delegates to the
  registry hook; no per-layer code in the canvas.

Adding a new layer = export a `ChartLayer` from `layers/<name>.ts` and append
to `LAYERS`. It then auto-renders, auto-mounts on the chart, and auto-shows
in the toggle panel.

## Test plan
- [x] `bunx vitest run src/features/studio` — 12 files / 50 tests passing
- [x] `bunx tsc -b --noEmit` — no new TS errors in `studio/`
- [x] `bunx eslint src/features/studio` — clean
- [ ] Manual: open `/studio/<session_id>`, verify each layer toggles independently and persists across reload
- [ ] Manual: scrub the timeline and confirm priceLines for decisions narrow to ± 5 bars

🤖 Generated with [Claude Code](https://claude.com/claude-code)