### PR TITLE
feat(studio): Phase S5 advanced layers + HTF inset + multi-analyst + PnL (QUA-65)

### DIFF
--- a/src/api/brooks_studio_router.py
+++ b/src/api/brooks_studio_router.py
@@ -1,12 +1,13 @@
 """Brooks Studio router — single backend truth for live + replay.
 
-The router exposes three endpoints used by the Studio panel:
+The router exposes the endpoints used by the Studio panel:
 
 * ``GET  /brooks-studio/sessions/{session_id}/timeline``           — full snapshot
 * ``GET  /brooks-studio/sessions/{session_id}/timeline/since/{seq}`` — incremental page
+* ``POST /brooks-studio/sessions/{session_id}/replay-bar``         — re-run analysts on one bar
 * ``WS   /ws/brooks-studio/{session_id}``                          — live BarEvent stream
 
-All three speak the same :class:`SessionTimeline` / :class:`BarEvent`
+All four speak the same :class:`SessionTimeline` / :class:`BarEvent`
 contract from :mod:`src.api.schemas.brooks_studio`, so the frontend has
 exactly one rendering path for both modes.
 """
@@ -19,9 +20,16 @@ from fastapi import APIRouter, HTTPException, Query, WebSocket, WebSocketDisconn
 
 from session_db import SessionDB
 from src.api.events import studio_channel_key
-from src.api.schemas.brooks_studio import SessionTimeline, TimelinePage
+from src.api.schemas.brooks_studio import (
+    ReplayBarAnalystResult,
+    ReplayBarRequest,
+    ReplayBarResponse,
+    SessionTimeline,
+    TimelinePage,
+)
 from src.api.websocket_manager import handle_websocket_message
 from src.api.websocket_manager import manager as ws_manager
+from src.services.brooks_replay_runner import BrooksReplayRunner
 from src.services.brooks_timeline_loader import BrooksTimelineLoader
 from src.utils.logging_config import get_logger
 
@@ -74,6 +82,32 @@ async def get_timeline_page(
         )
     except KeyError:
         raise HTTPException(status_code=404, detail=f"Session {session_id!r} not found")
+
+
+@router.post(
+    "/sessions/{session_id}/replay-bar",
+    response_model=ReplayBarResponse,
+)
+async def replay_bar(session_id: str, req: ReplayBarRequest) -> ReplayBarResponse:
+    """Re-run a chosen set of analysts against a single bar of a session.
+
+    Powers the MultiAnalystCompare side panel: the user selects a bar and a
+    set of analysts (``rule``, ``llm:claude-opus-4-7``, ``vlm:gemini``,
+    ``ensemble.critic``, …); each analyst's signals + decision (when one was
+    persisted) are returned for direct comparison.
+    """
+    runner = BrooksReplayRunner(SessionDB())
+    try:
+        results = await runner.run(session_id, req.bar_idx, req.analysts)
+    except KeyError:
+        raise HTTPException(status_code=404, detail=f"Session {session_id!r} not found")
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
+    return ReplayBarResponse(
+        bar_idx=req.bar_idx,
+        results=[ReplayBarAnalystResult(**r.to_dict()) for r in results],
+    )
 
 
 @ws_router.websocket("/ws/brooks-studio/{session_id}")

--- a/src/api/schemas/brooks_studio.py
+++ b/src/api/schemas/brooks_studio.py
@@ -109,6 +109,27 @@ class TimelinePage(BaseModel):
     has_more: bool
 
 
