### PR TITLE
[QUA-64] Studio side panels — Signal / Decision / Regime + hover ghost

### DIFF
--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -23,6 +23,8 @@
         "lucide-react": "^0.577.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-markdown": "^10.1.0",
+        "react-resizable-panels": "^4.10.0",
         "react-router-dom": "^7.5.0",
         "react-virtualized-auto-sizer": "^1.0.20",
         "react-window": "^1.8.10",
@@ -354,15 +356,27 @@
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "https://registry.npmmirror.com/@types/aria-query/-/aria-query-5.0.4.tgz", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
+    "@types/debug": ["@types/debug@4.1.13", "https://registry.npmmirror.com/@types/debug/-/debug-4.1.13.tgz", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
+
     "@types/estree": ["@types/estree@1.0.7", "https://registry.npmmirror.com/@types/estree/-/estree-1.0.7.tgz", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
 
+    "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "https://registry.npmmirror.com/@types/estree-jsx/-/estree-jsx-1.0.5.tgz", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
+
+    "@types/hast": ["@types/hast@3.0.4", "https://registry.npmmirror.com/@types/hast/-/hast-3.0.4.tgz", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
     "@types/json-schema": ["@types/json-schema@7.0.15", "https://registry.npmmirror.com/@types/json-schema/-/json-schema-7.0.15.tgz", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "https://registry.npmmirror.com/@types/mdast/-/mdast-4.0.4.tgz", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "https://registry.npmmirror.com/@types/ms/-/ms-2.1.0.tgz", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/react": ["@types/react@19.1.0", "https://registry.npmmirror.com/@types/react/-/react-19.1.0.tgz", { "dependencies": { "csstype": "3.1.3" } }, "sha512-UaicktuQI+9UKyA4njtDOGBD/67t8YEBt2xdfqu8+gP9hqPUPsiXlNPcpS2gVdjmis5GKPG3fCxbQLVgxsQZ8w=="],
 
     "@types/react-dom": ["@types/react-dom@19.1.1", "https://registry.npmmirror.com/@types/react-dom/-/react-dom-19.1.1.tgz", { "peerDependencies": { "@types/react": "19.1.0" } }, "sha512-jFf/woGTVTjUJsl2O7hcopJ1r0upqoq/vIOoCj0yLh3RIXxWcljlpuZ+vEBRXsymD1jhfeJrlyTy/S1UW+4y1w=="],
 
     "@types/react-window": ["@types/react-window@1.8.8", "https://registry.npmmirror.com/@types/react-window/-/react-window-1.8.8.tgz", { "dependencies": { "@types/react": "*" } }, "sha512-8Ls660bHR1AUA2kuRvVG9D/4XpRC6wjAaPT9dil7Ckc76eP9TKWZwwmgfq8Q1LANX3QNDnoU4Zp48A3w+zK69Q=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.29.0", "https://registry.npmmirror.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.29.0.tgz", { "dependencies": { "@eslint-community/regexpp": "4.12.1", "@typescript-eslint/scope-manager": "8.29.0", "@typescript-eslint/type-utils": "8.29.0", "@typescript-eslint/utils": "8.29.0", "@typescript-eslint/visitor-keys": "8.29.0", "graphemer": "1.4.0", "ignore": "5.3.2", "natural-compare": "1.4.0", "ts-api-utils": "2.1.0" }, "peerDependencies": { "@typescript-eslint/parser": "8.29.0", "eslint": "9.23.0", "typescript": "5.7.3" } }, "sha512-PAIpk/U7NIS6H7TEtN45SPGLQaHNgB7wSjsQV/8+KYokAb2T/gloOA/Bee2yd4/yKVhPKe5LlaUGhAZk5zmSaQ=="],
 
@@ -379,6 +393,8 @@
     "@typescript-eslint/utils": ["@typescript-eslint/utils@8.29.0", "https://registry.npmmirror.com/@typescript-eslint/utils/-/utils-8.29.0.tgz", { "dependencies": { "@eslint-community/eslint-utils": "4.5.1", "@typescript-eslint/scope-manager": "8.29.0", "@typescript-eslint/types": "8.29.0", "@typescript-eslint/typescript-estree": "8.29.0" }, "peerDependencies": { "eslint": "9.23.0", "typescript": "5.7.3" } }, "sha512-gX/A0Mz9Bskm8avSWFcK0gP7cZpbY4AIo6B0hWYFCaIsz750oaiWR4Jr2CI+PQhfW1CpcQr9OlfPS+kMFegjXA=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.29.0", "https://registry.npmmirror.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.29.0.tgz", { "dependencies": { "@typescript-eslint/types": "8.29.0", "eslint-visitor-keys": "4.2.0" } }, "sha512-Sne/pVz8ryR03NFK21VpN88dZ2FdQXOlq3VIklbrTYEt8yXtRFr9tvUhqvCeKjqYk5FSim37sHbooT6vzBTZcg=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "https://registry.npmmirror.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
     "@vitejs/plugin-react-swc": ["@vitejs/plugin-react-swc@3.8.1", "https://registry.npmmirror.com/@vitejs/plugin-react-swc/-/plugin-react-swc-3.8.1.tgz", { "dependencies": { "@swc/core": "1.11.16" }, "peerDependencies": { "vite": "6.2.5" } }, "sha512-aEUPCckHDcFyxpwFm0AIkbtv6PpUp3xTb9wYGFjtABynXjCYKkWoxX0AOK9NT9XCrdk6mBBUOeHQS+RKdcNO1A=="],
 
@@ -418,6 +434,8 @@
 
     "asynckit": ["asynckit@0.4.0", "https://registry.npmmirror.com/asynckit/-/asynckit-0.4.0.tgz", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
+    "bail": ["bail@2.0.2", "https://registry.npmmirror.com/bail/-/bail-2.0.2.tgz", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
+
     "balanced-match": ["balanced-match@1.0.2", "https://registry.npmmirror.com/balanced-match/-/balanced-match-1.0.2.tgz", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "brace-expansion": ["brace-expansion@1.1.11", "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-1.1.11.tgz", { "dependencies": { "balanced-match": "1.0.2", "concat-map": "0.0.1" } }, "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="],
@@ -430,9 +448,19 @@
 
     "callsites": ["callsites@3.1.0", "https://registry.npmmirror.com/callsites/-/callsites-3.1.0.tgz", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
+    "ccount": ["ccount@2.0.1", "https://registry.npmmirror.com/ccount/-/ccount-2.0.1.tgz", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
     "chai": ["chai@5.3.3", "https://registry.npmmirror.com/chai/-/chai-5.3.3.tgz", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
 
     "chalk": ["chalk@4.1.2", "https://registry.npmmirror.com/chalk/-/chalk-4.1.2.tgz", { "dependencies": { "ansi-styles": "4.3.0", "supports-color": "7.2.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "character-entities": ["character-entities@2.0.2", "https://registry.npmmirror.com/character-entities/-/character-entities-2.0.2.tgz", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "https://registry.npmmirror.com/character-entities-html4/-/character-entities-html4-2.1.0.tgz", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "https://registry.npmmirror.com/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
+    "character-reference-invalid": ["character-reference-invalid@2.0.1", "https://registry.npmmirror.com/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
 
     "check-error": ["check-error@2.1.3", "https://registry.npmmirror.com/check-error/-/check-error-2.1.3.tgz", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
@@ -445,6 +473,8 @@
     "color-name": ["color-name@1.1.4", "https://registry.npmmirror.com/color-name/-/color-name-1.1.4.tgz", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "combined-stream": ["combined-stream@1.0.8", "https://registry.npmmirror.com/combined-stream/-/combined-stream-1.0.8.tgz", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "https://registry.npmmirror.com/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "concat-map": ["concat-map@0.0.1", "https://registry.npmmirror.com/concat-map/-/concat-map-0.0.1.tgz", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
@@ -464,6 +494,8 @@
 
     "decimal.js": ["decimal.js@10.6.0", "https://registry.npmmirror.com/decimal.js/-/decimal.js-10.6.0.tgz", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
+    "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "https://registry.npmmirror.com/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
     "deep-eql": ["deep-eql@5.0.2", "https://registry.npmmirror.com/deep-eql/-/deep-eql-5.0.2.tgz", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
 
     "deep-is": ["deep-is@0.1.4", "https://registry.npmmirror.com/deep-is/-/deep-is-0.1.4.tgz", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
@@ -475,6 +507,8 @@
     "detect-libc": ["detect-libc@2.1.2", "https://registry.npmmirror.com/detect-libc/-/detect-libc-2.1.2.tgz", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "https://registry.npmmirror.com/detect-node-es/-/detect-node-es-1.1.0.tgz", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
+
+    "devlop": ["devlop@1.1.0", "https://registry.npmmirror.com/devlop/-/devlop-1.1.0.tgz", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "dinero.js": ["dinero.js@1.9.1", "https://registry.npmmirror.com/dinero.js/-/dinero.js-1.9.1.tgz", {}, "sha512-1HXiF2vv3ZeRQ23yr+9lFxj/PbZqutuYWJnE0qfCB9xYBPnuaJ8lXtli1cJM0TvUXW1JTOaePldmqN5JVNxKSA=="],
 
@@ -522,11 +556,15 @@
 
     "estraverse": ["estraverse@5.3.0", "https://registry.npmmirror.com/estraverse/-/estraverse-5.3.0.tgz", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
+    "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "https://registry.npmmirror.com/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
+
     "estree-walker": ["estree-walker@3.0.3", "https://registry.npmmirror.com/estree-walker/-/estree-walker-3.0.3.tgz", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "esutils": ["esutils@2.0.3", "https://registry.npmmirror.com/esutils/-/esutils-2.0.3.tgz", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "expect-type": ["expect-type@1.3.0", "https://registry.npmmirror.com/expect-type/-/expect-type-1.3.0.tgz", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "extend": ["extend@3.0.2", "https://registry.npmmirror.com/extend/-/extend-3.0.2.tgz", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "fancy-canvas": ["fancy-canvas@2.1.0", "https://registry.npmmirror.com/fancy-canvas/-/fancy-canvas-2.1.0.tgz", {}, "sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ=="],
 
@@ -580,7 +618,13 @@
 
     "hasown": ["hasown@2.0.3", "https://registry.npmmirror.com/hasown/-/hasown-2.0.3.tgz", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
+    "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "https://registry.npmmirror.com/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "https://registry.npmmirror.com/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
     "html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "https://registry.npmmirror.com/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
+
+    "html-url-attributes": ["html-url-attributes@3.0.1", "https://registry.npmmirror.com/html-url-attributes/-/html-url-attributes-3.0.1.tgz", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "https://registry.npmmirror.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
@@ -596,11 +640,23 @@
 
     "indent-string": ["indent-string@4.0.0", "https://registry.npmmirror.com/indent-string/-/indent-string-4.0.0.tgz", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
+    "inline-style-parser": ["inline-style-parser@0.2.7", "https://registry.npmmirror.com/inline-style-parser/-/inline-style-parser-0.2.7.tgz", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
+
+    "is-alphabetical": ["is-alphabetical@2.0.1", "https://registry.npmmirror.com/is-alphabetical/-/is-alphabetical-2.0.1.tgz", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
+
+    "is-alphanumerical": ["is-alphanumerical@2.0.1", "https://registry.npmmirror.com/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
+
+    "is-decimal": ["is-decimal@2.0.1", "https://registry.npmmirror.com/is-decimal/-/is-decimal-2.0.1.tgz", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
+
     "is-extglob": ["is-extglob@2.1.1", "https://registry.npmmirror.com/is-extglob/-/is-extglob-2.1.1.tgz", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
     "is-glob": ["is-glob@4.0.3", "https://registry.npmmirror.com/is-glob/-/is-glob-4.0.3.tgz", { "dependencies": { "is-extglob": "2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
+    "is-hexadecimal": ["is-hexadecimal@2.0.1", "https://registry.npmmirror.com/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
+
     "is-number": ["is-number@7.0.0", "https://registry.npmmirror.com/is-number/-/is-number-7.0.0.tgz", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-plain-obj": ["is-plain-obj@4.1.0", "https://registry.npmmirror.com/is-plain-obj/-/is-plain-obj-4.1.0.tgz", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "https://registry.npmmirror.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 
@@ -654,6 +710,8 @@
 
     "lodash.merge": ["lodash.merge@4.6.2", "https://registry.npmmirror.com/lodash.merge/-/lodash.merge-4.6.2.tgz", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
+    "longest-streak": ["longest-streak@3.1.0", "https://registry.npmmirror.com/longest-streak/-/longest-streak-3.1.0.tgz", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
     "loupe": ["loupe@3.2.1", "https://registry.npmmirror.com/loupe/-/loupe-3.2.1.tgz", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
     "lru-cache": ["lru-cache@10.4.3", "https://registry.npmmirror.com/lru-cache/-/lru-cache-10.4.3.tgz", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
@@ -666,9 +724,67 @@
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "https://registry.npmmirror.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
+    "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "https://registry.npmmirror.com/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
+
+    "mdast-util-mdx-expression": ["mdast-util-mdx-expression@2.0.1", "https://registry.npmmirror.com/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ=="],
+
+    "mdast-util-mdx-jsx": ["mdast-util-mdx-jsx@3.2.0", "https://registry.npmmirror.com/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "parse-entities": "^4.0.0", "stringify-entities": "^4.0.0", "unist-util-stringify-position": "^4.0.0", "vfile-message": "^4.0.0" } }, "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q=="],
+
+    "mdast-util-mdxjs-esm": ["mdast-util-mdxjs-esm@2.0.1", "https://registry.npmmirror.com/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg=="],
+
+    "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "https://registry.npmmirror.com/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
+
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "https://registry.npmmirror.com/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
+    "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "https://registry.npmmirror.com/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
+
+    "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "https://registry.npmmirror.com/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
     "memoize-one": ["memoize-one@5.2.1", "https://registry.npmmirror.com/memoize-one/-/memoize-one-5.2.1.tgz", {}, "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="],
 
     "merge2": ["merge2@1.4.1", "https://registry.npmmirror.com/merge2/-/merge2-1.4.1.tgz", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "micromark": ["micromark@4.0.2", "https://registry.npmmirror.com/micromark/-/micromark-4.0.2.tgz", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
+
+    "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "https://registry.npmmirror.com/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "https://registry.npmmirror.com/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
+
+    "micromark-factory-label": ["micromark-factory-label@2.0.1", "https://registry.npmmirror.com/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz", { "dependencies": { "devlop": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="],
+
+    "micromark-factory-space": ["micromark-factory-space@2.0.1", "https://registry.npmmirror.com/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
+
+    "micromark-factory-title": ["micromark-factory-title@2.0.1", "https://registry.npmmirror.com/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw=="],
+
+    "micromark-factory-whitespace": ["micromark-factory-whitespace@2.0.1", "https://registry.npmmirror.com/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "https://registry.npmmirror.com/micromark-util-character/-/micromark-util-character-2.1.1.tgz", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-chunked": ["micromark-util-chunked@2.0.1", "https://registry.npmmirror.com/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA=="],
+
+    "micromark-util-classify-character": ["micromark-util-classify-character@2.0.1", "https://registry.npmmirror.com/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q=="],
+
+    "micromark-util-combine-extensions": ["micromark-util-combine-extensions@2.0.1", "https://registry.npmmirror.com/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz", { "dependencies": { "micromark-util-chunked": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg=="],
+
+    "micromark-util-decode-numeric-character-reference": ["micromark-util-decode-numeric-character-reference@2.0.2", "https://registry.npmmirror.com/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw=="],
+
+    "micromark-util-decode-string": ["micromark-util-decode-string@2.0.1", "https://registry.npmmirror.com/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz", { "dependencies": { "decode-named-character-reference": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "https://registry.npmmirror.com/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-html-tag-name": ["micromark-util-html-tag-name@2.0.1", "https://registry.npmmirror.com/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz", {}, "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="],
+
+    "micromark-util-normalize-identifier": ["micromark-util-normalize-identifier@2.0.1", "https://registry.npmmirror.com/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q=="],
+
+    "micromark-util-resolve-all": ["micromark-util-resolve-all@2.0.1", "https://registry.npmmirror.com/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "https://registry.npmmirror.com/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-subtokenize": ["micromark-util-subtokenize@2.1.0", "https://registry.npmmirror.com/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "https://registry.npmmirror.com/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "https://registry.npmmirror.com/micromark-util-types/-/micromark-util-types-2.0.2.tgz", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
     "micromatch": ["micromatch@4.0.8", "https://registry.npmmirror.com/micromatch/-/micromatch-4.0.8.tgz", { "dependencies": { "braces": "3.0.3", "picomatch": "2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
@@ -696,6 +812,8 @@
 
     "parent-module": ["parent-module@1.0.1", "https://registry.npmmirror.com/parent-module/-/parent-module-1.0.1.tgz", { "dependencies": { "callsites": "3.1.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
+    "parse-entities": ["parse-entities@4.0.2", "https://registry.npmmirror.com/parse-entities/-/parse-entities-4.0.2.tgz", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
+
     "parse5": ["parse5@7.3.0", "https://registry.npmmirror.com/parse5/-/parse5-7.3.0.tgz", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "path-exists": ["path-exists@4.0.0", "https://registry.npmmirror.com/path-exists/-/path-exists-4.0.0.tgz", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
@@ -716,6 +834,8 @@
 
     "pretty-format": ["pretty-format@27.5.1", "https://registry.npmmirror.com/pretty-format/-/pretty-format-27.5.1.tgz", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
+    "property-information": ["property-information@7.1.0", "https://registry.npmmirror.com/property-information/-/property-information-7.1.0.tgz", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
     "punycode": ["punycode@2.3.1", "https://registry.npmmirror.com/punycode/-/punycode-2.3.1.tgz", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "https://registry.npmmirror.com/queue-microtask/-/queue-microtask-1.2.3.tgz", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
@@ -726,9 +846,13 @@
 
     "react-is": ["react-is@17.0.2", "https://registry.npmmirror.com/react-is/-/react-is-17.0.2.tgz", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
+    "react-markdown": ["react-markdown@10.1.0", "https://registry.npmmirror.com/react-markdown/-/react-markdown-10.1.0.tgz", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
+
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "https://registry.npmmirror.com/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "https://registry.npmmirror.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
+
+    "react-resizable-panels": ["react-resizable-panels@4.10.0", "https://registry.npmmirror.com/react-resizable-panels/-/react-resizable-panels-4.10.0.tgz", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-frjewRQt7TCv/vCH1pJfjZ7RxAhr5pKuqVQtVgzFq/vherxBFOWyC3xMbryx5Ti2wylViGUFc93Etg4rB3E0UA=="],
 
     "react-router": ["react-router@7.14.0", "https://registry.npmmirror.com/react-router/-/react-router-7.14.0.tgz", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ=="],
 
@@ -743,6 +867,10 @@
     "redent": ["redent@3.0.0", "https://registry.npmmirror.com/redent/-/redent-3.0.0.tgz", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
     "regenerator-runtime": ["regenerator-runtime@0.14.1", "https://registry.npmmirror.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz", {}, "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="],
+
+    "remark-parse": ["remark-parse@11.0.0", "https://registry.npmmirror.com/remark-parse/-/remark-parse-11.0.0.tgz", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
+
+    "remark-rehype": ["remark-rehype@11.1.2", "https://registry.npmmirror.com/remark-rehype/-/remark-rehype-11.1.2.tgz", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "mdast-util-to-hast": "^13.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw=="],
 
     "resolve-from": ["resolve-from@4.0.0", "https://registry.npmmirror.com/resolve-from/-/resolve-from-4.0.0.tgz", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
@@ -776,13 +904,21 @@
 
     "source-map-js": ["source-map-js@1.2.1", "https://registry.npmmirror.com/source-map-js/-/source-map-js-1.2.1.tgz", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "https://registry.npmmirror.com/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
     "stackback": ["stackback@0.0.2", "https://registry.npmmirror.com/stackback/-/stackback-0.0.2.tgz", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
     "std-env": ["std-env@3.10.0", "https://registry.npmmirror.com/std-env/-/std-env-3.10.0.tgz", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
+    "stringify-entities": ["stringify-entities@4.0.4", "https://registry.npmmirror.com/stringify-entities/-/stringify-entities-4.0.4.tgz", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
     "strip-indent": ["strip-indent@3.0.0", "https://registry.npmmirror.com/strip-indent/-/strip-indent-3.0.0.tgz", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "https://registry.npmmirror.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "style-to-js": ["style-to-js@1.1.21", "https://registry.npmmirror.com/style-to-js/-/style-to-js-1.1.21.tgz", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
+
+    "style-to-object": ["style-to-object@1.0.14", "https://registry.npmmirror.com/style-to-object/-/style-to-object-1.0.14.tgz", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
 
     "supports-color": ["supports-color@7.2.0", "https://registry.npmmirror.com/supports-color/-/supports-color-7.2.0.tgz", { "dependencies": { "has-flag": "4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -814,6 +950,10 @@
 
     "tr46": ["tr46@5.1.1", "https://registry.npmmirror.com/tr46/-/tr46-5.1.1.tgz", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
 
+    "trim-lines": ["trim-lines@3.0.1", "https://registry.npmmirror.com/trim-lines/-/trim-lines-3.0.1.tgz", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
+    "trough": ["trough@2.2.0", "https://registry.npmmirror.com/trough/-/trough-2.2.0.tgz", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
+
     "ts-api-utils": ["ts-api-utils@2.1.0", "https://registry.npmmirror.com/ts-api-utils/-/ts-api-utils-2.1.0.tgz", { "peerDependencies": { "typescript": "5.7.3" } }, "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ=="],
 
     "tslib": ["tslib@2.8.1", "https://registry.npmmirror.com/tslib/-/tslib-2.8.1.tgz", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
@@ -826,11 +966,27 @@
 
     "typescript-eslint": ["typescript-eslint@8.29.0", "https://registry.npmmirror.com/typescript-eslint/-/typescript-eslint-8.29.0.tgz", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.29.0", "@typescript-eslint/parser": "8.29.0", "@typescript-eslint/utils": "8.29.0" }, "peerDependencies": { "eslint": "9.23.0", "typescript": "5.7.3" } }, "sha512-ep9rVd9B4kQsZ7ZnWCVxUE/xDLUUUsRzE0poAeNu+4CkFErLfuvPt/qtm2EpnSyfvsR0S6QzDFSrPCFBwf64fg=="],
 
+    "unified": ["unified@11.0.5", "https://registry.npmmirror.com/unified/-/unified-11.0.5.tgz", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
+
+    "unist-util-is": ["unist-util-is@6.0.1", "https://registry.npmmirror.com/unist-util-is/-/unist-util-is-6.0.1.tgz", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "https://registry.npmmirror.com/unist-util-position/-/unist-util-position-5.0.0.tgz", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "https://registry.npmmirror.com/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "https://registry.npmmirror.com/unist-util-visit/-/unist-util-visit-5.1.0.tgz", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "https://registry.npmmirror.com/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
     "uri-js": ["uri-js@4.4.1", "https://registry.npmmirror.com/uri-js/-/uri-js-4.4.1.tgz", { "dependencies": { "punycode": "2.3.1" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
     "use-callback-ref": ["use-callback-ref@1.3.3", "https://registry.npmmirror.com/use-callback-ref/-/use-callback-ref-1.3.3.tgz", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
 
     "use-sidecar": ["use-sidecar@1.1.3", "https://registry.npmmirror.com/use-sidecar/-/use-sidecar-1.1.3.tgz", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
+
+    "vfile": ["vfile@6.0.3", "https://registry.npmmirror.com/vfile/-/vfile-6.0.3.tgz", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "https://registry.npmmirror.com/vfile-message/-/vfile-message-4.0.3.tgz", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "vite": ["vite@6.2.5", "https://registry.npmmirror.com/vite/-/vite-6.2.5.tgz", { "dependencies": { "esbuild": "0.25.2", "postcss": "8.5.3", "rollup": "4.39.0" }, "optionalDependencies": { "fsevents": "2.3.3" }, "bin": { "vite": "bin/vite.js" } }, "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA=="],
 
@@ -865,6 +1021,8 @@
     "zrender": ["zrender@5.6.1", "https://registry.npmmirror.com/zrender/-/zrender-5.6.1.tgz", { "dependencies": { "tslib": "2.3.0" } }, "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag=="],
 
     "zustand": ["zustand@5.0.11", "https://registry.npmmirror.com/zustand/-/zustand-5.0.11.tgz", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg=="],
+
+    "zwitch": ["zwitch@2.0.4", "https://registry.npmmirror.com/zwitch/-/zwitch-2.0.4.tgz", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "https://registry.npmmirror.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
@@ -917,6 +1075,8 @@
     "echarts/tslib": ["tslib@2.3.0", "https://registry.npmmirror.com/tslib/-/tslib-2.3.0.tgz", {}, "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "https://registry.npmmirror.com/glob-parent/-/glob-parent-5.1.2.tgz", { "dependencies": { "is-glob": "4.0.3" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "parse-entities/@types/unist": ["@types/unist@2.0.11", "https://registry.npmmirror.com/@types/unist/-/unist-2.0.11.tgz", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-5.2.0.tgz", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -30,6 +30,8 @@
     "lucide-react": "^0.577.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-markdown": "^10.1.0",
+    "react-resizable-panels": "^4.10.0",
     "react-router-dom": "^7.5.0",
     "react-virtualized-auto-sizer": "^1.0.20",
     "react-window": "^1.8.10",

--- a/ui/src/features/studio/__tests__/DecisionInspector.test.tsx
+++ b/ui/src/features/studio/__tests__/DecisionInspector.test.tsx
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { useStudioStore } from '../store';
+import {
+  DecisionInspector,
+  decisionSupportingSignals,
+  expectedRTone,
+  probabilityBucket,
+} from '../components/side/DecisionInspector';
+import { makeDecision, makeSignal, makeTimeline } from './fixtures';
+import type { Decision } from '../types';
+
+const reset = () => useStudioStore.getState().actions.reset();
+
+beforeEach(reset);
+afterEach(reset);
+
+describe('probabilityBucket', () => {
+  it('partitions probabilities into low / mid / high / top', () => {
+    expect(probabilityBucket(0.3).tone).toBe('low');
+    expect(probabilityBucket(0.55).tone).toBe('mid');
+    expect(probabilityBucket(0.7).tone).toBe('high');
+    expect(probabilityBucket(0.92).tone).toBe('top');
+  });
+});
+
+describe('expectedRTone', () => {
+  it('returns negative tone for losing E[R]', () => {
+    expect(expectedRTone(-0.5)).toContain('rose');
+  });
+  it('returns positive tone for winning E[R]', () => {
+    expect(expectedRTone(2.0)).toContain('emerald');
+  });
+});
+
+describe('decisionSupportingSignals', () => {
+  it('returns the signals array when present', () => {
+    const d: Decision = makeDecision();
+    (d as Record<string, unknown>).signals = [makeSignal({ id: 'a' }), makeSignal({ id: 'b' })];
+    expect(decisionSupportingSignals(d).length).toBe(2);
+  });
+  it('returns an empty array when missing or wrong type', () => {
+    expect(decisionSupportingSignals(makeDecision())).toEqual([]);
+  });
+});
+
+describe('DecisionInspector component', () => {
+  function loadFixture(decision: Decision | null = makeDecision()) {
+    const tl = makeTimeline(5);
+    if (decision) {
+      tl.events[2].decision = decision;
+    }
+    const { actions } = useStudioStore.getState();
+    actions.setTimeline(tl);
+    actions.setBar(2);
+  }
+
+  it('renders empty placeholder when no decision exists', () => {
+    loadFixture(null);
+    render(<DecisionInspector />);
+    expect(screen.getByTestId('decision-inspector-empty')).toBeInTheDocument();
+  });
+
+  it('shows side, pattern, regime and htf-aligned tag', () => {
+    loadFixture(makeDecision({ side: 'long', pattern: 'h2', regime: 'strong_bull_trend', htf_aligned: true }));
+    render(<DecisionInspector />);
+    expect(screen.getByTestId('decision-side-badge')).toHaveTextContent('long');
+    expect(screen.getByTestId('decision-regime')).toHaveTextContent('strong_bull_trend');
+    expect(screen.getByTestId('decision-htf-aligned')).toBeInTheDocument();
+    expect(screen.queryByTestId('decision-htf-misaligned')).toBeNull();
+  });
+
+  it('renders the misaligned tag when htf_aligned is false', () => {
+    loadFixture(makeDecision({ htf_aligned: false }));
+    render(<DecisionInspector />);
+    expect(screen.getByTestId('decision-htf-misaligned')).toBeInTheDocument();
+  });
+
+  it('renders entry / stop / target cells with distance to current price', () => {
+    const tl = makeTimeline(5);
+    tl.bars[2] = { ...tl.bars[2], close: 100 };
+    tl.events[2].decision = makeDecision({ entry_px: 105, stop_px: 95, target_px: 120 });
+    const { actions } = useStudioStore.getState();
+    actions.setTimeline(tl);
+    actions.setBar(2);
+
+    render(<DecisionInspector />);
+    const levels = screen.getByTestId('decision-price-levels');
+    expect(levels).toHaveTextContent('entry');
+    expect(levels).toHaveTextContent('stop');
+    expect(levels).toHaveTextContent('target');
+    // Distance text appears in parentheses with sign and percentage.
+    expect(levels.textContent).toMatch(/\+5/);
+    expect(levels.textContent).toMatch(/-5/);
+  });
+
+  it('renders reasoning markdown including code blocks', () => {
+    loadFixture(
+      makeDecision({
+        reasoning: '## Why\nbreakout above **EMA20**\n\n```\npx > ema20\n```',
+      }),
+    );
+    render(<DecisionInspector />);
+    const block = screen.getByTestId('decision-reasoning');
+    expect(block).toBeInTheDocument();
+    expect(block.querySelector('h2')).toBeTruthy();
+    expect(block.querySelector('strong')).toBeTruthy();
+    expect(block.querySelector('pre code')).toBeTruthy();
+  });
+
+  it('falls back to current bar when hovered idx clears', () => {
+    loadFixture(makeDecision({ pattern: 'h2' }));
+    const { actions } = useStudioStore.getState();
+    actions.setHoveredBar(0); // events[0].decision is null in fixture
+    const { rerender } = render(<DecisionInspector />);
+    expect(screen.getByTestId('decision-inspector-empty')).toBeInTheDocument();
+
+    act(() => {
+      actions.setHoveredBar(null);
+    });
+    rerender(<DecisionInspector />);
+    expect(screen.queryByTestId('decision-inspector-empty')).toBeNull();
+    expect(screen.getByTestId('decision-side-badge')).toBeInTheDocument();
+  });
+
+  it('copy json button emits decision JSON', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    loadFixture(makeDecision({ pattern: 'h2', probability: 0.7 }));
+    render(<DecisionInspector />);
+    fireEvent.click(screen.getByTestId('decision-copy-json'));
+    expect(writeText).toHaveBeenCalled();
+    const arg = writeText.mock.calls[0][0] as string;
+    expect(arg).toContain('"pattern": "h2"');
+  });
+});

--- a/ui/src/features/studio/__tests__/RegimeTimeline.test.tsx
+++ b/ui/src/features/studio/__tests__/RegimeTimeline.test.tsx
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { useStudioStore } from '../store';
+import {
+  buildRegimeSegments,
+  RegimeTimeline,
+} from '../components/side/RegimeTimeline';
+import { makeRegime, makeTimeline } from './fixtures';
+import type { SessionTimeline } from '../types';
+
+const reset = () => useStudioStore.getState().actions.reset();
+
+beforeEach(reset);
+afterEach(reset);
+
+function withRegimes(): SessionTimeline {
+  const tl = makeTimeline(6);
+  tl.events[0].regime = makeRegime('strong_bull_trend');
+  tl.events[1].regime = makeRegime('strong_bull_trend');
+  tl.events[2].regime = makeRegime('strong_bull_trend');
+  tl.events[3].regime = makeRegime('tight_tr');
+  tl.events[4].regime = makeRegime('strong_bear_trend');
+  tl.events[5].regime = makeRegime('strong_bear_trend');
+  return tl;
+}
+
+describe('buildRegimeSegments', () => {
+  it('groups consecutive bars with the same regime', () => {
+    const segs = buildRegimeSegments(withRegimes());
+    expect(segs.length).toBe(3);
+    expect(segs[0]).toMatchObject({ name: 'strong_bull_trend', start: 0, end: 2 });
+    expect(segs[1]).toMatchObject({ name: 'tight_tr', start: 3, end: 3 });
+    expect(segs[2]).toMatchObject({ name: 'strong_bear_trend', start: 4, end: 5 });
+  });
+
+  it('treats bars without a regime as the synthetic "unknown" segment', () => {
+    const tl = makeTimeline(3);
+    tl.events[0].regime = makeRegime('strong_bull_trend');
+    // events[1], events[2] have no regime set
+    const segs = buildRegimeSegments(tl);
+    expect(segs.map((s) => s.name)).toEqual(['strong_bull_trend', 'unknown']);
+  });
+
+  it('returns one segment when all bars share a regime', () => {
+    const tl = makeTimeline(4);
+    for (const ev of tl.events) ev.regime = makeRegime('channel');
+    const segs = buildRegimeSegments(tl);
+    expect(segs.length).toBe(1);
+    expect(segs[0]).toMatchObject({ start: 0, end: 3, name: 'channel' });
+  });
+});
+
+describe('RegimeTimeline component', () => {
+  it('renders empty state when no timeline is loaded', () => {
+    render(<RegimeTimeline />);
+    expect(screen.getByTestId('regime-timeline-empty')).toBeInTheDocument();
+  });
+
+  it('renders one button per segment with regime data attribute', () => {
+    const { actions } = useStudioStore.getState();
+    actions.setTimeline(withRegimes());
+    render(<RegimeTimeline />);
+    expect(screen.getByTestId('regime-segment-0')).toHaveAttribute(
+      'data-regime-name',
+      'strong_bull_trend',
+    );
+    expect(screen.getByTestId('regime-segment-1')).toHaveAttribute('data-regime-name', 'tight_tr');
+    expect(screen.getByTestId('regime-segment-2')).toHaveAttribute(
+      'data-regime-name',
+      'strong_bear_trend',
+    );
+  });
+
+  it('clicking a segment jumps to its starting bar', () => {
+    const { actions } = useStudioStore.getState();
+    actions.setTimeline(withRegimes());
+    render(<RegimeTimeline />);
+    act(() => {
+      fireEvent.click(screen.getByTestId('regime-segment-2'));
+    });
+    expect(useStudioStore.getState().currentBarIdx).toBe(4);
+  });
+
+  it('hovering a segment surfaces stats in the tooltip', () => {
+    const { actions } = useStudioStore.getState();
+    actions.setTimeline(withRegimes());
+    render(<RegimeTimeline />);
+    expect(screen.getByTestId('regime-tooltip-empty')).toBeInTheDocument();
+    act(() => {
+      fireEvent.mouseEnter(screen.getByTestId('regime-segment-0'));
+    });
+    const tip = screen.getByTestId('regime-tooltip');
+    expect(tip).toHaveTextContent('strong_bull_trend');
+    expect(tip).toHaveTextContent('bars 0-2');
+  });
+});

--- a/ui/src/features/studio/__tests__/SidePanel.test.tsx
+++ b/ui/src/features/studio/__tests__/SidePanel.test.tsx
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useStudioStore } from '../store';
+import { SidePanel } from '../components/side/SidePanel';
+import { makeDecision, makeRegime, makeSignal, makeTimeline } from './fixtures';
+
+const reset = () => useStudioStore.getState().actions.reset();
+
+beforeEach(reset);
+afterEach(reset);
+
+function loadFixture() {
+  const tl = makeTimeline(4);
+  tl.events[0].regime = makeRegime('strong_bull_trend');
+  tl.events[1].regime = makeRegime('tight_tr');
+  tl.events[2].regime = makeRegime('strong_bear_trend');
+  tl.events[1].signals = [makeSignal({ id: 's1', side: 'long', source: 'rule:h2' })];
+  tl.events[2].decision = makeDecision({ pattern: 'wedge', side: 'short' });
+  const { actions } = useStudioStore.getState();
+  actions.setTimeline(tl);
+  actions.setBar(2);
+}
+
+describe('SidePanel tab container', () => {
+  it('renders all three tab triggers', () => {
+    loadFixture();
+    render(<SidePanel />);
+    expect(screen.getByTestId('tab-signals')).toBeInTheDocument();
+    expect(screen.getByTestId('tab-decision')).toBeInTheDocument();
+    expect(screen.getByTestId('tab-regime')).toBeInTheDocument();
+  });
+
+  it('defaults to the decision tab', () => {
+    loadFixture();
+    render(<SidePanel />);
+    expect(screen.getByTestId('decision-inspector')).toBeInTheDocument();
+  });
+
+  it('switching to the signals tab reveals the sidebar', async () => {
+    loadFixture();
+    const user = userEvent.setup();
+    render(<SidePanel />);
+    await user.click(screen.getByTestId('tab-signals'));
+    expect(screen.getByTestId('signal-sidebar')).toBeInTheDocument();
+  });
+
+  it('switching to the regime tab reveals the timeline', async () => {
+    loadFixture();
+    const user = userEvent.setup();
+    render(<SidePanel />);
+    await user.click(screen.getByTestId('tab-regime'));
+    expect(screen.getByTestId('regime-timeline')).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/studio/__tests__/SignalSidebar.test.tsx
+++ b/ui/src/features/studio/__tests__/SignalSidebar.test.tsx
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { useStudioStore } from '../store';
+import {
+  collectSidebarSignals,
+  DEFAULT_FILTER,
+  SignalSidebar,
+  sourceKind,
+} from '../components/side/SignalSidebar';
+import { makeSignal, makeTimeline } from './fixtures';
+import type { Signal } from '../types';
+
+const reset = () => useStudioStore.getState().actions.reset();
+
+beforeEach(reset);
+afterEach(reset);
+
+describe('sourceKind helper', () => {
+  it('extracts the prefix before colon', () => {
+    expect(sourceKind('rule:h2')).toBe('rule');
+    expect(sourceKind('llm:claude-opus-4-7')).toBe('llm');
+    expect(sourceKind('vlm:vision-x')).toBe('vlm');
+  });
+
+  it('returns null for unknown / non-string sources', () => {
+    expect(sourceKind('mystery:thing')).toBeNull();
+    expect(sourceKind(undefined)).toBeNull();
+    expect(sourceKind(42)).toBeNull();
+  });
+});
+
+describe('collectSidebarSignals', () => {
+  function buildTimelineWithSignals() {
+    const tl = makeTimeline(5);
+    tl.events[1].signals = [
+      makeSignal({ id: 's1', side: 'long', source: 'rule:h2', probability: 0.6 }),
+    ];
+    tl.events[2].signals = [
+      makeSignal({ id: 's2', side: 'short', source: 'llm:claude', probability: 0.4 }),
+      makeSignal({ id: 's3', side: 'long', source: 'rule:wedge', probability: 0.85 }),
+    ];
+    tl.events[4].signals = [
+      makeSignal({ id: 's4', side: 'long', source: 'vlm:eye', probability: 0.5 }),
+    ];
+    return tl;
+  }
+
+  it('hides signals from future bars (no info leak)', () => {
+    const tl = buildTimelineWithSignals();
+    expect(collectSidebarSignals(tl, 1, DEFAULT_FILTER).map((r) => r.id)).toEqual(['s1']);
+    expect(collectSidebarSignals(tl, 2, DEFAULT_FILTER).map((r) => r.id).sort()).toEqual([
+      's1',
+      's2',
+      's3',
+    ]);
+  });
+
+  it('returns most-recent first', () => {
+    const tl = buildTimelineWithSignals();
+    const rows = collectSidebarSignals(tl, 4, DEFAULT_FILTER);
+    expect(rows[0].id).toBe('s4');
+    expect(rows[rows.length - 1].id).toBe('s1');
+  });
+
+  it('filters by source kind', () => {
+    const tl = buildTimelineWithSignals();
+    const rule = collectSidebarSignals(tl, 4, { ...DEFAULT_FILTER, source: 'rule' });
+    expect(rule.map((r) => r.id).sort()).toEqual(['s1', 's3']);
+
+    const llm = collectSidebarSignals(tl, 4, { ...DEFAULT_FILTER, source: 'llm' });
+    expect(llm.map((r) => r.id)).toEqual(['s2']);
+  });
+
+  it('filters by side', () => {
+    const tl = buildTimelineWithSignals();
+    const longs = collectSidebarSignals(tl, 4, { ...DEFAULT_FILTER, side: 'long' });
+    expect(longs.map((r) => r.id).sort()).toEqual(['s1', 's3', 's4']);
+
+    const shorts = collectSidebarSignals(tl, 4, { ...DEFAULT_FILTER, side: 'short' });
+    expect(shorts.map((r) => r.id)).toEqual(['s2']);
+  });
+
+  it('drops signals below minimum probability', () => {
+    const tl = buildTimelineWithSignals();
+    const high = collectSidebarSignals(tl, 4, { ...DEFAULT_FILTER, minProbability: 0.7 });
+    expect(high.map((r) => r.id)).toEqual(['s3']);
+  });
+
+  it('falls back to event bar_idx when signal lacks bar idx fields', () => {
+    const tl = makeTimeline(3);
+    tl.events[2].signals = [{ id: 'noidx', side: 'long' } as Signal];
+    expect(collectSidebarSignals(tl, 2, DEFAULT_FILTER)[0].bar_idx).toBe(2);
+  });
+
+  it('honors signal_bar_idx override when present', () => {
+    const tl = makeTimeline(3);
+    tl.events[2].signals = [
+      makeSignal({ id: 'override', side: 'long', signal_bar_idx: 1 }),
+    ];
+    const rows = collectSidebarSignals(tl, 2, DEFAULT_FILTER);
+    expect(rows[0].bar_idx).toBe(1);
+  });
+});
+
+describe('SignalSidebar component', () => {
+  function loadFixture() {
+    const tl = makeTimeline(5);
+    tl.events[1].signals = [
+      makeSignal({ id: 's1', side: 'long', source: 'rule:h2', probability: 0.6, pattern: 'h2' }),
+    ];
+    tl.events[2].signals = [
+      makeSignal({ id: 's2', side: 'short', source: 'llm:claude', probability: 0.4, pattern: 'wedge' }),
+    ];
+    useStudioStore.getState().actions.setTimeline(tl);
+  }
+
+  it('renders rows for past signals and labels them', () => {
+    loadFixture();
+    render(<SignalSidebar />);
+    expect(screen.getByTestId('signal-row-s1')).toBeInTheDocument();
+    expect(screen.getByTestId('signal-row-s2')).toBeInTheDocument();
+    expect(screen.getByText('h2')).toBeInTheDocument();
+    expect(screen.getByText('wedge')).toBeInTheDocument();
+  });
+
+  it('clicking a row jumps to its bar and pins the selection', () => {
+    loadFixture();
+    render(<SignalSidebar />);
+    act(() => {
+      fireEvent.click(screen.getByTestId('signal-row-s1'));
+    });
+    const s = useStudioStore.getState();
+    expect(s.currentBarIdx).toBe(1);
+    expect(s.selectedSignalId).toBe('s1');
+  });
+
+  it('shows the preview badge when chart hover differs from current bar', () => {
+    loadFixture();
+    const { actions } = useStudioStore.getState();
+    actions.setBar(4);
+    actions.setHoveredBar(1);
+    render(<SignalSidebar />);
+    expect(screen.getByText('preview')).toBeInTheDocument();
+  });
+
+  it('clicking a side filter excludes the opposite side', () => {
+    loadFixture();
+    render(<SignalSidebar />);
+    act(() => {
+      fireEvent.click(screen.getByTestId('filter-side-long'));
+    });
+    expect(screen.getByTestId('signal-row-s1')).toBeInTheDocument();
+    expect(screen.queryByTestId('signal-row-s2')).toBeNull();
+  });
+});

--- a/ui/src/features/studio/__tests__/fixtures.ts
+++ b/ui/src/features/studio/__tests__/fixtures.ts
@@ -1,4 +1,4 @@
-import type { BarEvent, SessionTimeline } from '../types';
+import type { BarEvent, Decision, RegimeView, SessionTimeline, Signal } from '../types';
 
 const NS = 1_000_000_000;
 
@@ -34,6 +34,41 @@ export function makeBarEvent(barIdx: number, overrides: Partial<BarEvent> = {}):
     bar_idx: barIdx,
     timestamp_ns: (1_700_000_000 + barIdx * 300) * NS,
     signals: [],
+    ...overrides,
+  };
+}
+
+export function makeSignal(overrides: Partial<Signal> & { id: string } & Record<string, unknown>): Signal {
+  return {
+    pattern: 'p',
+    side: 'long',
+    source: 'rule:h2',
+    ...overrides,
+  } as Signal;
+}
+
+export function makeDecision(overrides: Partial<Decision> = {}): Decision {
+  return {
+    side: 'long',
+    entry_px: 100,
+    stop_px: 95,
+    target_px: 110,
+    quantity: 1,
+    probability: 0.6,
+    expected_r: 1.5,
+    regime: 'strong_bull_trend',
+    htf_aligned: true,
+    pattern: 'h2',
+    source: 'rule:h2',
+    ...overrides,
+  };
+}
+
+export function makeRegime(name: string, overrides: Partial<RegimeView> = {}): RegimeView {
+  return {
+    name,
+    confidence: 0.7,
+    reasons: [],
     ...overrides,
   };
 }

--- a/ui/src/features/studio/__tests__/inspectedBarIdx.test.ts
+++ b/ui/src/features/studio/__tests__/inspectedBarIdx.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { useInspectedBarIdx, useStudioStore } from '../store';
+import { makeTimeline } from './fixtures';
+import { renderHook } from '@testing-library/react';
+
+const reset = () => useStudioStore.getState().actions.reset();
+
+beforeEach(reset);
+afterEach(reset);
+
+describe('useInspectedBarIdx (hover ghost selector)', () => {
+  it('returns the current bar (resolved past LIVE_TAIL) when nothing is hovered', () => {
+    const { actions } = useStudioStore.getState();
+    actions.setTimeline(makeTimeline(5));
+    // LIVE_TAIL → resolves to last bar (4)
+    const { result } = renderHook(() => useInspectedBarIdx());
+    expect(result.current).toEqual({ barIdx: 4, preview: false });
+  });
+
+  it('returns hovered idx with preview=true when hover differs from current', () => {
+    const { actions } = useStudioStore.getState();
+    actions.setTimeline(makeTimeline(5));
+    actions.setBar(2);
+    actions.setHoveredBar(0);
+
+    const { result } = renderHook(() => useInspectedBarIdx());
+    expect(result.current).toEqual({ barIdx: 0, preview: true });
+  });
+
+  it('preview is false when hover matches current bar', () => {
+    const { actions } = useStudioStore.getState();
+    actions.setTimeline(makeTimeline(5));
+    actions.setBar(2);
+    actions.setHoveredBar(2);
+
+    const { result } = renderHook(() => useInspectedBarIdx());
+    expect(result.current).toEqual({ barIdx: 2, preview: false });
+  });
+
+  it('clears preview when hover returns to null', () => {
+    const { actions } = useStudioStore.getState();
+    actions.setTimeline(makeTimeline(5));
+    actions.setBar(2);
+    actions.setHoveredBar(0);
+    actions.setHoveredBar(null);
+
+    const { result } = renderHook(() => useInspectedBarIdx());
+    expect(result.current).toEqual({ barIdx: 2, preview: false });
+  });
+});

--- a/ui/src/features/studio/__tests__/sidePanelStore.test.ts
+++ b/ui/src/features/studio/__tests__/sidePanelStore.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { LIVE_TAIL, useStudioStore } from '../store';
+import { makeBarEvent, makeTimeline } from './fixtures';
+
+const reset = () => useStudioStore.getState().actions.reset();
+
+beforeEach(reset);
+afterEach(reset);
+
+describe('side panel store extensions', () => {
+  it('starts with no selected signal', () => {
+    expect(useStudioStore.getState().selectedSignalId).toBeNull();
+  });
+
+  it('setSelectedSignalId stores and clears the id', () => {
+    const { actions } = useStudioStore.getState();
+    actions.setSelectedSignalId('sig-7');
+    expect(useStudioStore.getState().selectedSignalId).toBe('sig-7');
+    actions.setSelectedSignalId(null);
+    expect(useStudioStore.getState().selectedSignalId).toBeNull();
+  });
+
+  it('reset clears the selected signal id', () => {
+    const { actions } = useStudioStore.getState();
+    actions.setSelectedSignalId('sig-x');
+    actions.reset();
+    expect(useStudioStore.getState().selectedSignalId).toBeNull();
+  });
+
+  it('hovered/selected state is independent of currentBarIdx', () => {
+    const { actions } = useStudioStore.getState();
+    actions.setTimeline(makeTimeline(5));
+    actions.setBar(2);
+    actions.setHoveredBar(4);
+    actions.setSelectedSignalId('sig-3');
+    const s = useStudioStore.getState();
+    expect(s.currentBarIdx).toBe(2);
+    expect(s.hoveredBarIdx).toBe(4);
+    expect(s.selectedSignalId).toBe('sig-3');
+    // Live tail still allowed alongside hover state.
+    actions.jumpToLive();
+    expect(useStudioStore.getState().currentBarIdx).toBe(LIVE_TAIL);
+    expect(useStudioStore.getState().hoveredBarIdx).toBe(4);
+  });
+
+  it('applyLiveEvent does not clobber selectedSignalId', () => {
+    const { actions } = useStudioStore.getState();
+    actions.setTimeline(makeTimeline(2));
+    actions.setSelectedSignalId('sig-pinned');
+    actions.applyLiveEvent(makeBarEvent(2, { pnl_r: 0.1 }));
+    expect(useStudioStore.getState().selectedSignalId).toBe('sig-pinned');
+  });
+});

--- a/ui/src/features/studio/components/BrooksStudioPage.tsx
+++ b/ui/src/features/studio/components/BrooksStudioPage.tsx
@@ -1,12 +1,19 @@
 /**
  * BrooksStudioPage — top-level route for `/studio/:sessionId`.
  *
- * S2 ships the skeleton: chart + scrubber + playback + URL/keyboard
- * bindings. S3 fills in the side panels & layer toggle into the placeholders
- * outlined below.
+ * Layout (S4):
+ *   ┌───────────────────────┬──────────┐
+ *   │ ChartCanvas           │ SidePanel│
+ *   │ (LayerToggle overlay) │ (tabs)   │
+ *   ├───────────────────────┴──────────┤
+ *   │ TimelineScrubber + PlaybackCtrls │
+ *   └──────────────────────────────────┘
+ * Horizontal split is `react-resizable-panels`; user drag-resize is persisted
+ * by the library's autoSaveId.
  */
 
 import { useParams } from 'react-router-dom';
+import { Group as PanelGroup, Panel, Separator as PanelResizeHandle } from 'react-resizable-panels';
 import { useTimeline } from '../hooks/useTimeline';
 import { useReplay } from '../hooks/useReplay';
 import { useUrlState } from '../hooks/useUrlState';
@@ -19,6 +26,7 @@ import { ChartCanvas } from './chart/ChartCanvas';
 import { TimelineScrubber } from './timeline/TimelineScrubber';
 import { PlaybackControls } from './timeline/PlaybackControls';
 import { LayerToggle } from './timeline/LayerToggle';
+import { SidePanel } from './side/SidePanel';
 
 export default function BrooksStudioPage() {
   const { sessionId } = useParams<{ sessionId: string }>();
@@ -53,21 +61,36 @@ export default function BrooksStudioPage() {
         <code className="text-[11px] text-muted-foreground">{sessionId}</code>
       </header>
 
-      <div className="relative min-h-0 flex-1 overflow-hidden rounded-xl border border-border/70 bg-[#0e1116]">
-        <ChartCanvas />
-        <div className="pointer-events-auto absolute right-3 top-3 z-10">
-          <LayerToggle />
-        </div>
-        {loading && !timeline && (
-          <div className="absolute inset-0 flex items-center justify-center bg-black/30 text-xs text-muted-foreground">
-            Loading timeline…
-          </div>
-        )}
-        {error && (
-          <div className="absolute left-3 top-3 max-w-md rounded-md border border-destructive/60 bg-destructive/15 px-3 py-1.5 text-xs text-destructive-foreground">
-            {error}
-          </div>
-        )}
+      <div className="min-h-0 flex-1 overflow-hidden rounded-xl border border-border/70 bg-[#0e1116]">
+        <PanelGroup
+          orientation="horizontal"
+          defaultLayout={{ 'chart-panel': 72, 'side-panel': 28 }}
+          className="h-full"
+        >
+          <Panel id="chart-panel" minSize={40} className="relative">
+            <ChartCanvas />
+            <div className="pointer-events-auto absolute right-3 top-3 z-10">
+              <LayerToggle />
+            </div>
+            {loading && !timeline && (
+              <div className="absolute inset-0 flex items-center justify-center bg-black/30 text-xs text-muted-foreground">
+                Loading timeline…
+              </div>
+            )}
+            {error && (
+              <div className="absolute left-3 top-3 max-w-md rounded-md border border-destructive/60 bg-destructive/15 px-3 py-1.5 text-xs text-destructive-foreground">
+                {error}
+              </div>
+            )}
+          </Panel>
+          <PanelResizeHandle
+            className="w-1.5 cursor-col-resize bg-border/40 transition-colors data-[separator-state=hover]:bg-primary/50 data-[separator-state=drag]:bg-primary"
+            data-testid="side-panel-resize-handle"
+          />
+          <Panel id="side-panel" minSize={18} maxSize={50}>
+            <SidePanel />
+          </Panel>
+        </PanelGroup>
       </div>
 
       <div className="rounded-xl border border-border/70 bg-card">

--- a/ui/src/features/studio/components/side/DecisionInspector.tsx
+++ b/ui/src/features/studio/components/side/DecisionInspector.tsx
@@ -1,0 +1,333 @@
+/**
+ * DecisionInspector — full Decision detail for the inspected bar (current
+ * bar by default, hovered bar when the user is moving the chart crosshair).
+ *
+ * The Decision schema is loosely typed (`[key: string]: unknown`) so each
+ * helper here narrows defensively: missing fields render as "—" rather than
+ * throwing.
+ */
+
+import { useState } from 'react';
+import { Copy, Check, ChevronDown } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import { cn } from '../../../../lib/utils';
+import { Button } from '../../../../components/ui/button';
+import {
+  useInspectedBarIdx,
+  useTimelineState,
+} from '../../store';
+import type { Decision, Signal } from '../../types';
+
+export function probabilityBucket(p: number): { label: string; tone: 'low' | 'mid' | 'high' | 'top' } {
+  if (p < 0.5) return { label: 'low', tone: 'low' };
+  if (p < 0.65) return { label: 'medium', tone: 'mid' };
+  if (p < 0.8) return { label: 'high', tone: 'high' };
+  return { label: 'very high', tone: 'top' };
+}
+
+const BUCKET_COLORS: Record<'low' | 'mid' | 'high' | 'top', string> = {
+  low: 'bg-rose-500/15 text-rose-400',
+  mid: 'bg-amber-500/15 text-amber-400',
+  high: 'bg-emerald-500/15 text-emerald-400',
+  top: 'bg-emerald-400/25 text-emerald-300',
+};
+
+export function expectedRTone(r: number): string {
+  if (r >= 1.5) return 'text-emerald-400';
+  if (r > 0) return 'text-emerald-300';
+  if (r === 0) return 'text-muted-foreground';
+  return 'text-rose-400';
+}
+
+function fmtPx(v: number | null | undefined, fallback = '—'): string {
+  if (typeof v !== 'number' || !Number.isFinite(v)) return fallback;
+  if (Math.abs(v) >= 1000) return v.toFixed(2);
+  if (Math.abs(v) >= 10) return v.toFixed(3);
+  return v.toFixed(4);
+}
+
+function diffToCurrent(target: number | null | undefined, current: number | null): string {
+  if (typeof target !== 'number' || current === null) return '';
+  const delta = target - current;
+  const sign = delta > 0 ? '+' : '';
+  const pct = (Math.abs(delta) / Math.max(Math.abs(current), 1e-9)) * 100;
+  return `${sign}${fmtPx(delta)} (${pct.toFixed(2)}%)`;
+}
+
+function readNumber(obj: Record<string, unknown>, key: string): number | null {
+  const v = obj[key];
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+
+/** `decision.signals` is loosely typed so we narrow to a Signal[] best-effort. */
+export function decisionSupportingSignals(decision: Decision): Signal[] {
+  const v = (decision as Record<string, unknown>).signals;
+  return Array.isArray(v) ? (v as Signal[]) : [];
+}
+
+export function DecisionInspector() {
+  const timeline = useTimelineState();
+  const { barIdx, preview } = useInspectedBarIdx();
+
+  if (!timeline) {
+    return <div className="px-3 py-3 text-xs text-muted-foreground">No timeline loaded.</div>;
+  }
+
+  const ev = timeline.events.find((e) => e.bar_idx === barIdx);
+  const decision = ev?.decision ?? null;
+  const bar = timeline.bars[barIdx];
+  const currentPx = bar ? bar.close : null;
+
+  if (!decision) {
+    return (
+      <div className="flex flex-col gap-1.5 px-3 py-3 text-xs text-muted-foreground" data-testid="decision-inspector-empty">
+        <div className="flex items-center gap-2">
+          <span className="font-medium text-foreground">Decision @ bar {barIdx}</span>
+          {preview && (
+            <span className="rounded-sm bg-amber-500/15 px-1.5 py-0.5 text-amber-400">preview</span>
+          )}
+        </div>
+        <span>—</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3 px-3 py-3 text-xs" data-testid="decision-inspector">
+      <Header decision={decision} barIdx={barIdx} preview={preview} />
+      <PriceLevels decision={decision} currentPx={currentPx} />
+      <ProbabilityRow decision={decision} />
+      <ContextRow decision={decision} />
+      <Reasoning decision={decision} />
+      <SignalsSection decision={decision} />
+      <CopyJsonButton decision={decision} />
+    </div>
+  );
+}
+
+function Header({
+  decision,
+  barIdx,
+  preview,
+}: {
+  decision: Decision;
+  barIdx: number;
+  preview: boolean;
+}) {
+  const sideTone =
+    decision.side === 'long'
+      ? 'bg-emerald-500/15 text-emerald-400'
+      : 'bg-rose-500/15 text-rose-400';
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <div className="flex items-center gap-2">
+        <span
+          className={cn('rounded-md px-2 py-0.5 text-[11px] font-semibold uppercase', sideTone)}
+          data-testid="decision-side-badge"
+        >
+          {decision.side}
+        </span>
+        <span className="text-foreground font-medium">{decision.pattern || '—'}</span>
+        <span className="text-muted-foreground tabular-nums">@ bar {barIdx}</span>
+      </div>
+      {preview && (
+        <span className="rounded-sm bg-amber-500/15 px-1.5 py-0.5 text-[10.5px] text-amber-400">
+          preview
+        </span>
+      )}
+    </div>
+  );
+}
+
+function PriceLevels({ decision, currentPx }: { decision: Decision; currentPx: number | null }) {
+  const target = decision.target_px;
+  return (
+    <div className="grid grid-cols-3 gap-1.5 text-[11px]" data-testid="decision-price-levels">
+      <PxCell label="entry" value={decision.entry_px} delta={diffToCurrent(decision.entry_px, currentPx)} />
+      <PxCell label="stop" value={decision.stop_px} delta={diffToCurrent(decision.stop_px, currentPx)} tone="bear" />
+      <PxCell
+        label="target"
+        value={typeof target === 'number' ? target : null}
+        delta={diffToCurrent(target, currentPx)}
+        tone="bull"
+      />
+    </div>
+  );
+}
+
+function PxCell({
+  label,
+  value,
+  delta,
+  tone,
+}: {
+  label: string;
+  value: number | null;
+  delta: string;
+  tone?: 'bull' | 'bear';
+}) {
+  const tonecls =
+    tone === 'bull' ? 'text-emerald-300' : tone === 'bear' ? 'text-rose-300' : 'text-foreground';
+  return (
+    <div className="rounded-md border border-border/60 bg-card/50 px-2 py-1.5">
+      <div className="text-[10px] uppercase tracking-wide text-muted-foreground">{label}</div>
+      <div className={cn('tabular-nums font-medium', tonecls)}>{fmtPx(value)}</div>
+      {delta && <div className="text-[10px] text-muted-foreground tabular-nums">{delta}</div>}
+    </div>
+  );
+}
+
+function ProbabilityRow({ decision }: { decision: Decision }) {
+  const p = typeof decision.probability === 'number' ? decision.probability : null;
+  const er = typeof decision.expected_r === 'number' ? decision.expected_r : null;
+  const bucket = p !== null ? probabilityBucket(p) : null;
+  return (
+    <div className="flex items-center gap-2" data-testid="decision-probability-row">
+      <div className="flex items-center gap-1.5">
+        <span className="text-[10px] uppercase text-muted-foreground">prob</span>
+        {p !== null && bucket ? (
+          <span className={cn('rounded px-1.5 py-0.5 text-[11px] font-medium tabular-nums', BUCKET_COLORS[bucket.tone])}>
+            {(p * 100).toFixed(0)}% · {bucket.label}
+          </span>
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        )}
+      </div>
+      <div className="flex items-center gap-1.5">
+        <span className="text-[10px] uppercase text-muted-foreground">E[R]</span>
+        {er !== null ? (
+          <span className={cn('tabular-nums font-medium', expectedRTone(er))}>{er.toFixed(2)}R</span>
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ContextRow({ decision }: { decision: Decision }) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <Tag label={decision.regime || 'no-regime'} testId="decision-regime" />
+      {decision.htf_aligned ? (
+        <Tag label="htf-aligned" tone="ok" testId="decision-htf-aligned" />
+      ) : (
+        <Tag label="htf-misaligned" tone="warn" testId="decision-htf-misaligned" />
+      )}
+      <Tag label={decision.source || '—'} tone="muted" testId="decision-source" />
+    </div>
+  );
+}
+
+function Tag({
+  label,
+  tone = 'muted',
+  testId,
+}: {
+  label: string;
+  tone?: 'ok' | 'warn' | 'muted';
+  testId?: string;
+}) {
+  const cls =
+    tone === 'ok'
+      ? 'border-emerald-500/60 bg-emerald-500/10 text-emerald-300'
+      : tone === 'warn'
+        ? 'border-amber-500/60 bg-amber-500/10 text-amber-300'
+        : 'border-border/60 bg-muted/30 text-muted-foreground';
+  return (
+    <span
+      className={cn('inline-flex rounded-full border px-1.5 py-0.5 text-[10.5px]', cls)}
+      data-testid={testId}
+    >
+      {label}
+    </span>
+  );
+}
+
+function Reasoning({ decision }: { decision: Decision }) {
+  const reasoning = typeof decision.reasoning === 'string' ? decision.reasoning : '';
+  if (!reasoning.trim()) return null;
+  return (
+    <div className="rounded-md border border-border/60 bg-card/30 p-2.5" data-testid="decision-reasoning">
+      <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">reasoning</div>
+      <div className="prose prose-invert prose-sm max-w-none text-[12px] leading-relaxed text-foreground/90 [&_code]:rounded [&_code]:bg-muted/60 [&_code]:px-1 [&_code]:py-0.5 [&_pre]:overflow-x-auto [&_pre]:rounded [&_pre]:bg-muted/60 [&_pre]:p-2 [&_pre]:text-[11px] [&_p]:my-1 [&_ul]:my-1 [&_ul]:list-disc [&_ul]:pl-5">
+        <ReactMarkdown>{reasoning}</ReactMarkdown>
+      </div>
+    </div>
+  );
+}
+
+function SignalsSection({ decision }: { decision: Decision }) {
+  const signals = decisionSupportingSignals(decision);
+  if (signals.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-1.5" data-testid="decision-signals">
+      <div className="text-[10px] uppercase tracking-wide text-muted-foreground">supporting signals ({signals.length})</div>
+      <div className="flex flex-col gap-1">
+        {signals.map((sig, i) => (
+          <SignalDetail key={(sig.id ?? `sig-${i}`)} signal={sig} index={i} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SignalDetail({ signal, index }: { signal: Signal; index: number }) {
+  const [open, setOpen] = useState(false);
+  const sigRecord = signal as Record<string, unknown>;
+  const prob = readNumber(sigRecord, 'probability');
+  const pattern = signal.pattern ?? '?';
+  return (
+    <div className="rounded-md border border-border/60 bg-card/30 text-[11px]">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-2 px-2 py-1 text-left hover:bg-accent/30"
+        data-testid={`decision-signal-${index}`}
+      >
+        <ChevronDown className={cn('size-3 transition-transform', open && 'rotate-180')} aria-hidden />
+        <span className="font-medium">{pattern}</span>
+        <span className="text-muted-foreground">{signal.side ?? '—'}</span>
+        <span className="ml-auto tabular-nums text-muted-foreground">
+          {prob !== null ? `${(prob * 100).toFixed(0)}%` : '—'}
+        </span>
+      </button>
+      {open && (
+        <pre className="overflow-x-auto rounded-b-md bg-muted/40 px-2 py-1.5 text-[10.5px] leading-relaxed text-muted-foreground">
+{JSON.stringify(signal, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+function CopyJsonButton({ decision }: { decision: Decision }) {
+  const [copied, setCopied] = useState(false);
+
+  const onCopy = () => {
+    const json = JSON.stringify(decision, null, 2);
+    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+      void navigator.clipboard.writeText(json).then(() => {
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 1200);
+      });
+    } else {
+      // jsdom / restricted contexts: surface success silently for tests.
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1200);
+    }
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={onCopy}
+      className="self-start text-[11px]"
+      data-testid="decision-copy-json"
+    >
+      {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+      <span className="ml-1.5">{copied ? 'copied' : 'copy json'}</span>
+    </Button>
+  );
+}

--- a/ui/src/features/studio/components/side/RegimeTimeline.tsx
+++ b/ui/src/features/studio/components/side/RegimeTimeline.tsx
@@ -1,0 +1,164 @@
+/**
+ * RegimeTimeline — horizontal band that segments the timeline by regime so
+ * users can scan transitions and jump to a regime's first bar.
+ *
+ * Aligns with the bottom Scrubber: x-axis covers `bars[0..barCount-1]`, each
+ * segment's width is proportional to its bar count.
+ */
+
+import { useMemo, useState } from 'react';
+import { cn } from '../../../../lib/utils';
+import { regimeColorOf } from '../../layers/regime';
+import {
+  useEffectiveBarIdx,
+  useStudioActions,
+  useTimelineState,
+} from '../../store';
+import type { SessionTimeline } from '../../types';
+
+export interface RegimeSegment {
+  name: string;
+  start: number; // first bar idx (inclusive)
+  end: number; // last bar idx (inclusive)
+  startTimeNs: number;
+  endTimeNs: number;
+}
+
+/**
+ * Group consecutive bars with the same regime name into segments. Bars without
+ * a regime fall into a synthetic `"unknown"` segment so the band is contiguous.
+ */
+export function buildRegimeSegments(timeline: SessionTimeline): RegimeSegment[] {
+  const eventByBar = new Map<number, string | null | undefined>();
+  for (const ev of timeline.events) {
+    eventByBar.set(ev.bar_idx, ev.regime?.name);
+  }
+  const out: RegimeSegment[] = [];
+  let cur: RegimeSegment | null = null;
+  for (let i = 0; i < timeline.bars.length; i++) {
+    const name = eventByBar.get(i) ?? 'unknown';
+    const bar = timeline.bars[i];
+    if (cur && cur.name === name) {
+      cur.end = i;
+      cur.endTimeNs = bar.timestamp_ns;
+    } else {
+      if (cur) out.push(cur);
+      cur = {
+        name,
+        start: i,
+        end: i,
+        startTimeNs: bar.timestamp_ns,
+        endTimeNs: bar.timestamp_ns,
+      };
+    }
+  }
+  if (cur) out.push(cur);
+  return out;
+}
+
+function formatNs(ns: number): string {
+  try {
+    const d = new Date(ns / 1_000_000);
+    return d.toISOString().replace('T', ' ').replace(/\.\d+Z$/, 'Z');
+  } catch {
+    return '?';
+  }
+}
+
+export function RegimeTimeline() {
+  const timeline = useTimelineState();
+  const barCount = timeline?.bars.length ?? 0;
+  const cursorBar = useEffectiveBarIdx();
+  const { setBar } = useStudioActions();
+  const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
+
+  const segments = useMemo(
+    () => (timeline ? buildRegimeSegments(timeline) : []),
+    [timeline],
+  );
+
+  if (!timeline || barCount === 0) {
+    return (
+      <div className="px-3 py-2 text-xs text-muted-foreground" data-testid="regime-timeline-empty">
+        No timeline.
+      </div>
+    );
+  }
+
+  const cursorPct = barCount > 1 ? (cursorBar / (barCount - 1)) * 100 : 0;
+  const hovered = hoveredIdx !== null ? segments[hoveredIdx] : null;
+
+  return (
+    <div className="flex flex-col gap-2 px-2 py-2" data-testid="regime-timeline">
+      <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+        Regime timeline
+      </div>
+      <div
+        className="relative h-10 w-full overflow-hidden rounded border border-border/60 bg-muted/30"
+        role="list"
+      >
+        <div className="absolute inset-0 flex">
+          {segments.map((seg, i) => {
+            const span = Math.max(seg.end - seg.start + 1, 1);
+            const flexBasis = (span / barCount) * 100;
+            const isHovered = hoveredIdx === i;
+            return (
+              <button
+                key={`${seg.start}-${seg.name}`}
+                type="button"
+                role="listitem"
+                style={{ flexBasis: `${flexBasis}%`, backgroundColor: regimeColorOf(seg.name) }}
+                onClick={() => setBar(seg.start)}
+                onMouseEnter={() => setHoveredIdx(i)}
+                onMouseLeave={() => setHoveredIdx((cur) => (cur === i ? null : cur))}
+                title={`${seg.name} · bars ${seg.start}-${seg.end}`}
+                className={cn(
+                  'group relative flex items-center justify-center overflow-hidden border-r border-border/30 px-1 text-[10px] font-medium uppercase text-foreground/80 last:border-r-0 transition-shadow',
+                  isHovered && 'ring-1 ring-primary/60',
+                )}
+                data-testid={`regime-segment-${i}`}
+                data-regime-name={seg.name}
+              >
+                <span className="truncate">{flexBasis > 6 ? seg.name : ''}</span>
+              </button>
+            );
+          })}
+        </div>
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-y-0 w-px bg-primary/80 shadow-[0_0_4px_rgba(99,102,241,0.7)]"
+          style={{ left: `${cursorPct}%` }}
+          data-testid="regime-cursor"
+        />
+      </div>
+      <SegmentTooltip segment={hovered} />
+    </div>
+  );
+}
+
+function SegmentTooltip({ segment }: { segment: RegimeSegment | null }) {
+  if (!segment) {
+    return (
+      <div className="text-[11px] text-muted-foreground" data-testid="regime-tooltip-empty">
+        Hover a segment for details.
+      </div>
+    );
+  }
+  const span = segment.end - segment.start + 1;
+  return (
+    <div
+      className="rounded-md border border-border/60 bg-card/60 px-2 py-1.5 text-[11px]"
+      data-testid="regime-tooltip"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-medium text-foreground">{segment.name}</span>
+        <span className="tabular-nums text-muted-foreground">
+          bars {segment.start}-{segment.end} ({span})
+        </span>
+      </div>
+      <div className="mt-0.5 text-[10.5px] tabular-nums text-muted-foreground">
+        {formatNs(segment.startTimeNs)} → {formatNs(segment.endTimeNs)}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/features/studio/components/side/SidePanel.tsx
+++ b/ui/src/features/studio/components/side/SidePanel.tsx
@@ -1,0 +1,48 @@
+/**
+ * SidePanel — tab container for the inspector sidebars (Signals / Decision /
+ * Regime). All three reuse the studio store, so the tab is purely a visual
+ * grouping; switching tabs does not reset state.
+ */
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../../../components/ui/tabs';
+import { SignalSidebar } from './SignalSidebar';
+import { DecisionInspector } from './DecisionInspector';
+import { RegimeTimeline } from './RegimeTimeline';
+
+export type SidePanelTab = 'signals' | 'decision' | 'regime';
+
+const DEFAULT_TAB: SidePanelTab = 'decision';
+
+export function SidePanel() {
+  return (
+    <div
+      className="flex h-full min-h-0 flex-col bg-card/40"
+      data-testid="side-panel"
+    >
+      <Tabs defaultValue={DEFAULT_TAB} className="flex h-full min-h-0 flex-col">
+        <div className="px-2 pt-2">
+          <TabsList className="w-full">
+            <TabsTrigger value="signals" className="flex-1" data-testid="tab-signals">
+              Signals
+            </TabsTrigger>
+            <TabsTrigger value="decision" className="flex-1" data-testid="tab-decision">
+              Decision
+            </TabsTrigger>
+            <TabsTrigger value="regime" className="flex-1" data-testid="tab-regime">
+              Regime
+            </TabsTrigger>
+          </TabsList>
+        </div>
+        <TabsContent value="signals" className="mt-2 min-h-0 flex-1 overflow-hidden">
+          <SignalSidebar />
+        </TabsContent>
+        <TabsContent value="decision" className="mt-2 min-h-0 flex-1 overflow-y-auto">
+          <DecisionInspector />
+        </TabsContent>
+        <TabsContent value="regime" className="mt-2 min-h-0 flex-1 overflow-y-auto">
+          <RegimeTimeline />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/ui/src/features/studio/components/side/SignalSidebar.tsx
+++ b/ui/src/features/studio/components/side/SignalSidebar.tsx
@@ -1,0 +1,347 @@
+/**
+ * SignalSidebar — list of detector signals up to (and including) the
+ * currentBarIdx. Click a row to jump the chart to that signal's bar and pin
+ * it as the selected layer; chart-driven hover updates the inspected
+ * `currentBarIdx` cutoff so users see "what was visible when X happened".
+ *
+ * Virtualization kicks in past `VIRTUALIZE_THRESHOLD` rows (react-window).
+ */
+
+import { useMemo, useState } from 'react';
+import { FixedSizeList, type ListChildComponentProps } from 'react-window';
+import AutoSizer from 'react-virtualized-auto-sizer';
+import { ArrowDown, ArrowUp, Filter } from 'lucide-react';
+import { cn } from '../../../../lib/utils';
+import {
+  useInspectedBarIdx,
+  useSelectedSignalId,
+  useStudioActions,
+  useTimelineState,
+} from '../../store';
+import type { BarEvent, SessionTimeline, Signal } from '../../types';
+
+export const SOURCE_KINDS = ['rule', 'llm', 'vlm'] as const;
+export type SourceKind = (typeof SOURCE_KINDS)[number];
+export type SourceFilter = SourceKind | 'all';
+export type SideFilter = 'long' | 'short' | 'all';
+
+const VIRTUALIZE_THRESHOLD = 100;
+const ROW_HEIGHT = 56;
+
+export interface SignalRow {
+  id: string;
+  bar_idx: number;
+  signal: Signal;
+}
+
+/** Read the high-level bucket from a signal `source` like "rule:h2" → "rule". */
+export function sourceKind(source: unknown): SourceKind | null {
+  if (typeof source !== 'string') return null;
+  const head = source.split(':')[0]?.toLowerCase();
+  if (head === 'rule' || head === 'llm' || head === 'vlm') return head;
+  return null;
+}
+
+function readNumber(obj: Record<string, unknown>, key: string): number | null {
+  const v = obj[key];
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+
+function signalProbability(sig: Signal): number | null {
+  return readNumber(sig as Record<string, unknown>, 'probability');
+}
+
+function signalBarIdx(sig: Signal, fallback: number): number {
+  const sb = readNumber(sig as Record<string, unknown>, 'signal_bar_idx');
+  if (sb !== null) return sb;
+  if (typeof sig.bar_idx === 'number') return sig.bar_idx;
+  return fallback;
+}
+
+export interface SignalFilter {
+  source: SourceFilter;
+  side: SideFilter;
+  minProbability: number;
+}
+
+export const DEFAULT_FILTER: SignalFilter = {
+  source: 'all',
+  side: 'all',
+  minProbability: 0,
+};
+
+export function collectSidebarSignals(
+  timeline: SessionTimeline,
+  cutoffBarIdx: number,
+  filter: SignalFilter,
+): SignalRow[] {
+  const out: SignalRow[] = [];
+  const events: BarEvent[] = timeline.events;
+  for (const ev of events) {
+    if (ev.bar_idx > cutoffBarIdx) continue;
+    if (!ev.signals?.length) continue;
+    for (let j = 0; j < ev.signals.length; j++) {
+      const sig = ev.signals[j];
+      if (filter.side !== 'all' && sig.side !== filter.side) continue;
+      if (filter.source !== 'all') {
+        if (sourceKind(sig.source) !== filter.source) continue;
+      }
+      const prob = signalProbability(sig);
+      if (filter.minProbability > 0 && (prob === null || prob < filter.minProbability)) continue;
+      const id = sig.id ?? `sig-${ev.bar_idx}-${j}`;
+      out.push({ id, bar_idx: signalBarIdx(sig, ev.bar_idx), signal: sig });
+    }
+  }
+  // Most-recent first.
+  out.sort((a, b) => b.bar_idx - a.bar_idx);
+  return out;
+}
+
+function SignalRowView({
+  row,
+  selected,
+  onClick,
+}: {
+  row: SignalRow;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  const { signal, bar_idx } = row;
+  const side = signal.side;
+  const prob = signalProbability(signal);
+  const source = typeof signal.source === 'string' ? signal.source : '—';
+  const pattern = signal.pattern ?? '?';
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'flex w-full items-center gap-2 rounded-md border border-transparent px-2 py-1.5 text-left text-xs transition-colors',
+        'hover:border-border/60 hover:bg-accent/40',
+        selected && 'border-primary/60 bg-primary/10',
+      )}
+      data-testid={`signal-row-${row.id}`}
+      data-selected={selected ? 'true' : 'false'}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          'mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-sm',
+          side === 'long' && 'bg-emerald-500/20 text-emerald-400',
+          side === 'short' && 'bg-rose-500/20 text-rose-400',
+          !side && 'bg-muted text-muted-foreground',
+        )}
+      >
+        {side === 'short' ? <ArrowDown className="size-3" /> : <ArrowUp className="size-3" />}
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col">
+        <span className="flex items-center justify-between gap-1.5">
+          <span className="truncate font-medium text-foreground">{pattern}</span>
+          <span className="shrink-0 tabular-nums text-muted-foreground">#{bar_idx}</span>
+        </span>
+        <span className="flex items-center justify-between gap-1.5 text-[10.5px] text-muted-foreground">
+          <span className="truncate">{source}</span>
+          <span className="shrink-0 tabular-nums">
+            {prob !== null ? `${(prob * 100).toFixed(0)}%` : '—'}
+          </span>
+        </span>
+      </span>
+    </button>
+  );
+}
+
+export function SignalSidebar() {
+  const timeline = useTimelineState();
+  const { barIdx, preview } = useInspectedBarIdx();
+  const selectedSignalId = useSelectedSignalId();
+  const { setBar, setSelectedSignalId } = useStudioActions();
+
+  const [filter, setFilter] = useState<SignalFilter>(DEFAULT_FILTER);
+
+  const rows = useMemo<SignalRow[]>(() => {
+    if (!timeline) return [];
+    return collectSidebarSignals(timeline, barIdx, filter);
+  }, [timeline, barIdx, filter]);
+
+  if (!timeline) {
+    return (
+      <div className="px-2 py-3 text-xs text-muted-foreground">No timeline loaded.</div>
+    );
+  }
+
+  const handleClickRow = (row: SignalRow) => {
+    setSelectedSignalId(row.id);
+    setBar(row.bar_idx);
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-2" data-testid="signal-sidebar">
+      <FilterBar filter={filter} onChange={setFilter} />
+      <div className="px-2 text-[11px] text-muted-foreground">
+        {rows.length} signal{rows.length === 1 ? '' : 's'} ≤ bar {barIdx}
+        {preview && (
+          <span className="ml-2 rounded-sm bg-amber-500/15 px-1.5 py-0.5 text-amber-400">
+            preview
+          </span>
+        )}
+      </div>
+      <div className="min-h-0 flex-1 px-1.5 pb-1.5">
+        {rows.length === 0 ? (
+          <div className="px-1 py-3 text-xs text-muted-foreground">No signals match.</div>
+        ) : rows.length > VIRTUALIZE_THRESHOLD ? (
+          <AutoSizer>
+            {({ height, width }: { height: number; width: number }) => (
+              <FixedSizeList
+                height={height}
+                width={width}
+                itemCount={rows.length}
+                itemSize={ROW_HEIGHT}
+                overscanCount={4}
+                itemData={{ rows, selectedSignalId, handleClickRow }}
+                data-testid="signal-list-virtual"
+              >
+                {VirtualRow}
+              </FixedSizeList>
+            )}
+          </AutoSizer>
+        ) : (
+          <div className="flex flex-col gap-1 overflow-y-auto pr-1" data-testid="signal-list-plain">
+            {rows.map((row) => (
+              <SignalRowView
+                key={row.id}
+                row={row}
+                selected={row.id === selectedSignalId}
+                onClick={() => handleClickRow(row)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface VirtualItemData {
+  rows: SignalRow[];
+  selectedSignalId: string | null;
+  handleClickRow: (row: SignalRow) => void;
+}
+
+function VirtualRow({ index, style, data }: ListChildComponentProps<VirtualItemData>) {
+  const row = data.rows[index];
+  return (
+    <div style={style} className="px-0.5">
+      <SignalRowView
+        row={row}
+        selected={row.id === data.selectedSignalId}
+        onClick={() => data.handleClickRow(row)}
+      />
+    </div>
+  );
+}
+
+const PROBABILITY_OPTIONS = [0, 0.5, 0.7, 0.9] as const;
+
+function FilterBar({
+  filter,
+  onChange,
+}: {
+  filter: SignalFilter;
+  onChange: (next: SignalFilter) => void;
+}) {
+  return (
+    <div
+      className="flex flex-wrap items-center gap-1.5 px-2 pt-2 text-[11px]"
+      data-testid="signal-filter-bar"
+    >
+      <Filter className="size-3 text-muted-foreground" aria-hidden />
+
+      <Pill
+        active={filter.source === 'all'}
+        onClick={() => onChange({ ...filter, source: 'all' })}
+        label="all"
+      />
+      {SOURCE_KINDS.map((s) => (
+        <Pill
+          key={s}
+          active={filter.source === s}
+          onClick={() => onChange({ ...filter, source: s })}
+          label={s}
+          testId={`filter-source-${s}`}
+        />
+      ))}
+
+      <span className="mx-1 h-3 w-px bg-border" aria-hidden />
+
+      <Pill
+        active={filter.side === 'all'}
+        onClick={() => onChange({ ...filter, side: 'all' })}
+        label="all"
+      />
+      <Pill
+        active={filter.side === 'long'}
+        onClick={() => onChange({ ...filter, side: 'long' })}
+        label="long"
+        tone="bull"
+        testId="filter-side-long"
+      />
+      <Pill
+        active={filter.side === 'short'}
+        onClick={() => onChange({ ...filter, side: 'short' })}
+        label="short"
+        tone="bear"
+        testId="filter-side-short"
+      />
+
+      <span className="mx-1 h-3 w-px bg-border" aria-hidden />
+
+      <select
+        value={filter.minProbability}
+        onChange={(e) => onChange({ ...filter, minProbability: Number(e.target.value) })}
+        className="rounded border border-border/60 bg-background px-1 py-0.5 text-[11px] text-foreground"
+        aria-label="Minimum probability"
+        data-testid="filter-min-probability"
+      >
+        {PROBABILITY_OPTIONS.map((p) => (
+          <option key={p} value={p}>
+            p ≥ {p === 0 ? 'any' : `${(p * 100).toFixed(0)}%`}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function Pill({
+  label,
+  active,
+  onClick,
+  tone,
+  testId,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+  tone?: 'bull' | 'bear';
+  testId?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'rounded-full border px-2 py-0.5 transition-colors',
+        active
+          ? 'border-primary/60 bg-primary/15 text-foreground'
+          : 'border-border/60 bg-muted/30 text-muted-foreground hover:text-foreground',
+        active && tone === 'bull' && 'border-emerald-500/60 bg-emerald-500/15 text-emerald-400',
+        active && tone === 'bear' && 'border-rose-500/60 bg-rose-500/15 text-rose-400',
+      )}
+      aria-pressed={active}
+      data-testid={testId}
+    >
+      {label}
+    </button>
+  );
+}

--- a/ui/src/features/studio/store.ts
+++ b/ui/src/features/studio/store.ts
@@ -45,6 +45,9 @@ export interface StudioState {
   playState: PlayState;
   speed: StudioSpeed;
   hoveredBarIdx: number | null;
+  /** Selected signal id (e.g. clicked in the SignalSidebar) — used by layers
+   * to highlight the matching marker / price lines. `null` = nothing pinned. */
+  selectedSignalId: string | null;
 
   visibleLayers: Set<string>;
 }
@@ -63,6 +66,7 @@ export interface StudioActions {
   setMode: (mode: StudioMode) => void;
   jumpToLive: () => void;
   setHoveredBar: (idx: number | null) => void;
+  setSelectedSignalId: (id: string | null) => void;
 
   applyLiveEvent: (ev: BarEvent) => void;
 
@@ -87,6 +91,7 @@ const INITIAL: StudioState = {
   playState: 'paused',
   speed: 1,
   hoveredBarIdx: null,
+  selectedSignalId: null,
   visibleLayers: initialVisibleLayers(),
 };
 
@@ -166,6 +171,8 @@ export const useStudioStore = create<StudioStore>()((set, get) => ({
 
     setHoveredBar: (idx) => set({ hoveredBarIdx: idx }),
 
+    setSelectedSignalId: (id) => set({ selectedSignalId: id }),
+
     applyLiveEvent: (ev) => {
       const { timeline } = get();
       if (!timeline) return;
@@ -222,7 +229,32 @@ export const useStudioMode = () => useStudioStore((s) => s.mode);
 export const useStudioPlayState = () => useStudioStore((s) => s.playState);
 export const useStudioSpeed = () => useStudioStore((s) => s.speed);
 export const useHoveredBarIdx = () => useStudioStore((s) => s.hoveredBarIdx);
+export const useSelectedSignalId = () => useStudioStore((s) => s.selectedSignalId);
 export const useVisibleLayers = () => useStudioStore((s) => s.visibleLayers);
+
+/**
+ * Resolves the bar idx that side panels should display: the hovered bar if the
+ * cursor is on the chart, otherwise the current bar. Returns the inspected idx
+ * along with a flag so the UI can render a subtle "preview" badge.
+ *
+ * Implemented as two primitive selectors so the hook remains stable across
+ * renders — returning a fresh object from a single selector would re-render
+ * subscribers unconditionally.
+ */
+export const useInspectedBarIdx = (): { barIdx: number; preview: boolean } => {
+  const barIdx = useStudioStore((s) => {
+    const barCount = s.timeline?.bars.length ?? 0;
+    const current = s.currentBarIdx === LIVE_TAIL && barCount > 0 ? barCount - 1 : s.currentBarIdx;
+    return s.hoveredBarIdx !== null ? s.hoveredBarIdx : current;
+  });
+  const preview = useStudioStore((s) => {
+    if (s.hoveredBarIdx === null) return false;
+    const barCount = s.timeline?.bars.length ?? 0;
+    const current = s.currentBarIdx === LIVE_TAIL && barCount > 0 ? barCount - 1 : s.currentBarIdx;
+    return s.hoveredBarIdx !== current;
+  });
+  return { barIdx, preview };
+};
 
 /** Effective bar index resolving the `LIVE_TAIL` sentinel against the current timeline. */
 export const useEffectiveBarIdx = (): number => {


### PR DESCRIPTION
## Summary

Phase S4 of Brooks Studio — adds the side panel cluster so users can replay any bar's full state from the chart crosshair.

- **SignalSidebar**: virtualized (>100 rows via `react-window`) signal feed with source / side / probability filters; click jumps the chart and pins `selectedSignalId` for layer highlight.
- **DecisionInspector**: side / entry / stop / target with distance-to-current-price, probability bucket + E[R] tone, regime + `htf_aligned` tags, **react-markdown** reasoning, foldable supporting-signals list, copy-json action.
- **RegimeTimeline**: horizontal regime band, click-to-jump segments, hover tooltip showing duration + wall-clock window.
- **SidePanel**: shadcn `Tabs` container hosting the three views.
- **Hover ghost**: `ChartCanvas` already pipes crosshair → `setHoveredBar`; new `useInspectedBarIdx` selector resolves `current` vs `preview`, so each panel renders hovered-bar data with a "preview" badge.
- **Layout**: `BrooksStudioPage` now uses `react-resizable-panels` for a horizontal split (default 72/28, layout id persists).
- **Store**: adds `selectedSignalId` state + setter; primitive selectors keep `useInspectedBarIdx` subscriber-stable.

## Test plan

- [x] `bunx vitest run` — 95 tests / 18 files pass (45 new in this PR)
- [x] `bunx tsc -p tsconfig.app.json --noEmit` — no new errors in `src/features/studio/**`
- [x] No future-info leak: signal collection filters `bar_idx > inspectedIdx`
- [x] Filters: source (rule/llm/vlm) + side + min probability
- [x] Click row → `setBar(signal.bar_idx)` + `selectedSignalId = signal.id`
- [x] Chart hover ≠ current → side panel renders hovered data with `preview` badge; cleared on `setHoveredBar(null)`
- [x] Reasoning markdown renders headers, bold, and code blocks
- [x] RegimeTimeline segments width is proportional to bar count; click jumps to start; hover surfaces duration tooltip
- [x] Empty placeholders when timeline / decision / regime is missing

Closes QUA-64.