+class ReplayBarRequest(BaseModel):
+    """Body for ``POST /sessions/{id}/replay-bar``."""
+
+    bar_idx: int = Field(ge=0)
+    analysts: List[str] = Field(min_length=1)
+
+
+class ReplayBarAnalystResult(BaseModel):
+    analyst: str
+    bar_idx: int
+    signals: List[Signal] = Field(default_factory=list)
+    decision: Optional[Decision] = None
+    error: Optional[str] = None
+    cached: bool = False
+
+
+class ReplayBarResponse(BaseModel):
+    bar_idx: int
+    results: List[ReplayBarAnalystResult] = Field(default_factory=list)
+
+
 __all__ = [
     "Bar",
     "RegimeView",
@@ -121,4 +142,7 @@ __all__ = [
     "PnLPoint",
     "SessionTimeline",
     "TimelinePage",
+    "ReplayBarRequest",
+    "ReplayBarAnalystResult",
+    "ReplayBarResponse",
 ]

--- a/src/services/brooks_replay_runner.py
+++ b/src/services/brooks_replay_runner.py
@@ -1,0 +1,198 @@
+"""Re-run analysts against a single bar for the Brooks Studio compare panel.
+
+The MultiAnalystCompare side panel asks the backend for the output of N
+analysts on the same bar so the user can diff their decisions while
+replaying. This module builds a :class:`BrooksContext` from the data already
+captured in ``session_db`` (per-bar OHLCV plus any HTF bars persisted by the
+strategy) and runs each requested analyst against it.
+
+Design notes:
+
+* The runner is *best-effort*. LLM/VLM analysts make remote calls; if those
+  fail (no API key, network down, etc.) we surface the error in the result
+  payload rather than 500ing the whole request.
+* The runner does **not** re-evaluate the EV gate or the risk layer — it
+  exposes raw analyst signals plus, when available, the strategy's persisted
+  decision for the chosen bar. That's the contract the frontend wants for a
+  visual diff.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from session_db import SessionDB
+from src.api.schemas.brooks_studio import SessionTimeline
+from src.brooks.analyst.base import AnalystRegistry
+from src.brooks.context import AccountSnapshot, Bar, BrooksContext, TFSnapshot
+from src.brooks.schema import Decision, Signal
+from src.services.brooks_timeline_loader import BrooksTimelineLoader
+
+__all__ = [
+    "AnalystResult",
+    "BrooksReplayRunner",
+    "DEFAULT_BAR_CONTEXT",
+]
+
+DEFAULT_BAR_CONTEXT = 200
+DEFAULT_HTF_CONTEXT = 60
+
+
+@dataclass
+class AnalystResult:
+    """Result for one analyst on one bar."""
+
+    analyst: str
+    bar_idx: int
+    signals: List[Signal]
+    decision: Optional[Decision]
+    error: Optional[str] = None
+    cached: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "analyst": self.analyst,
+            "bar_idx": self.bar_idx,
+            "signals": [s.model_dump() for s in self.signals],
+            "decision": self.decision.model_dump() if self.decision is not None else None,
+            "error": self.error,
+            "cached": self.cached,
+        }
+
+
+class BrooksReplayRunner:
+    """Run the requested analysts against a chosen bar of a session."""
+
+    def __init__(
+        self,
+        session_db: SessionDB,
+        bar_context: int = DEFAULT_BAR_CONTEXT,
+        htf_context: int = DEFAULT_HTF_CONTEXT,
+    ):
+        self._loader = BrooksTimelineLoader(session_db)
+        self._bar_context = max(2, int(bar_context))
+        self._htf_context = max(2, int(htf_context))
+
+    # ------------------------------------------------------------------ public
+
+    async def run(
+        self,
+        session_id: str,
+        bar_idx: int,
+        analysts: List[str],
+    ) -> List[AnalystResult]:
+        timeline = await asyncio.to_thread(self._loader.load, session_id)
+        if not timeline.bars:
+            raise ValueError(f"session {session_id!r} has no bars")
+        if bar_idx < 0 or bar_idx >= len(timeline.bars):
+            raise ValueError(
+                f"bar_idx {bar_idx} out of range [0, {len(timeline.bars) - 1}]"
+            )
+        if not analysts:
+            raise ValueError("analysts list is empty")
+
+        ctx = self._build_context(timeline, bar_idx)
+        persisted = self._persisted_event(timeline, bar_idx)
+
+        coros = [self._run_one(name, ctx, persisted, bar_idx) for name in analysts]
+        return await asyncio.gather(*coros)
+
+    # ------------------------------------------------------------------ helpers
+
+    async def _run_one(
+        self,
+        name: str,
+        ctx: BrooksContext,
+        persisted: Dict[str, Any],
+        bar_idx: int,
+    ) -> AnalystResult:
+        if name not in AnalystRegistry.all():
+            return AnalystResult(
+                analyst=name,
+                bar_idx=bar_idx,
+                signals=[],
+                decision=None,
+                error=f"unknown analyst {name!r}",
+            )
+        try:
+            analyst = AnalystRegistry.build(name)
+            signals = await analyst.analyze(ctx)
+        except Exception as e:  # network / config / runtime — surface to UI
+            return AnalystResult(
+                analyst=name,
+                bar_idx=bar_idx,
+                signals=[],
+                decision=persisted.get("decision"),
+                error=f"{type(e).__name__}: {e}",
+            )
+
+        # Use the persisted decision if it matches this analyst, otherwise
+        # leave decision None (the side panel renders signal-level diffs).
+        decision = None
+        persisted_dec = persisted.get("decision")
+        if isinstance(persisted_dec, Decision):
+            if persisted_dec.source == name or persisted_dec.source.startswith(f"{name}:"):
+                decision = persisted_dec
+
+        return AnalystResult(
+            analyst=name,
+            bar_idx=bar_idx,
+            signals=list(signals),
+            decision=decision,
+        )
+
+    def _build_context(self, timeline: SessionTimeline, bar_idx: int) -> BrooksContext:
+        start = max(0, bar_idx - self._bar_context + 1)
+        primary_bars = [
+            Bar(
+                timestamp_ns=int(b.timestamp_ns),
+                open=float(b.open),
+                high=float(b.high),
+                low=float(b.low),
+                close=float(b.close),
+                volume=float(b.volume),
+            )
+            for b in timeline.bars[start : bar_idx + 1]
+        ]
+        primary = TFSnapshot(interval=timeline.base_interval, bars=primary_bars)
+
+        cursor_ns = primary_bars[-1].timestamp_ns if primary_bars else 0
+        htf_snapshots: Dict[str, TFSnapshot] = {}
+        for tf, bars in timeline.htf_bars.items():
+            visible = [
+                Bar(
+                    timestamp_ns=int(b.timestamp_ns),
+                    open=float(b.open),
+                    high=float(b.high),
+                    low=float(b.low),
+                    close=float(b.close),
+                    volume=float(b.volume),
+                )
+                for b in bars
+                if int(b.timestamp_ns) <= cursor_ns
+            ][-self._htf_context :]
+            if visible:
+                htf_snapshots[tf] = TFSnapshot(interval=tf, bars=visible)
+
+        return BrooksContext(
+            symbol=timeline.symbol or "",
+            primary=primary,
+            htf=htf_snapshots,
+            account=AccountSnapshot(equity=0.0, cash=0.0),
+            now_ns=cursor_ns,
+        )
+
+    def _persisted_event(
+        self,
+        timeline: SessionTimeline,
+        bar_idx: int,
+    ) -> Dict[str, Any]:
+        for ev in timeline.events:
+            if ev.bar_idx == bar_idx:
+                return {
+                    "decision": ev.decision,
+                    "signals": list(ev.signals or []),
+                }
+        return {"decision": None, "signals": []}

--- a/tests/api/test_brooks_studio_router.py
+++ b/tests/api/test_brooks_studio_router.py
@@ -181,6 +181,57 @@ class TestTimelinePage:
         assert resp.status_code == 422
 
 
+class TestReplayBar:
+    def test_runs_rule_analyst(self, app_client):
+        resp = app_client.post(
+            f"/brooks-studio/sessions/{SESSION_ID}/replay-bar",
+            json={"bar_idx": 10, "analysts": ["rule"]},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["bar_idx"] == 10
+        assert len(body["results"]) == 1
+        result = body["results"][0]
+        assert result["analyst"] == "rule"
+        assert result["bar_idx"] == 10
+        assert isinstance(result["signals"], list)
+        # rule analyst is best-effort: error stays None unless something exploded
+        assert result["error"] is None
+
+    def test_unknown_analyst_returns_error_not_500(self, app_client):
+        resp = app_client.post(
+            f"/brooks-studio/sessions/{SESSION_ID}/replay-bar",
+            json={"bar_idx": 0, "analysts": ["does-not-exist"]},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        result = body["results"][0]
+        assert result["analyst"] == "does-not-exist"
+        assert result["error"] is not None
+        assert "unknown" in result["error"].lower()
+
+    def test_unknown_session_404(self, app_client):
+        resp = app_client.post(
+            "/brooks-studio/sessions/no-such/replay-bar",
+            json={"bar_idx": 0, "analysts": ["rule"]},
+        )
+        assert resp.status_code == 404
+
+    def test_out_of_range_bar_idx_422(self, app_client):
+        resp = app_client.post(
+            f"/brooks-studio/sessions/{SESSION_ID}/replay-bar",
+            json={"bar_idx": 9999, "analysts": ["rule"]},
+        )
+        assert resp.status_code == 422
+
+    def test_empty_analyst_list_rejected(self, app_client):
+        resp = app_client.post(
+            f"/brooks-studio/sessions/{SESSION_ID}/replay-bar",
+            json={"bar_idx": 0, "analysts": []},
+        )
+        assert resp.status_code == 422
+
+
 class TestStudioWebSocket:
     def test_studio_ws_receives_bar_event(self, app_client):
         from src.api.events import emit_studio_bar_event

--- a/ui/src/features/studio/__tests__/channelsLayer.test.ts
+++ b/ui/src/features/studio/__tests__/channelsLayer.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('lightweight-charts', () => ({
+  LineSeries: { type: 'Line' },
+  LineStyle: { Solid: 0, Dotted: 1, Dashed: 2 },
+}));
+
+import { buildChannelLineData, channelsLayer, latestStructure } from '../layers/channels';
+import { makeLayerCtx } from './mockChart';
+import { makeTimeline } from './fixtures';
+
+describe('channels layer', () => {
+  it('returns the latest structure at-or-before the cursor', () => {
+    const tl = makeTimeline(5);
+    tl.events[2].structure = {
+      always_in: 'long',
+      confirmed_swings: [],
+      micro_channel_top: { slope: 0.5, intercept: 100, start: 1, end: 4 },
+      micro_channel_bot: null,
+    };
+    expect(latestStructure(tl, 4)?.micro_channel_top?.slope).toBe(0.5);
+    expect(latestStructure(tl, 1)).toBeNull();
+  });
+
+  it('builds two endpoints from the channel fit clamped to the cursor', () => {
+    const tl = makeTimeline(5);
+    const channel = { slope: 1, intercept: 100, start: 1, end: 4 };
+    const data = buildChannelLineData(tl, channel, 3);
+    expect(data.length).toBe(2);
+    // y = 1*x + 100; clamped end = 3
+    expect(data[0].value).toBe(101); // x=1
+    expect(data[1].value).toBe(103); // x=3
+  });
+
+  it('returns empty data when no channel or end <= start', () => {
+    const tl = makeTimeline(5);
+    expect(buildChannelLineData(tl, null, 3).length).toBe(0);
+    expect(buildChannelLineData(tl, undefined, 3).length).toBe(0);
+    expect(
+      buildChannelLineData(tl, { slope: 1, intercept: 0, start: 4, end: 2 }, 3).length,
+    ).toBe(0);
+  });
+
+  it('mounts two line series and pushes data on update', () => {
+    const { ctx, chart } = makeLayerCtx();
+    const handle = channelsLayer.mount(ctx);
+    expect(chart.added.length).toBe(2);
+
+    const tl = makeTimeline(5);
+    tl.events[1].structure = {
+      always_in: 'neutral',
+      confirmed_swings: [],
+      micro_channel_top: { slope: 0.5, intercept: 100, start: 0, end: 4 },
+      micro_channel_bot: { slope: -0.2, intercept: 102, start: 0, end: 4 },
+    };
+    handle.update(tl, 4);
+
+    expect(chart.added[0].data.length).toBe(2); // top
+    expect(chart.added[1].data.length).toBe(2); // bot
+
+    handle.unmount();
+    expect(chart.removed.length).toBe(2);
+  });
+});

--- a/ui/src/features/studio/__tests__/htfInset.test.ts
+++ b/ui/src/features/studio/__tests__/htfInset.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('lightweight-charts', () => ({
+  ColorType: { Solid: 0 },
+  CandlestickSeries: { type: 'Candlestick' },
+  LineSeries: { type: 'Line' },
+  LineStyle: { Solid: 0, Dotted: 1, Dashed: 2 },
+  createChart: vi.fn(),
+}));
+
+import { findHtfBarForLtf, pickDefaultInterval } from '../components/chart/HTFInset';
+import { makeTimeline } from './fixtures';
+import type { Bar } from '../types';
+
+const NS = 1_000_000_000;
+
+function bar(tsSec: number, price = 100): Bar {
+  return {
+    timestamp_ns: tsSec * NS,
+    open: price,
+    high: price + 1,
+    low: price - 1,
+    close: price,
+    volume: 1,
+  };
+}
+
+describe('HTFInset helpers', () => {
+  it('finds the latest HTF bar at-or-before the LTF cursor', () => {
+    const htf = [bar(100), bar(200), bar(300), bar(400)];
+    expect(findHtfBarForLtf(htf, 250 * NS)?.timestamp_ns).toBe(200 * NS);
+    expect(findHtfBarForLtf(htf, 100 * NS)?.timestamp_ns).toBe(100 * NS);
+    expect(findHtfBarForLtf(htf, 50 * NS)).toBeNull();
+    expect(findHtfBarForLtf([], 100 * NS)).toBeNull();
+  });
+
+  it('picks the first declared HTF interval when populated', () => {
+    const tl = makeTimeline(3);
+    tl.htf_intervals = ['1h', '4h'];
+    tl.htf_bars = { '1h': [bar(100)], '4h': [bar(100)] };
+    expect(pickDefaultInterval(tl)).toBe('1h');
+  });
+
+  it('falls back to any populated entry in htf_bars', () => {
+    const tl = makeTimeline(3);
+    tl.htf_intervals = [];
+    tl.htf_bars = { '15m': [bar(100)] };
+    expect(pickDefaultInterval(tl)).toBe('15m');
+  });
+
+  it('returns null when no HTF data is available', () => {
+    const tl = makeTimeline(3);
+    tl.htf_intervals = [];
+    tl.htf_bars = {};
+    expect(pickDefaultInterval(tl)).toBeNull();
+    expect(pickDefaultInterval(null)).toBeNull();
+  });
+});

--- a/ui/src/features/studio/__tests__/htfOverlayLayer.test.ts
+++ b/ui/src/features/studio/__tests__/htfOverlayLayer.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('lightweight-charts', () => ({
+  LineStyle: { Solid: 0, Dotted: 1, Dashed: 2 },
+}));
+
+import {
+  HTF_OVERLAY_MAX_LEVELS,
+  detectSwings,
+  htfOverlayLayer,
+  selectHtfLevels,
+} from '../layers/htf_overlay';
+import { makeLayerCtx } from './mockChart';
+import { makeTimeline } from './fixtures';
+import type { Bar } from '../types';
+
+const NS = 1_000_000_000;
+
+function htfBars(prices: number[]): Bar[] {
+  return prices.map((p, i) => ({
+    timestamp_ns: (1_700_000_000 + i * 3600) * NS,
+    open: p,
+    high: p + 1,
+    low: p - 1,
+    close: p,
+    volume: 1,
+  }));
+}
+
+describe('htf overlay layer', () => {
+  it('finds local highs/lows with a 2-bar lookback', () => {
+    const bars = htfBars([10, 12, 14, 12, 10, 11, 13, 11, 9]);
+    const swings = detectSwings(bars, bars.length - 1);
+    const idxs = swings.map((s) => `${s.kind}@${s.bar_idx}`);
+    // Expect a high near idx 2 and a low near idx 4.
+    expect(idxs).toContain('high@2');
+    expect(idxs).toContain('low@4');
+  });
+
+  it('selects up to N most-recent levels and never leaks future bars', () => {
+    const tl = makeTimeline(10);
+    tl.htf_intervals = ['1h'];
+    // The HTF bars are spaced wider than the LTF bars (1h vs 5m); the cursor at
+    // ltf bar 5 corresponds to roughly htf bar 0 in terms of timestamps. We
+    // seed enough HTF history to detect swings before the cursor.
+    const htfTs = (i: number) =>
+      tl.bars[0].timestamp_ns - 6 * 3600 * NS + i * 3600 * NS;
+    tl.htf_bars['1h'] = [10, 12, 14, 12, 10, 11, 13, 11, 9].map((p, i) => ({
+      timestamp_ns: htfTs(i),
+      open: p,
+      high: p + 1,
+      low: p - 1,
+      close: p,
+      volume: 1,
+    }));
+    const levels = selectHtfLevels(tl, 5, HTF_OVERLAY_MAX_LEVELS);
+    expect(levels.length).toBeGreaterThan(0);
+    expect(levels.length).toBeLessThanOrEqual(HTF_OVERLAY_MAX_LEVELS);
+    for (const lvl of levels) {
+      expect(tl.htf_bars['1h'][lvl.bar_idx].timestamp_ns).toBeLessThanOrEqual(
+        tl.bars[5].timestamp_ns,
+      );
+    }
+  });
+
+  it('adds and clears price lines on the primary series', () => {
+    const { ctx, primarySeries } = makeLayerCtx();
+    const handle = htfOverlayLayer.mount(ctx);
+
+    const tl = makeTimeline(10);
+    tl.htf_intervals = ['1h'];
+    tl.htf_bars['1h'] = [10, 12, 14, 12, 10, 11, 13, 11, 9].map((p, i) => ({
+      timestamp_ns: tl.bars[0].timestamp_ns - 6 * 3600 * NS + i * 3600 * NS,
+      open: p,
+      high: p + 1,
+      low: p - 1,
+      close: p,
+      volume: 1,
+    }));
+
+    handle.update(tl, 5);
+    expect(primarySeries.priceLines.length).toBeGreaterThan(0);
+
+    // Clear path: an empty htf_bars set produces zero lines.
+    const empty = makeTimeline(3);
+    handle.update(empty, 2);
+    expect(primarySeries.priceLines.length).toBe(0);
+
+    handle.unmount();
+  });
+});

--- a/ui/src/features/studio/__tests__/multiAnalystCompare.test.tsx
+++ b/ui/src/features/studio/__tests__/multiAnalystCompare.test.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { probabilityBucket } from '../components/side/MultiAnalystCompare';
+
+describe('MultiAnalystCompare helpers', () => {
+  it('buckets probabilities into low/med/high', () => {
+    expect(probabilityBucket(0.1)).toBe('low');
+    expect(probabilityBucket(0.39)).toBe('low');
+    expect(probabilityBucket(0.4)).toBe('med');
+    expect(probabilityBucket(0.59)).toBe('med');
+    expect(probabilityBucket(0.6)).toBe('high');
+    expect(probabilityBucket(1.0)).toBe('high');
+  });
+
+  it('returns em-dash for missing or invalid values', () => {
+    expect(probabilityBucket(null)).toBe('—');
+    expect(probabilityBucket(undefined)).toBe('—');
+    expect(probabilityBucket(Number.NaN)).toBe('—');
+  });
+});

--- a/ui/src/features/studio/__tests__/pnlStrip.test.ts
+++ b/ui/src/features/studio/__tests__/pnlStrip.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('lightweight-charts', () => ({
+  ColorType: { Solid: 0 },
+  LineSeries: { type: 'Line' },
+  LineStyle: { Solid: 0, Dotted: 1, Dashed: 2 },
+  createChart: vi.fn(),
+}));
+
+import { buildPnLLineData } from '../components/timeline/PnLStrip';
+import { makeTimeline } from './fixtures';
+
+describe('PnLStrip', () => {
+  it('returns an empty list when timeline is null', () => {
+    expect(buildPnLLineData(null)).toEqual([]);
+  });
+
+  it('skips points whose bar_idx has no matching bar', () => {
+    const tl = makeTimeline(3);
+    tl.pnl_curve = [
+      { bar_idx: 0, equity_r: 0 },
+      { bar_idx: 99, equity_r: 0.5 }, // no matching bar — skipped
+      { bar_idx: 2, equity_r: 1.0 },
+    ];
+    const data = buildPnLLineData(tl);
+    expect(data.length).toBe(2);
+    expect(data[0].value).toBe(0);
+    expect(data[1].value).toBe(1.0);
+  });
+
+  it('produces strictly ascending unique timestamps', () => {
+    const tl = makeTimeline(4);
+    tl.pnl_curve = [
+      { bar_idx: 0, equity_r: 0 },
+      { bar_idx: 1, equity_r: 0.1 },
+      { bar_idx: 2, equity_r: 0.2 },
+      { bar_idx: 3, equity_r: 0.3 },
+    ];
+    const data = buildPnLLineData(tl);
+    for (let i = 1; i < data.length; i++) {
+      expect((data[i].time as number) > (data[i - 1].time as number)).toBe(true);
+    }
+  });
+});

--- a/ui/src/features/studio/__tests__/reasoningLayer.test.ts
+++ b/ui/src/features/studio/__tests__/reasoningLayer.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const markerCalls: { setMarkers: ReturnType<typeof vi.fn>; markers: unknown[]; detach: ReturnType<typeof vi.fn> }[] = [];
+
+vi.mock('lightweight-charts', () => ({
+  createSeriesMarkers: vi.fn(() => {
+    const handle: any = {
+      markers: [] as unknown[],
+      setMarkers: vi.fn(function (this: any, m: unknown[]) {
+        this.markers = m;
+      }),
+      detach: vi.fn(),
+    };
+    handle.setMarkers = vi.fn((m: unknown[]) => {
+      handle.markers = m;
+    });
+    markerCalls.push(handle);
+    return handle;
+  }),
+}));
+
+import {
+  buildReasoningMarkers,
+  reasoningLayer,
+  reasoningSnippet,
+} from '../layers/reasoning';
+import { makeLayerCtx } from './mockChart';
+import { makeTimeline } from './fixtures';
+
+describe('reasoning layer', () => {
+  it('extracts a trimmed snippet from decision reasoning first', () => {
+    const snippet = reasoningSnippet({
+      bar_idx: 1,
+      timestamp_ns: 0,
+      signals: [{ reasoning: 'fallback' } as any],
+      decision: { reasoning: '  multi   line\n reasoning ' } as any,
+    });
+    expect(snippet?.startsWith('multi line reasoning')).toBe(true);
+  });
+
+  it('falls back to signal reasoning when decision is missing', () => {
+    expect(
+      reasoningSnippet({ bar_idx: 0, timestamp_ns: 0, signals: [{ reasoning: 'sig' } as any] }),
+    ).toBe('sig');
+  });
+
+  it('truncates very long reasoning with an ellipsis', () => {
+    const long = 'x'.repeat(200);
+    const snippet = reasoningSnippet({
+      bar_idx: 0,
+      timestamp_ns: 0,
+      signals: [],
+      decision: { reasoning: long } as any,
+    });
+    expect(snippet?.length).toBeLessThanOrEqual(60);
+    expect(snippet?.endsWith('…')).toBe(true);
+  });
+
+  it('drops markers for bars beyond currentBarIdx', () => {
+    const tl = makeTimeline(5);
+    tl.events[1].decision = { reasoning: 'A' } as any;
+    tl.events[3].decision = { reasoning: 'B' } as any;
+    expect(buildReasoningMarkers(tl, 2).length).toBe(1);
+    expect(buildReasoningMarkers(tl, 4).length).toBe(2);
+  });
+
+  it('mounts a markers plugin and sets markers on update', () => {
+    const before = markerCalls.length;
+    const { ctx } = makeLayerCtx();
+    const handle = reasoningLayer.mount(ctx);
+    expect(markerCalls.length).toBe(before + 1);
+    const recorded = markerCalls[markerCalls.length - 1];
+
+    const tl = makeTimeline(3);
+    tl.events[1].decision = { reasoning: 'hi' } as any;
+    handle.update(tl, 2);
+    expect((recorded.markers as unknown[]).length).toBe(1);
+
+    handle.unmount();
+  });
+});

--- a/ui/src/features/studio/__tests__/registry.test.ts
+++ b/ui/src/features/studio/__tests__/registry.test.ts
@@ -13,7 +13,7 @@ vi.mock('lightweight-charts', () => ({
 import { DEFAULT_VISIBLE, LAYERS, findLayer } from '../layers/registry';
 
 describe('layer registry', () => {
-  it('exposes the six core layers (with EMA split)', () => {
+  it('exposes core + S5 advanced layers in registration order', () => {
     expect(LAYERS.map((l) => l.id)).toEqual([
       'regime',
       'swings',
@@ -22,13 +22,21 @@ describe('layer registry', () => {
       'signals',
       'decisions',
       'fills',
+      'channels',
+      'stop_adj',
+      'htf_overlay',
+      'reasoning',
     ]);
   });
 
-  it('default-visible omits ema200', () => {
+  it('default-visible omits ema200, htf_overlay, and reasoning', () => {
     expect(DEFAULT_VISIBLE.has('ema200')).toBe(false);
+    expect(DEFAULT_VISIBLE.has('htf_overlay')).toBe(false);
+    expect(DEFAULT_VISIBLE.has('reasoning')).toBe(false);
     expect(DEFAULT_VISIBLE.has('ema20')).toBe(true);
     expect(DEFAULT_VISIBLE.has('regime')).toBe(true);
+    expect(DEFAULT_VISIBLE.has('channels')).toBe(true);
+    expect(DEFAULT_VISIBLE.has('stop_adj')).toBe(true);
   });
 
   it('layer ids are unique', () => {

--- a/ui/src/features/studio/__tests__/stopAdjLayer.test.ts
+++ b/ui/src/features/studio/__tests__/stopAdjLayer.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const markerHandles: { setMarkers: ReturnType<typeof vi.fn>; detach: ReturnType<typeof vi.fn> }[] = [];
+
+vi.mock('lightweight-charts', () => ({
+  LineSeries: { type: 'Line' },
+  LineStyle: { Solid: 0, Dotted: 1, Dashed: 2 },
+  createSeriesMarkers: vi.fn(() => {
+    const handle = { setMarkers: vi.fn(), detach: vi.fn() };
+    markerHandles.push(handle);
+    return handle;
+  }),
+}));
+
+import {
+  buildStopAdjMarkers,
+  buildStopLadderData,
+  collectStopAdjustments,
+  stopAdjLayer,
+} from '../layers/stop_adj';
+import { makeLayerCtx } from './mockChart';
+import { makeTimeline } from './fixtures';
+
+describe('stop adjustment layer', () => {
+  it('collects only adjustments at-or-before the cursor', () => {
+    const tl = makeTimeline(6);
+    tl.events[1].stop_adj = { from_px: 100, to_px: 99, reason: 'init' };
+    tl.events[3].stop_adj = { from_px: 99, to_px: 101, reason: 'be' };
+    tl.events[5].stop_adj = { from_px: 101, to_px: 103, reason: 'trail' };
+    expect(collectStopAdjustments(tl, 4).map((p) => p.bar_idx)).toEqual([1, 3]);
+    expect(collectStopAdjustments(tl, 5).length).toBe(3);
+  });
+
+  it('builds a step-line from first adjustment to current bar', () => {
+    const tl = makeTimeline(6);
+    tl.events[1].stop_adj = { from_px: 100, to_px: 99, reason: 'init' };
+    tl.events[3].stop_adj = { from_px: 99, to_px: 101, reason: 'be' };
+    const data = buildStopLadderData(tl, 4);
+    // Bars 1..4 → 4 entries; values: 99 (after step), 99, 101 (after step), 101
+    expect(data.length).toBe(4);
+    expect(data.map((p) => p.value)).toEqual([99, 99, 101, 101]);
+  });
+
+  it('emits one marker per adjustment', () => {
+    const tl = makeTimeline(6);
+    tl.events[1].stop_adj = { from_px: 100, to_px: 99, reason: 'init' };
+    tl.events[3].stop_adj = { from_px: 99, to_px: 101, reason: 'be' };
+    expect(buildStopAdjMarkers(tl, 5).length).toBe(2);
+  });
+
+  it('mounts a series + markers plugin and tears them down', () => {
+    const { ctx, chart } = makeLayerCtx();
+    const handle = stopAdjLayer.mount(ctx);
+    expect(chart.added.length).toBe(1); // ladder series
+    expect(markerHandles.length).toBeGreaterThan(0);
+
+    const tl = makeTimeline(3);
+    tl.events[1].stop_adj = { from_px: 100, to_px: 99, reason: 'init' };
+    handle.update(tl, 2);
+    expect(chart.added[0].data.length).toBe(2); // bars 1..2
+
+    handle.unmount();
+    expect(chart.removed.length).toBe(1);
+  });
+});

--- a/ui/src/features/studio/api.ts
+++ b/ui/src/features/studio/api.ts
@@ -7,7 +7,7 @@
  */
 
 import { WS_BASE, apiFetch, getToken } from '../../utils/api';
-import type { BarEvent, SessionTimeline } from './types';
+import type { BarEvent, Decision, SessionTimeline, Signal } from './types';
 
 export class StudioApiError extends Error {
   constructor(message: string, readonly status: number) {
@@ -22,6 +22,42 @@ export async function fetchTimeline(sessionId: string, signal?: AbortSignal): Pr
     throw new StudioApiError(`Failed to load timeline (${resp.status})`, resp.status);
   }
   return (await resp.json()) as SessionTimeline;
+}
+
+export interface ReplayBarAnalystResult {
+  analyst: string;
+  bar_idx: number;
+  signals: Signal[];
+  decision: Decision | null;
+  error: string | null;
+  cached: boolean;
+}
+
+export interface ReplayBarResponse {
+  bar_idx: number;
+  results: ReplayBarAnalystResult[];
+}
+
+/**
+ * Re-run a chosen set of analysts on a single bar of a session — backs the
+ * MultiAnalystCompare side panel.
+ */
+export async function replayBar(
+  sessionId: string,
+  bar_idx: number,
+  analysts: string[],
+  signal?: AbortSignal,
+): Promise<ReplayBarResponse> {
+  const resp = await apiFetch(`/brooks-studio/sessions/${sessionId}/replay-bar`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ bar_idx, analysts }),
+    signal,
+  });
+  if (!resp.ok) {
+    throw new StudioApiError(`Failed to replay bar (${resp.status})`, resp.status);
+  }
+  return (await resp.json()) as ReplayBarResponse;
 }
 
 export type WsHandlers = {

--- a/ui/src/features/studio/components/BrooksStudioPage.tsx
+++ b/ui/src/features/studio/components/BrooksStudioPage.tsx
@@ -1,12 +1,17 @@
 /**
  * BrooksStudioPage — top-level route for `/studio/:sessionId`.
  *
- * S2 ships the skeleton: chart + scrubber + playback + URL/keyboard
- * bindings. S3 fills in the side panels & layer toggle into the placeholders
- * outlined below.
+ * Layout:
+ *   ┌────────────────────────────┬───────────┐
+ *   │  Chart  (LayerToggle, HTF) │ SidePanel │
+ *   ├────────────────────────────┴───────────┤
+ *   │  PnLStrip                              │
+ *   │  Scrubber + PlaybackControls           │
+ *   └────────────────────────────────────────┘
  */
 
 import { useParams } from 'react-router-dom';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../../components/ui/tabs';
 import { useTimeline } from '../hooks/useTimeline';
 import { useReplay } from '../hooks/useReplay';
 import { useUrlState } from '../hooks/useUrlState';
@@ -16,9 +21,12 @@ import {
   useTimelineState,
 } from '../store';
 import { ChartCanvas } from './chart/ChartCanvas';
+import { HTFInset } from './chart/HTFInset';
 import { TimelineScrubber } from './timeline/TimelineScrubber';
 import { PlaybackControls } from './timeline/PlaybackControls';
 import { LayerToggle } from './timeline/LayerToggle';
+import { PnLStrip } from './timeline/PnLStrip';
+import { MultiAnalystCompare } from './side/MultiAnalystCompare';
 
 export default function BrooksStudioPage() {
   const { sessionId } = useParams<{ sessionId: string }>();
@@ -53,25 +61,45 @@ export default function BrooksStudioPage() {
         <code className="text-[11px] text-muted-foreground">{sessionId}</code>
       </header>
 
-      <div className="relative min-h-0 flex-1 overflow-hidden rounded-xl border border-border/70 bg-[#0e1116]">
-        <ChartCanvas />
-        <div className="pointer-events-auto absolute right-3 top-3 z-10">
-          <LayerToggle />
+      <div className="flex min-h-0 flex-1 gap-3">
+        <div className="relative min-h-0 flex-1 overflow-hidden rounded-xl border border-border/70 bg-[#0e1116]">
+          <ChartCanvas />
+          <div className="pointer-events-auto absolute right-3 top-3 z-10 flex items-start gap-2">
+            <HTFInset />
+            <LayerToggle />
+          </div>
+          {loading && !timeline && (
+            <div className="absolute inset-0 flex items-center justify-center bg-black/30 text-xs text-muted-foreground">
+              Loading timeline…
+            </div>
+          )}
+          {error && (
+            <div className="absolute left-3 top-3 max-w-md rounded-md border border-destructive/60 bg-destructive/15 px-3 py-1.5 text-xs text-destructive-foreground">
+              {error}
+            </div>
+          )}
         </div>
-        {loading && !timeline && (
-          <div className="absolute inset-0 flex items-center justify-center bg-black/30 text-xs text-muted-foreground">
-            Loading timeline…
-          </div>
-        )}
-        {error && (
-          <div className="absolute left-3 top-3 max-w-md rounded-md border border-destructive/60 bg-destructive/15 px-3 py-1.5 text-xs text-destructive-foreground">
-            {error}
-          </div>
-        )}
+
+        <aside
+          className="hidden min-h-0 w-[360px] shrink-0 flex-col overflow-hidden rounded-xl border border-border/70 bg-card md:flex"
+          data-testid="studio-side-panel"
+        >
+          <Tabs defaultValue="compare" className="flex min-h-0 flex-1 flex-col">
+            <TabsList className="m-2 self-start">
+              <TabsTrigger value="compare">Compare</TabsTrigger>
+            </TabsList>
+            <TabsContent value="compare" className="mt-0 min-h-0 flex-1 overflow-y-auto">
+              <MultiAnalystCompare />
+            </TabsContent>
+          </Tabs>
+        </aside>
       </div>
 
       <div className="rounded-xl border border-border/70 bg-card">
-        <TimelineScrubber />
+        <PnLStrip />
+        <div className="border-t border-border/60">
+          <TimelineScrubber />
+        </div>
         <div className="border-t border-border/60">
           <PlaybackControls />
         </div>

--- a/ui/src/features/studio/components/chart/HTFInset.tsx
+++ b/ui/src/features/studio/components/chart/HTFInset.tsx
@@ -1,0 +1,330 @@
+/**
+ * HTFInset — picture-in-picture HTF candlestick mini-chart anchored top-right
+ * of the primary chart.
+ *
+ * The chart shows `timeline.htf_bars[interval]` for the user-selected HTF
+ * interval (defaulted to the first listed in `timeline.htf_intervals`) and
+ * highlights the HTF bar that contains the current LTF cursor with a red
+ * vertical line. It can be:
+ *   - collapsed to a small "1h ▾" pill (saving screen real estate);
+ *   - switched between any HTF intervals the timeline ships with;
+ *   - expanded into a full-screen modal with the same chart at large size.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  CandlestickSeries,
+  ColorType,
+  LineSeries,
+  LineStyle,
+  createChart,
+  type CandlestickData,
+  type IChartApi,
+  type ISeriesApi,
+  type LineData,
+  type UTCTimestamp,
+} from 'lightweight-charts';
+import { Maximize2, Minimize2, Monitor, X } from 'lucide-react';
+import { Button } from '../../../../components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from '../../../../components/ui/dialog';
+import {
+  useEffectiveBarIdx,
+  useTimelineState,
+} from '../../store';
+import type { Bar, SessionTimeline } from '../../types';
+
+const THEME = {
+  background: '#0b0e13',
+  text: '#cbd2dc',
+  grid: '#1c2230',
+  bull: '#26A69A',
+  bear: '#EF5350',
+  cursor: '#EF5350',
+} as const;
+
+const INSET_WIDTH = 240;
+const INSET_HEIGHT = 120;
+
+function toCandlesticks(bars: Bar[]): CandlestickData<UTCTimestamp>[] {
+  const seen = new Set<number>();
+  const out: CandlestickData<UTCTimestamp>[] = [];
+  for (const b of bars) {
+    const t = Math.floor(b.timestamp_ns / 1_000_000_000);
+    if (seen.has(t)) continue;
+    seen.add(t);
+    out.push({ time: t as UTCTimestamp, open: b.open, high: b.high, low: b.low, close: b.close });
+  }
+  out.sort((a, b) => (a.time as number) - (b.time as number));
+  return out;
+}
+
+/**
+ * Find the HTF bar that contains the LTF bar's timestamp — the most recent
+ * HTF bar with `timestamp_ns <= ltfTs`.
+ */
+export function findHtfBarForLtf(htfBars: Bar[], ltfTs: number): Bar | null {
+  let chosen: Bar | null = null;
+  for (const b of htfBars) {
+    if (b.timestamp_ns <= ltfTs) chosen = b;
+    else break;
+  }
+  return chosen;
+}
+
+/** Pick a sensible default interval: prefer `htf_intervals` then anything in `htf_bars`. */
+export function pickDefaultInterval(timeline: SessionTimeline | null): string | null {
+  if (!timeline) return null;
+  if (timeline.htf_intervals.length > 0) {
+    const first = timeline.htf_intervals[0];
+    if (timeline.htf_bars[first]?.length) return first;
+  }
+  for (const k of Object.keys(timeline.htf_bars)) {
+    if (timeline.htf_bars[k]?.length) return k;
+  }
+  return null;
+}
+
+interface InsetChartProps {
+  bars: Bar[];
+  cursorTime: UTCTimestamp | null;
+  width: number;
+  height: number;
+}
+
+function InsetChart({ bars, cursorTime, width, height }: InsetChartProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const chartRef = useRef<IChartApi | null>(null);
+  const candleRef = useRef<ISeriesApi<'Candlestick'> | null>(null);
+  const cursorRef = useRef<ISeriesApi<'Line'> | null>(null);
+
+  const candles = useMemo(() => toCandlesticks(bars), [bars]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const chart = createChart(container, {
+      layout: {
+        background: { type: ColorType.Solid, color: THEME.background },
+        textColor: THEME.text,
+        fontSize: 10,
+      },
+      grid: { vertLines: { visible: false }, horzLines: { color: THEME.grid } },
+      rightPriceScale: { borderColor: THEME.grid },
+      timeScale: { borderColor: THEME.grid, timeVisible: true, secondsVisible: false },
+      handleScroll: false,
+      handleScale: false,
+      autoSize: false,
+      width,
+      height,
+    });
+    const candle = chart.addSeries(CandlestickSeries, {
+      upColor: THEME.bull,
+      downColor: THEME.bear,
+      wickUpColor: THEME.bull,
+      wickDownColor: THEME.bear,
+      borderVisible: false,
+    });
+    const cursor = chart.addSeries(LineSeries, {
+      color: THEME.cursor,
+      lineWidth: 1,
+      lineStyle: LineStyle.Solid,
+      priceLineVisible: false,
+      lastValueVisible: false,
+      crosshairMarkerVisible: false,
+    });
+
+    chartRef.current = chart;
+    candleRef.current = candle;
+    cursorRef.current = cursor;
+
+    return () => {
+      chart.remove();
+      chartRef.current = null;
+      candleRef.current = null;
+      cursorRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Keep the chart sized to its container.
+  useEffect(() => {
+    chartRef.current?.resize(width, height);
+  }, [width, height]);
+
+  // Push candles.
+  useEffect(() => {
+    candleRef.current?.setData(candles);
+    if (candles.length > 0) chartRef.current?.timeScale().fitContent();
+  }, [candles]);
+
+  // Update cursor (a vertical line by drawing two points at min/max price on the same time).
+  useEffect(() => {
+    const cursor = cursorRef.current;
+    if (!cursor) return;
+    if (cursorTime == null || candles.length === 0) {
+      cursor.setData([]);
+      return;
+    }
+    let lo = Number.POSITIVE_INFINITY;
+    let hi = Number.NEGATIVE_INFINITY;
+    for (const c of candles) {
+      if (c.low < lo) lo = c.low;
+      if (c.high > hi) hi = c.high;
+    }
+    if (!Number.isFinite(lo) || !Number.isFinite(hi)) {
+      cursor.setData([]);
+      return;
+    }
+    // lightweight-charts requires two points with strictly distinct times to
+    // draw a line; we cheat with a 1-second offset so it shows as a near-
+    // vertical sliver on the screen.
+    const data: LineData<UTCTimestamp>[] = [
+      { time: cursorTime, value: lo },
+      { time: ((cursorTime as number) + 1) as UTCTimestamp, value: hi },
+    ];
+    cursor.setData(data);
+  }, [cursorTime, candles]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="bg-[#0b0e13]"
+      data-testid="htf-inset-chart"
+      style={{ width, height }}
+    />
+  );
+}
+
+export function HTFInset() {
+  const timeline = useTimelineState();
+  const currentBarIdx = useEffectiveBarIdx();
+
+  const defaultInterval = pickDefaultInterval(timeline);
+  const [selected, setSelected] = useState<string | null>(defaultInterval);
+  const [collapsed, setCollapsed] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+
+  // Reset selection if timeline changes & current selection is stale.
+  useEffect(() => {
+    if (!timeline) return;
+    if (selected && timeline.htf_bars[selected]?.length) return;
+    setSelected(pickDefaultInterval(timeline));
+    // intentionally one-shot per timeline identity
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [timeline]);
+
+  if (!timeline) return null;
+  const intervals = Object.keys(timeline.htf_bars).filter(
+    (k) => timeline.htf_bars[k]?.length,
+  );
+  if (intervals.length === 0) return null;
+
+  const interval = selected ?? intervals[0];
+  const htfBars = timeline.htf_bars[interval] ?? [];
+
+  const ltfTs = timeline.bars[currentBarIdx]?.timestamp_ns ?? null;
+  const htfBar = ltfTs != null ? findHtfBarForLtf(htfBars, ltfTs) : null;
+  const cursorTime = htfBar
+    ? (Math.floor(htfBar.timestamp_ns / 1_000_000_000) as UTCTimestamp)
+    : null;
+
+  if (collapsed) {
+    return (
+      <div className="flex items-center gap-1 rounded-md border border-border/70 bg-card/70 p-1 text-xs shadow-sm">
+        <button
+          type="button"
+          onClick={() => setCollapsed(false)}
+          className="flex items-center gap-1 rounded px-1.5 py-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+          title="Expand HTF inset"
+          data-testid="htf-inset-expand"
+        >
+          <Monitor className="size-3.5" />
+          <span className="tabular-nums">{interval}</span>
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex flex-col gap-1 rounded-md border border-border/70 bg-card/70 p-1.5 text-xs shadow-sm"
+      data-testid="htf-inset"
+    >
+      <div className="flex items-center justify-between gap-2 px-1">
+        <div className="flex items-center gap-1.5 text-muted-foreground">
+          <Monitor className="size-3.5" />
+          <span>HTF</span>
+        </div>
+        <div className="flex items-center gap-0.5">
+          <select
+            aria-label="HTF interval"
+            data-testid="htf-inset-select"
+            className="rounded bg-secondary/40 px-1.5 py-0.5 text-[11px] text-foreground"
+            value={interval}
+            onChange={(e) => setSelected(e.target.value)}
+          >
+            {intervals.map((iv) => (
+              <option key={iv} value={iv}>
+                {iv}
+              </option>
+            ))}
+          </select>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => setExpanded(true)}
+            title="Expand to fullscreen"
+            aria-label="Expand HTF inset"
+            data-testid="htf-inset-fullscreen"
+            className="h-6 w-6"
+          >
+            <Maximize2 className="size-3" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => setCollapsed(true)}
+            title="Collapse"
+            aria-label="Collapse HTF inset"
+            data-testid="htf-inset-collapse"
+            className="h-6 w-6"
+          >
+            <Minimize2 className="size-3" />
+          </Button>
+        </div>
+      </div>
+      <InsetChart
+        bars={htfBars}
+        cursorTime={cursorTime}
+        width={INSET_WIDTH}
+        height={INSET_HEIGHT}
+      />
+      <Dialog open={expanded} onOpenChange={setExpanded}>
+        <DialogContent className="max-w-[80vw]">
+          <DialogTitle className="flex items-center gap-2 text-sm">
+            HTF {interval}
+            <button
+              type="button"
+              onClick={() => setExpanded(false)}
+              className="ml-auto rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+              aria-label="Close"
+            >
+              <X className="size-4" />
+            </button>
+          </DialogTitle>
+          <InsetChart
+            bars={htfBars}
+            cursorTime={cursorTime}
+            width={Math.min(window.innerWidth * 0.75, 1100)}
+            height={Math.min(window.innerHeight * 0.6, 500)}
+          />
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/ui/src/features/studio/components/side/MultiAnalystCompare.tsx
+++ b/ui/src/features/studio/components/side/MultiAnalystCompare.tsx
@@ -1,0 +1,304 @@
+/**
+ * MultiAnalystCompare — side panel that fans the same bar out to N analysts
+ * and shows their results side-by-side.
+ *
+ * The user picks a set of analysts (rule / llm:claude / vlm:gemini /
+ * ensemble.critic …) and presses *Run*; we POST `/replay-bar` with the
+ * analyst list and current bar index, then render a table where each column
+ * is one analyst and rows show the comparable fields (side, primary
+ * pattern, probability, expected R, signal entry/stop, decision target).
+ *
+ * Caching: results are keyed by `${sessionId}|${barIdx}|${analyst}` so that
+ * re-running the same combination is an O(1) lookup. Concurrency: all
+ * analysts in one request fan out on the backend (`asyncio.gather`), so
+ * walltime is bounded by the slowest single analyst.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { Loader2, Play } from 'lucide-react';
+import { Button } from '../../../../components/ui/button';
+import { replayBar, type ReplayBarAnalystResult } from '../../api';
+import { useEffectiveBarIdx } from '../../store';
+import type { Decision, Signal } from '../../types';
+
+const DEFAULT_ANALYSTS = [
+  'rule',
+  'llm',
+  'vlm',
+  'ensemble.critic',
+] as const;
+
+type CacheKey = string;
+
+function cacheKey(sessionId: string, barIdx: number, analyst: string): CacheKey {
+  return `${sessionId}|${barIdx}|${analyst}`;
+}
+
+/** Bucket-style probability (0…1 → "low/med/high") for visual diff. */
+export function probabilityBucket(p: number | null | undefined): string {
+  if (p == null || !Number.isFinite(p)) return '—';
+  if (p < 0.4) return 'low';
+  if (p < 0.6) return 'med';
+  return 'high';
+}
+
+function topSignal(signals: Signal[]): Signal | null {
+  if (signals.length === 0) return null;
+  return signals.reduce((best, cur) => {
+    const a = (cur.probability as number | undefined) ?? 0;
+    const b = (best.probability as number | undefined) ?? 0;
+    return a > b ? cur : best;
+  });
+}
+
+interface Row {
+  label: string;
+  pick: (r: ReplayBarAnalystResult) => string;
+}
+
+const ROWS: Row[] = [
+  {
+    label: '#signals',
+    pick: (r) => String(r.signals.length),
+  },
+  {
+    label: 'top side',
+    pick: (r) => topSignal(r.signals)?.side ?? '—',
+  },
+  {
+    label: 'top pattern',
+    pick: (r) => topSignal(r.signals)?.pattern ?? '—',
+  },
+  {
+    label: 'top prob',
+    pick: (r) => {
+      const t = topSignal(r.signals);
+      const p = (t?.probability as number | undefined) ?? null;
+      return p == null ? '—' : `${(p * 100).toFixed(0)}% (${probabilityBucket(p)})`;
+    },
+  },
+  {
+    label: 'top entry',
+    pick: (r) => {
+      const t = topSignal(r.signals);
+      const v = (t?.entry_px as number | undefined) ?? (t?.['entry'] as number | undefined);
+      return typeof v === 'number' ? v.toFixed(4) : '—';
+    },
+  },
+  {
+    label: 'top stop',
+    pick: (r) => {
+      const t = topSignal(r.signals);
+      const v = (t?.stop_px as number | undefined) ?? (t?.['stop'] as number | undefined);
+      return typeof v === 'number' ? v.toFixed(4) : '—';
+    },
+  },
+  {
+    label: 'decision',
+    pick: (r) => decisionLabel(r.decision),
+  },
+  {
+    label: 'expected R',
+    pick: (r) => (r.decision ? r.decision.expected_r.toFixed(2) : '—'),
+  },
+  {
+    label: 'error',
+    pick: (r) => r.error ?? '—',
+  },
+];
+
+function decisionLabel(d: Decision | null): string {
+  if (!d) return '—';
+  const tgt = d.target_px != null ? ` t=${d.target_px.toFixed(2)}` : '';
+  return `${d.side} e=${d.entry_px.toFixed(2)} s=${d.stop_px.toFixed(2)}${tgt}`;
+}
+
+/** Diff highlight: cell value differs from the *first* (reference) result. */
+function diffClass(values: string[], idx: number): string {
+  if (idx === 0) return '';
+  return values[idx] !== values[0] ? 'bg-amber-500/15 text-amber-200' : '';
+}
+
+export function MultiAnalystCompare() {
+  const { sessionId } = useParams<{ sessionId: string }>();
+  const currentBarIdx = useEffectiveBarIdx();
+  const [selected, setSelected] = useState<string[]>([...DEFAULT_ANALYSTS]);
+  const [draft, setDraft] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [results, setResults] = useState<ReplayBarAnalystResult[]>([]);
+  const cacheRef = useRef<Map<CacheKey, ReplayBarAnalystResult>>(new Map());
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Drop pending request on unmount.
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const cachedView = useMemo(() => {
+    if (!sessionId) return null;
+    const out: ReplayBarAnalystResult[] = [];
+    for (const a of selected) {
+      const cached = cacheRef.current.get(cacheKey(sessionId, currentBarIdx, a));
+      if (cached) out.push({ ...cached, cached: true });
+    }
+    return out.length === selected.length && selected.length > 0 ? out : null;
+  }, [sessionId, currentBarIdx, selected]);
+
+  useEffect(() => {
+    if (cachedView) setResults(cachedView);
+  }, [cachedView]);
+
+  const onRun = async () => {
+    if (!sessionId || selected.length === 0 || currentBarIdx < 0) return;
+    abortRef.current?.abort();
+    const ctl = new AbortController();
+    abortRef.current = ctl;
+    setLoading(true);
+    setError(null);
+    try {
+      // Skip analysts already cached for this bar.
+      const fresh = selected.filter(
+        (a) => !cacheRef.current.has(cacheKey(sessionId, currentBarIdx, a)),
+      );
+      let next: ReplayBarAnalystResult[];
+      if (fresh.length === 0) {
+        next = selected.map((a) => ({
+          ...(cacheRef.current.get(cacheKey(sessionId, currentBarIdx, a)) as ReplayBarAnalystResult),
+          cached: true,
+        }));
+      } else {
+        const resp = await replayBar(sessionId, currentBarIdx, fresh, ctl.signal);
+        for (const r of resp.results) {
+          cacheRef.current.set(cacheKey(sessionId, currentBarIdx, r.analyst), r);
+        }
+        next = selected.map((a) => {
+          const r = cacheRef.current.get(cacheKey(sessionId, currentBarIdx, a));
+          return r ? { ...r, cached: !fresh.includes(a) } : (
+            { analyst: a, bar_idx: currentBarIdx, signals: [], decision: null, error: 'missing', cached: false }
+          );
+        });
+      }
+      setResults(next);
+    } catch (e) {
+      if ((e as Error).name === 'AbortError') return;
+      setError((e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const removeAnalyst = (a: string) => {
+    setSelected((cur) => cur.filter((x) => x !== a));
+  };
+
+  const addAnalyst = () => {
+    const trimmed = draft.trim();
+    if (!trimmed || selected.includes(trimmed)) return;
+    setSelected((cur) => [...cur, trimmed]);
+    setDraft('');
+  };
+
+  // Render rows: each cell value gathered first so we can diff.
+  const cellValues: string[][] = ROWS.map((row) => results.map(row.pick));
+
+  return (
+    <div className="flex flex-col gap-3 p-3 text-xs" data-testid="multi-analyst-compare">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-[11px] uppercase tracking-wide text-muted-foreground">
+          Compare on bar {currentBarIdx >= 0 ? currentBarIdx : '—'}
+        </span>
+        <div className="ml-auto flex items-center gap-1">
+          <input
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                addAnalyst();
+              }
+            }}
+            placeholder="add analyst…"
+            className="rounded border border-border/70 bg-secondary/30 px-2 py-1 text-xs outline-none focus:border-primary"
+            data-testid="multi-analyst-add-input"
+          />
+          <Button size="sm" variant="secondary" onClick={addAnalyst} data-testid="multi-analyst-add">
+            +
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-1.5">
+        {selected.map((a) => (
+          <button
+            key={a}
+            type="button"
+            onClick={() => removeAnalyst(a)}
+            className="rounded-full bg-secondary/50 px-2 py-0.5 text-[11px] text-foreground hover:bg-destructive/40"
+            title={`Remove ${a}`}
+            data-testid={`multi-analyst-chip-${a}`}
+          >
+            {a} ×
+          </button>
+        ))}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button
+          size="sm"
+          onClick={onRun}
+          disabled={loading || selected.length === 0 || currentBarIdx < 0}
+          data-testid="multi-analyst-run"
+        >
+          {loading ? <Loader2 className="size-3.5 animate-spin" /> : <Play className="size-3.5" />}
+          <span className="ml-1.5">{loading ? 'Running…' : 'Run'}</span>
+        </Button>
+        {error && (
+          <span className="text-[11px] text-destructive" data-testid="multi-analyst-error">
+            {error}
+          </span>
+        )}
+      </div>
+
+      {results.length > 0 && (
+        <div className="overflow-x-auto rounded border border-border/60">
+          <table className="min-w-full text-xs">
+            <thead>
+              <tr className="bg-secondary/40">
+                <th className="px-2 py-1 text-left font-medium text-muted-foreground">field</th>
+                {results.map((r) => (
+                  <th
+                    key={r.analyst}
+                    className="px-2 py-1 text-left font-medium tabular-nums"
+                    data-testid={`multi-analyst-col-${r.analyst}`}
+                  >
+                    {r.analyst}
+                    {r.cached && <span className="ml-1 text-[10px] text-muted-foreground">(cached)</span>}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {ROWS.map((row, ri) => (
+                <tr key={row.label} className="border-t border-border/50">
+                  <td className="px-2 py-1 text-muted-foreground">{row.label}</td>
+                  {results.map((_, ci) => {
+                    const value = cellValues[ri][ci];
+                    return (
+                      <td
+                        key={ci}
+                        className={`px-2 py-1 tabular-nums ${diffClass(cellValues[ri], ci)}`}
+                        data-testid={`multi-analyst-cell-${row.label}-${ci}`}
+                      >
+                        {value}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/features/studio/components/timeline/PnLStrip.tsx
+++ b/ui/src/features/studio/components/timeline/PnLStrip.tsx
@@ -1,0 +1,176 @@
+/**
+ * PnLStrip — bottom 60px equity-R sub-chart, time-axis aligned with the main
+ * chart's timeline.
+ *
+ * Each point in `timeline.pnl_curve` maps to a `{time, value}` entry on a
+ * `LineSeries`; the entry's `time` is the timestamp of the matching bar in
+ * `timeline.bars` so that a horizontal scroll of the main chart and a scrub
+ * of `currentBarIdx` both align with the strip. A vertical cursor line marks
+ * the current bar and updates as the user drags the scrubber.
+ */
+
+import { useEffect, useMemo, useRef } from 'react';
+import {
+  ColorType,
+  LineSeries,
+  LineStyle,
+  createChart,
+  type IChartApi,
+  type ISeriesApi,
+  type LineData,
+  type UTCTimestamp,
+} from 'lightweight-charts';
+import {
+  useEffectiveBarIdx,
+  useTimelineState,
+} from '../../store';
+import type { SessionTimeline } from '../../types';
+
+const THEME = {
+  background: '#0e1116',
+  text: '#9ca3af',
+  grid: '#1c2230',
+  line: '#60a5fa',
+  cursor: '#e5e7eb',
+} as const;
+
+const STRIP_HEIGHT = 60;
+
+export function buildPnLLineData(timeline: SessionTimeline | null): LineData<UTCTimestamp>[] {
+  if (!timeline) return [];
+  const out: LineData<UTCTimestamp>[] = [];
+  const seen = new Set<number>();
+  for (const point of timeline.pnl_curve) {
+    const bar = timeline.bars[point.bar_idx];
+    if (!bar) continue;
+    const t = Math.floor(bar.timestamp_ns / 1_000_000_000);
+    if (seen.has(t)) continue;
+    seen.add(t);
+    out.push({ time: t as UTCTimestamp, value: point.equity_r });
+  }
+  out.sort((a, b) => (a.time as number) - (b.time as number));
+  return out;
+}
+
+export function PnLStrip() {
+  const timeline = useTimelineState();
+  const currentBarIdx = useEffectiveBarIdx();
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const chartRef = useRef<IChartApi | null>(null);
+  const seriesRef = useRef<ISeriesApi<'Line'> | null>(null);
+  const cursorRef = useRef<ISeriesApi<'Line'> | null>(null);
+
+  const data = useMemo(() => buildPnLLineData(timeline), [timeline]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const chart = createChart(container, {
+      layout: {
+        background: { type: ColorType.Solid, color: THEME.background },
+        textColor: THEME.text,
+        fontSize: 10,
+      },
+      grid: { vertLines: { visible: false }, horzLines: { color: THEME.grid } },
+      rightPriceScale: { borderColor: THEME.grid },
+      timeScale: { borderColor: THEME.grid, timeVisible: true, secondsVisible: false },
+      handleScroll: false,
+      handleScale: false,
+      autoSize: false,
+      width: container.clientWidth,
+      height: STRIP_HEIGHT,
+    });
+    const line = chart.addSeries(LineSeries, {
+      color: THEME.line,
+      lineWidth: 2,
+      priceLineVisible: false,
+      lastValueVisible: true,
+      crosshairMarkerVisible: false,
+    });
+    const cursor = chart.addSeries(LineSeries, {
+      color: THEME.cursor,
+      lineWidth: 1,
+      lineStyle: LineStyle.Solid,
+      priceLineVisible: false,
+      lastValueVisible: false,
+      crosshairMarkerVisible: false,
+    });
+
+    chartRef.current = chart;
+    seriesRef.current = line;
+    cursorRef.current = cursor;
+
+    const ro = new ResizeObserver(() => {
+      chart.resize(container.clientWidth, STRIP_HEIGHT);
+    });
+    ro.observe(container);
+
+    return () => {
+      ro.disconnect();
+      chart.remove();
+      chartRef.current = null;
+      seriesRef.current = null;
+      cursorRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Push line data.
+  useEffect(() => {
+    seriesRef.current?.setData(data);
+    if (data.length > 0) chartRef.current?.timeScale().fitContent();
+  }, [data]);
+
+  // Cursor line (drawn the same way as in HTFInset: two near-touching points
+  // spanning the visible value range).
+  useEffect(() => {
+    const cursor = cursorRef.current;
+    if (!cursor) return;
+    if (!timeline || data.length === 0 || currentBarIdx < 0) {
+      cursor.setData([]);
+      return;
+    }
+    const bar = timeline.bars[currentBarIdx];
+    if (!bar) {
+      cursor.setData([]);
+      return;
+    }
+    const cursorTime = Math.floor(bar.timestamp_ns / 1_000_000_000) as UTCTimestamp;
+    let lo = Number.POSITIVE_INFINITY;
+    let hi = Number.NEGATIVE_INFINITY;
+    for (const p of data) {
+      if (p.value < lo) lo = p.value;
+      if (p.value > hi) hi = p.value;
+    }
+    if (!Number.isFinite(lo) || !Number.isFinite(hi) || lo === hi) {
+      // Avoid degenerate line by widening the range a touch.
+      lo = lo - 0.001;
+      hi = hi + 0.001;
+    }
+    cursor.setData([
+      { time: cursorTime, value: lo },
+      { time: ((cursorTime as number) + 1) as UTCTimestamp, value: hi },
+    ]);
+  }, [timeline, currentBarIdx, data]);
+
+  if (!timeline || data.length === 0) {
+    return (
+      <div
+        className="flex h-[60px] items-center justify-center px-3 text-[11px] text-muted-foreground"
+        data-testid="pnl-strip-empty"
+      >
+        No PnL data
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="h-[60px] w-full bg-[#0e1116]"
+      data-testid="pnl-strip"
+    />
+  );
+}

--- a/ui/src/features/studio/layers/channels.ts
+++ b/ui/src/features/studio/layers/channels.ts
@@ -1,0 +1,108 @@
+/**
+ * Channels layer — micro_channel_top / micro_channel_bot fits drawn as
+ * semi-transparent dashed lines.
+ *
+ * Reads the latest event at-or-before `currentBarIdx` (the same convention
+ * the swings layer uses, since structure is accumulated). For each channel
+ * fit (line of the form `y = slope * x + intercept`, valid on the bar range
+ * `[start, end]`) we sample two endpoints and render with a dedicated
+ * `LineSeries`. Sampling outside the fit range is intentionally avoided so
+ * the line doesn't extrapolate past the data the model fit on.
+ */
+
+import {
+  LineSeries,
+  LineStyle,
+  type ISeriesApi,
+  type LineData,
+  type UTCTimestamp,
+} from 'lightweight-charts';
+import type { ChartLayer, LayerCtx, LayerHandle } from './types';
+import type { ChannelLine, SessionTimeline, StructureView } from '../types';
+
+const TOP_COLOR = 'rgba(239, 83, 80, 0.55)';
+const BOT_COLOR = 'rgba(38, 166, 154, 0.55)';
+
+function timeForBar(timeline: SessionTimeline, idx: number): UTCTimestamp | null {
+  const bar = timeline.bars[idx];
+  if (!bar) return null;
+  return Math.floor(bar.timestamp_ns / 1_000_000_000) as UTCTimestamp;
+}
+
+export function latestStructure(
+  timeline: SessionTimeline,
+  currentBarIdx: number,
+): StructureView | null {
+  for (let i = Math.min(currentBarIdx, timeline.events.length - 1); i >= 0; i--) {
+    const ev = timeline.events[i];
+    if (ev?.structure) return ev.structure;
+  }
+  return null;
+}
+
+export function buildChannelLineData(
+  timeline: SessionTimeline,
+  channel: ChannelLine | null | undefined,
+  currentBarIdx: number,
+): LineData<UTCTimestamp>[] {
+  if (!channel) return [];
+  const start = Math.max(0, Math.floor(channel.start));
+  const end = Math.min(currentBarIdx, Math.floor(channel.end));
+  if (end <= start) return [];
+
+  const startT = timeForBar(timeline, start);
+  const endT = timeForBar(timeline, end);
+  if (startT === null || endT === null) return [];
+
+  // y = slope * x + intercept; x is bar index.
+  return [
+    { time: startT, value: channel.slope * start + channel.intercept },
+    { time: endT, value: channel.slope * end + channel.intercept },
+  ];
+}
+
+export const channelsLayer: ChartLayer = {
+  id: 'channels',
+  name: 'Micro channels',
+  swatch: TOP_COLOR,
+  defaultVisible: true,
+
+  mount(ctx: LayerCtx): LayerHandle {
+    const { chart } = ctx;
+    let topSeries: ISeriesApi<'Line'> | null = chart.addSeries(LineSeries, {
+      color: TOP_COLOR,
+      lineWidth: 1,
+      lineStyle: LineStyle.Dashed,
+      priceLineVisible: false,
+      lastValueVisible: false,
+      crosshairMarkerVisible: false,
+    });
+    let botSeries: ISeriesApi<'Line'> | null = chart.addSeries(LineSeries, {
+      color: BOT_COLOR,
+      lineWidth: 1,
+      lineStyle: LineStyle.Dashed,
+      priceLineVisible: false,
+      lastValueVisible: false,
+      crosshairMarkerVisible: false,
+    });
+
+    return {
+      update(timeline, currentBarIdx) {
+        if (!topSeries || !botSeries) return;
+        const struct = latestStructure(timeline, currentBarIdx);
+        topSeries.setData(buildChannelLineData(timeline, struct?.micro_channel_top, currentBarIdx));
+        botSeries.setData(buildChannelLineData(timeline, struct?.micro_channel_bot, currentBarIdx));
+      },
+      unmount() {
+        try {
+          if (topSeries) chart.removeSeries(topSeries);
+          if (botSeries) chart.removeSeries(botSeries);
+        } catch {
+          // chart already disposed
+        }
+        topSeries = null;
+        botSeries = null;
+      },
+    };
+  },
+};

--- a/ui/src/features/studio/layers/htf_overlay.ts
+++ b/ui/src/features/studio/layers/htf_overlay.ts
@@ -1,0 +1,131 @@
+/**
+ * HTF overlay layer — projects key swing levels from the first available HTF
+ * timeframe onto the primary chart as horizontal dashed price lines.
+ *
+ * For each HTF bar at-or-before the current LTF bar's timestamp we derive a
+ * "swing high" / "swing low" by comparing the bar's high/low against the
+ * preceding HTF bars; the most recent few survive as `IPriceLine`s on the
+ * primary series. This gives a quick visual reference for the dominant
+ * higher-timeframe levels without leaving the primary candle view.
+ */
+
+import {
+  LineStyle,
+  type IPriceLine,
+} from 'lightweight-charts';
+import type { ChartLayer, LayerCtx, LayerHandle } from './types';
+import type { Bar, SessionTimeline } from '../types';
+
+const HIGH_COLOR = 'rgba(239, 83, 80, 0.65)';
+const LOW_COLOR = 'rgba(38, 166, 154, 0.65)';
+
+/** Maximum swings (high + low combined) drawn at any time. */
+export const HTF_OVERLAY_MAX_LEVELS = 6;
+
+/** Number of HTF bars on each side of a candidate that must be lower (for a high) or higher (for a low). */
+const SWING_LOOKBACK = 2;
+
+export interface HtfSwing {
+  bar_idx: number;
+  price: number;
+  kind: 'high' | 'low';
+  interval: string;
+}
+
+function pickInterval(timeline: SessionTimeline): string | null {
+  if (timeline.htf_intervals.length > 0) return timeline.htf_intervals[0];
+  const fromMap = Object.keys(timeline.htf_bars);
+  return fromMap.length > 0 ? fromMap[0] : null;
+}
+
+/** Identify confirmed HTF swings within `bars[0..end]`. */
+export function detectSwings(bars: Bar[], end: number): HtfSwing[] {
+  const out: HtfSwing[] = [];
+  const last = Math.min(end, bars.length - 1);
+  for (let i = SWING_LOOKBACK; i <= last - SWING_LOOKBACK; i++) {
+    const cur = bars[i];
+    let isHigh = true;
+    let isLow = true;
+    for (let k = 1; k <= SWING_LOOKBACK; k++) {
+      const left = bars[i - k];
+      const right = bars[i + k];
+      if (cur.high <= left.high || cur.high <= right.high) isHigh = false;
+      if (cur.low >= left.low || cur.low >= right.low) isLow = false;
+      if (!isHigh && !isLow) break;
+    }
+    if (isHigh) out.push({ bar_idx: i, price: cur.high, kind: 'high', interval: '' });
+    if (isLow) out.push({ bar_idx: i, price: cur.low, kind: 'low', interval: '' });
+  }
+  return out;
+}
+
+export function selectHtfLevels(
+  timeline: SessionTimeline,
+  currentBarIdx: number,
+  maxLevels: number = HTF_OVERLAY_MAX_LEVELS,
+): HtfSwing[] {
+  const interval = pickInterval(timeline);
+  if (!interval) return [];
+  const htfBars = timeline.htf_bars[interval];
+  if (!htfBars?.length) return [];
+
+  const cursorTs = timeline.bars[currentBarIdx]?.timestamp_ns;
+  if (cursorTs == null) return [];
+
+  // Drop HTF bars whose close lies after the LTF cursor — no future leak.
+  let visibleEnd = -1;
+  for (let i = 0; i < htfBars.length; i++) {
+    if (htfBars[i].timestamp_ns <= cursorTs) visibleEnd = i;
+    else break;
+  }
+  if (visibleEnd < 0) return [];
+
+  const swings = detectSwings(htfBars, visibleEnd).map((s) => ({ ...s, interval }));
+  // Keep most recent N (by HTF bar index) so the chart stays readable.
+  swings.sort((a, b) => b.bar_idx - a.bar_idx);
+  return swings.slice(0, maxLevels);
+}
+
+export const htfOverlayLayer: ChartLayer = {
+  id: 'htf_overlay',
+  name: 'HTF swings',
+  swatch: HIGH_COLOR,
+  defaultVisible: false,
+
+  mount(ctx: LayerCtx): LayerHandle {
+    let priceLines: IPriceLine[] = [];
+
+    const clear = () => {
+      for (const pl of priceLines) {
+        try {
+          ctx.primarySeries.removePriceLine(pl);
+        } catch {
+          // series already detached
+        }
+      }
+      priceLines = [];
+    };
+
+    return {
+      update(timeline, currentBarIdx) {
+        clear();
+        const levels = selectHtfLevels(timeline, currentBarIdx);
+        for (const lvl of levels) {
+          priceLines.push(
+            ctx.primarySeries.createPriceLine({
+              price: lvl.price,
+              color: lvl.kind === 'high' ? HIGH_COLOR : LOW_COLOR,
+              lineWidth: 1,
+              lineStyle: LineStyle.Dashed,
+              axisLabelVisible: true,
+              title: `${lvl.interval} ${lvl.kind} #${lvl.bar_idx}`,
+            }),
+          );
+        }
+      },
+      unmount() {
+        clear();
+      },
+    };
+  },
+};

--- a/ui/src/features/studio/layers/reasoning.ts
+++ b/ui/src/features/studio/layers/reasoning.ts
@@ -1,0 +1,102 @@
+/**
+ * Reasoning layer — small ℹ️ marker on every bar that carries an LLM/VLM
+ * decision reasoning string, so users can spot at a glance which bars have
+ * model commentary.
+ *
+ * Hover preview is delivered through the `text` field on the marker (a 60-
+ * char single-line excerpt); clicking jumps the user to the
+ * DecisionInspector via the studio store's `setBar` action, which is what
+ * the side panel is already keyed off.
+ *
+ * Future-info safety: bars with `bar_idx > currentBarIdx` are dropped.
+ */
+
+import {
+  createSeriesMarkers,
+  type ISeriesMarkersPluginApi,
+  type SeriesMarker,
+  type Time,
+  type UTCTimestamp,
+} from 'lightweight-charts';
+import type { ChartLayer, LayerCtx, LayerHandle } from './types';
+import type { BarEvent, SessionTimeline } from '../types';
+
+const HINT_COLOR = '#60a5fa';
+
+const PREVIEW_LIMIT = 60;
+
+function timeForBar(timeline: SessionTimeline, idx: number): UTCTimestamp | null {
+  const bar = timeline.bars[idx];
+  if (!bar) return null;
+  return Math.floor(bar.timestamp_ns / 1_000_000_000) as UTCTimestamp;
+}
+
+export function reasoningSnippet(ev: BarEvent): string | null {
+  const candidates: (string | undefined)[] = [
+    ev.decision?.reasoning as string | undefined,
+    ...((ev.signals ?? []).map((s) => s.reasoning as string | undefined)),
+  ];
+  for (const txt of candidates) {
+    if (typeof txt !== 'string') continue;
+    const trimmed = txt.replace(/\s+/g, ' ').trim();
+    if (!trimmed) continue;
+    return trimmed.length > PREVIEW_LIMIT
+      ? `${trimmed.slice(0, PREVIEW_LIMIT - 1)}…`
+      : trimmed;
+  }
+  return null;
+}
+
+export function buildReasoningMarkers(
+  timeline: SessionTimeline,
+  currentBarIdx: number,
+): SeriesMarker<Time>[] {
+  const out: SeriesMarker<Time>[] = [];
+  for (const ev of timeline.events) {
+    if (ev.bar_idx > currentBarIdx) continue;
+    const snippet = reasoningSnippet(ev);
+    if (!snippet) continue;
+    const t = timeForBar(timeline, ev.bar_idx);
+    if (t === null) continue;
+    out.push({
+      time: t as Time,
+      position: 'aboveBar',
+      shape: 'circle',
+      color: HINT_COLOR,
+      text: `ℹ ${snippet}`,
+      size: 0,
+      id: `reasoning-${ev.bar_idx}`,
+    });
+  }
+  out.sort((a, b) => (a.time as number) - (b.time as number));
+  return out;
+}
+
+export const reasoningLayer: ChartLayer = {
+  id: 'reasoning',
+  name: 'Reasoning hints',
+  swatch: HINT_COLOR,
+  defaultVisible: false,
+
+  mount(ctx: LayerCtx): LayerHandle {
+    let plugin: ISeriesMarkersPluginApi<Time> | null = createSeriesMarkers(
+      ctx.primarySeries,
+      [],
+    );
+
+    return {
+      update(timeline, currentBarIdx) {
+        if (!plugin) return;
+        plugin.setMarkers(buildReasoningMarkers(timeline, currentBarIdx));
+      },
+      unmount() {
+        try {
+          plugin?.detach();
+        } catch {
+          // chart already disposed
+        }
+        plugin = null;
+      },
+    };
+  },
+};

--- a/ui/src/features/studio/layers/registry.ts
+++ b/ui/src/features/studio/layers/registry.ts
@@ -4,9 +4,6 @@
  * Order is the order they appear in the `LayerToggle` panel and the order
  * they mount onto the chart. Adding a new layer = export a `ChartLayer`
  * from a sibling file and append it here.
- *
- * Phase S5 will append: channelsLayer, stopAdjLayer, htfOverlayLayer,
- * reasoningLayer.
  */
 
 import type { ChartLayer } from './types';
@@ -16,6 +13,10 @@ import { ema20Layer, ema200Layer } from './ema';
 import { signalsLayer } from './signals';
 import { decisionsLayer } from './decisions';
 import { fillsLayer } from './fills';
+import { channelsLayer } from './channels';
+import { stopAdjLayer } from './stop_adj';
+import { htfOverlayLayer } from './htf_overlay';
+import { reasoningLayer } from './reasoning';
 
 export const LAYERS: readonly ChartLayer[] = [
   regimeLayer,
@@ -25,6 +26,10 @@ export const LAYERS: readonly ChartLayer[] = [
   signalsLayer,
   decisionsLayer,
   fillsLayer,
+  channelsLayer,
+  stopAdjLayer,
+  htfOverlayLayer,
+  reasoningLayer,
 ];
 
 export const DEFAULT_VISIBLE: ReadonlySet<string> = new Set(

--- a/ui/src/features/studio/layers/stop_adj.ts
+++ b/ui/src/features/studio/layers/stop_adj.ts
@@ -1,0 +1,143 @@
+/**
+ * Stop ladder layer — step-line of every `stop_adj` event up to the current
+ * bar (initial → BE → trail).
+ *
+ * The stop value is held flat between adjustments and steps to the new value
+ * exactly on the bar where the adjustment fired, giving a staircase-shaped
+ * line. We additionally drop a small text marker on each step so users can
+ * eyeball the reason (`init`, `be`, `trail`, `chandelier`, etc.).
+ */
+
+import {
+  LineSeries,
+  LineStyle,
+  createSeriesMarkers,
+  type ISeriesApi,
+  type ISeriesMarkersPluginApi,
+  type LineData,
+  type SeriesMarker,
+  type Time,
+  type UTCTimestamp,
+} from 'lightweight-charts';
+import type { ChartLayer, LayerCtx, LayerHandle } from './types';
+import type { SessionTimeline, StopAdj } from '../types';
+
+const STOP_COLOR = '#FF7043';
+
+function timeForBar(timeline: SessionTimeline, idx: number): UTCTimestamp | null {
+  const bar = timeline.bars[idx];
+  if (!bar) return null;
+  return Math.floor(bar.timestamp_ns / 1_000_000_000) as UTCTimestamp;
+}
+
+export interface StopAdjPoint {
+  bar_idx: number;
+  adj: StopAdj;
+}
+
+export function collectStopAdjustments(
+  timeline: SessionTimeline,
+  currentBarIdx: number,
+): StopAdjPoint[] {
+  const out: StopAdjPoint[] = [];
+  for (const ev of timeline.events) {
+    if (ev.bar_idx > currentBarIdx) break;
+    if (ev.stop_adj) out.push({ bar_idx: ev.bar_idx, adj: ev.stop_adj });
+  }
+  return out;
+}
+
+export function buildStopLadderData(
+  timeline: SessionTimeline,
+  currentBarIdx: number,
+): LineData<UTCTimestamp>[] {
+  const points = collectStopAdjustments(timeline, currentBarIdx);
+  if (points.length === 0) return [];
+
+  // Build a value-per-bar series: hold flat until each adjustment's bar
+  // then step to the new value. Lightweight-charts requires strictly
+  // ascending unique timestamps; one sample per bar gives that for free.
+  const adjByBar = new Map<number, StopAdj>();
+  for (const { bar_idx, adj } of points) adjByBar.set(bar_idx, adj);
+
+  const startBar = points[0].bar_idx;
+  const endBar = Math.min(currentBarIdx, timeline.bars.length - 1);
+
+  const out: LineData<UTCTimestamp>[] = [];
+  let value = points[0].adj.from_px;
+  for (let i = startBar; i <= endBar; i++) {
+    const adj = adjByBar.get(i);
+    if (adj) value = adj.to_px;
+    const t = timeForBar(timeline, i);
+    if (t === null) continue;
+    out.push({ time: t, value });
+  }
+  return out;
+}
+
+export function buildStopAdjMarkers(
+  timeline: SessionTimeline,
+  currentBarIdx: number,
+): SeriesMarker<Time>[] {
+  const out: SeriesMarker<Time>[] = [];
+  for (const { bar_idx, adj } of collectStopAdjustments(timeline, currentBarIdx)) {
+    const t = timeForBar(timeline, bar_idx);
+    if (t === null) continue;
+    out.push({
+      time: t as Time,
+      position: 'aboveBar',
+      shape: 'square',
+      color: STOP_COLOR,
+      text: adj.reason || 'stop',
+      size: 0,
+      id: `stop-adj-${bar_idx}`,
+    });
+  }
+  out.sort((a, b) => (a.time as number) - (b.time as number));
+  return out;
+}
+
+export const stopAdjLayer: ChartLayer = {
+  id: 'stop_adj',
+  name: 'Stop ladder',
+  swatch: STOP_COLOR,
+  defaultVisible: true,
+
+  mount(ctx: LayerCtx): LayerHandle {
+    const { chart } = ctx;
+    let series: ISeriesApi<'Line'> | null = chart.addSeries(LineSeries, {
+      color: STOP_COLOR,
+      lineWidth: 2,
+      lineStyle: LineStyle.Solid,
+      priceLineVisible: false,
+      lastValueVisible: false,
+      crosshairMarkerVisible: false,
+    });
+    let plugin: ISeriesMarkersPluginApi<Time> | null = createSeriesMarkers(
+      ctx.primarySeries,
+      [],
+    );
+
+    return {
+      update(timeline, currentBarIdx) {
+        if (!series) return;
+        series.setData(buildStopLadderData(timeline, currentBarIdx));
+        plugin?.setMarkers(buildStopAdjMarkers(timeline, currentBarIdx));
+      },
+      unmount() {
+        try {
+          if (series) chart.removeSeries(series);
+        } catch {
+          // chart already disposed
+        }
+        try {
+          plugin?.detach();
+        } catch {
+          // chart already disposed
+        }
+        series = null;
+        plugin = null;
+      },
+    };
+  },
+};


### PR DESCRIPTION
## Summary
Phase S5 of Brooks Studio:

- **4 advanced chart layers** auto-registered in `LAYERS`: `channels` (micro-channel top/bot dashed), `stop_adj` (initial→BE→trail step ladder), `htf_overlay` (HTF swing high/low projected as dashed price-lines), `reasoning` (ℹ marker with single-line LLM/VLM reasoning preview).
- **HTFInset** 240×120 picture-in-picture HTF candle mini-chart top-right of the main chart; collapsible, interval-switchable, and expandable to a fullscreen modal; LTF cursor projected onto the HTF bar.
- **PnLStrip** 60 px equity-R sub-chart, time-axis aligned with the primary chart and cursor-tracked.
- **MultiAnalystCompare** side panel: POSTs `{bar_idx, analysts}` to a new backend endpoint, renders a diff-highlighted comparison table, with per-bar/per-analyst result cache and abortable concurrent requests.
- **`POST /brooks-studio/sessions/{id}/replay-bar`** — fans the analyst pipeline out via `asyncio.gather`, surfaces per-analyst errors inline (no 500s for unknown / failing analysts).

## Test plan
- [x] `bunx vitest run src/features/studio/` — 75 tests pass (8 new test files for the S5 surface)
- [x] `pytest tests/api/test_brooks_studio_router.py` — 10 tests pass (5 new for replay-bar: rule-analyst happy path, unknown analyst → error not 500, missing session 404, out-of-range bar 422, empty analyst list 422)
- [x] `bunx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)