### PR TITLE
feat(brooks): ContextFilter — background→signal gate (QUA-68)

### DIFF
--- a/scripts/measure_context_filter_reduction.py
+++ b/scripts/measure_context_filter_reduction.py
@@ -1,0 +1,262 @@
+"""Quantify how much ContextFilter reduces trade count on a synthetic
+multi-regime session.
+
+Generates a single-symbol bar series that walks through:
+
+  1. ~120 bars of tight chop (noisy mean-revert around 100)
+  2. ~120 bars of broad trading range (50% wider swings)
+  3. ~80 bars of strong bull breakout + continuation
+  4. ~60 bars of climax acceleration
+  5. ~80 bars of bear reversal + downtrend
+  6. ~80 bars of sideways consolidation again
+
+then drives :class:`BrooksStrategy` over it twice — once with the
+context filter disabled (legacy behaviour), once with it enabled
+(the defaults from this PR) — and reports the entry counts.
+
+Run via::
+
+    uv run --extra gpu python scripts/measure_context_filter_reduction.py
+
+The script is intentionally tiny and self-contained; it doesn't try to
+be a real backtest. The numbers it prints serve as the "≥ 50% trade-
+count reduction" acceptance check on the QUA-68 issue.
+"""
+
+from __future__ import annotations
+
+import random
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional
+
+from src.brooks.strategy import BrooksStrategy
+from src.core.backtest_broker import BacktestBroker
+from src.core.base import Bar, DataStream
+from src.core.engine import TradingEngine
+
+
+class _ListStream(DataStream):
+    def __init__(self, bars: List[Bar]) -> None:
+        self._bars = bars
+        self._i = 0
+
+    def next_bar(self) -> Optional[Dict[str, Bar]]:
+        if self._i >= len(self._bars):
+            return None
+        b = self._bars[self._i]
+        self._i += 1
+        return {b.symbol: b}
+
+    def reset(self) -> None:
+        self._i = 0
+
+
+def _bar(i: int, o: float, h: float, l: float, c: float, *, base: datetime) -> Bar:
+    return Bar(
+        symbol="BTCUSDT",
+        timestamp=base + timedelta(minutes=5 * i),
+        open=o,
+        high=h,
+        low=l,
+        close=c,
+        volume=1.0,
+        amount=c,
+    )
+
+
+def _build_multi_regime_session(seed: int = 7) -> List[Bar]:
+    """Mostly-noise session typical of intraday crypto on 5m bars.
+
+    The mix is ~70% chop / range, ~20% one trend leg, ~10% climax +
+    reversal — closer to the empirical regime distribution than a
+    handcrafted multi-regime parade. Brooks' "background → signal"
+    teaching is most valuable in chop, so the savings concentrate
+    there.
+    """
+    rng = random.Random(seed)
+    base = datetime(2025, 4, 1, 0, 0)
+    out: List[Bar] = []
+    price = 100.0
+    idx = 0
+
+    def push(o: float, h: float, l: float, c: float) -> None:
+        nonlocal idx
+        out.append(_bar(idx, o, h, l, c, base=base))
+        idx += 1
+
+    # ---- 1. Tight chop (heavy) --------------------------------------------
+    for _ in range(220):
+        o = price
+        c = o + rng.uniform(-0.2, 0.2)
+        h = max(o, c) + rng.uniform(0.0, 0.1)
+        l = min(o, c) - rng.uniform(0.0, 0.1)
+        push(o, h, l, c)
+        price = c
+
+    # ---- 2. Broad trading range -------------------------------------------
+    for k in range(160):
+        o = price
+        target = 100.0 + 4.0 * (1 if (k // 8) % 2 == 0 else -1)
+        c = o + (target - o) * 0.25 + rng.uniform(-0.5, 0.5)
+        h = max(o, c) + rng.uniform(0.1, 0.6)
+        l = min(o, c) - rng.uniform(0.1, 0.6)
+        push(o, h, l, c)
+        price = c
+
+    # ---- 3. Strong bull breakout + continuation ---------------------------
+    o = price
+    c = o + 8.0
+    h = c + 0.2
+    l = o - 0.2
+    push(o, h, l, c)
+    price = c
+    for _ in range(80):
+        o = price
+        c = o + rng.uniform(0.3, 1.2)
+        h = c + rng.uniform(0.05, 0.3)
+        l = o - rng.uniform(0.05, 0.3)
+        push(o, h, l, c)
+        price = c
+
+    # ---- 4. Climax (3-bar accel + over-extension) -------------------------
+    for _ in range(3):
+        o = price
+        c = o + rng.uniform(4.0, 6.0)
+        h = c + 0.2
+        l = o - 0.1
+        push(o, h, l, c)
+        price = c
+    for _ in range(40):
+        o = price
+        c = o + rng.uniform(-0.5, 0.5)
+        h = max(o, c) + rng.uniform(0.05, 0.5)
+        l = min(o, c) - rng.uniform(0.05, 0.5)
+        push(o, h, l, c)
+        price = c
+
+    # ---- 5. Bear reversal + tight chop (more chop, less trend) -----------
+    o = price
+    c = o - 6.0
+    h = o + 0.2
+    l = c - 0.2
+    push(o, h, l, c)
+    price = c
+    for _ in range(40):
+        o = price
+        c = o - rng.uniform(0.2, 1.0)
+        h = o + rng.uniform(0.05, 0.3)
+        l = c - rng.uniform(0.05, 0.3)
+        push(o, h, l, c)
+        price = c
+    for _ in range(160):
+        o = price
+        c = o + rng.uniform(-0.25, 0.25)
+        h = max(o, c) + rng.uniform(0.0, 0.15)
+        l = min(o, c) - rng.uniform(0.0, 0.15)
+        push(o, h, l, c)
+        price = c
+
+    return out
+
+
+def _make_strategy(*, context_filter_enabled: bool, ev_gate_active: bool) -> BrooksStrategy:
+    """Build the strategy used by the measurement.
+
+    ``ev_gate_active=False`` neutralises the EV gate (``min_expected_r=-100``),
+    isolating the ContextFilter's signal-reduction effect. ``True`` keeps
+    the default EV gate so the comparison reflects the cumulative gating
+    you'd see in production.
+    """
+    return BrooksStrategy(
+        analyst="rule",
+        analyst_params={
+            "extractor_kwargs": {"breakout_lookback": 20, "swing_k": 2},
+            "structure_kwargs": {"breakout_lookback": 20},
+        },
+        aggregator_params={"confluence_n": 1},
+        context_filter_enabled=context_filter_enabled,
+        te_params={"cost_r": 0.0},
+        min_expected_r=0.1 if ev_gate_active else -100.0,
+        sizer_params={"kind": "fixed", "risk_pct": 0.01},
+    )
+
+
+def _run_once(
+    bars: List[Bar], *, context_filter_enabled: bool, ev_gate_active: bool = False
+) -> int:
+    strat = _make_strategy(
+        context_filter_enabled=context_filter_enabled,
+        ev_gate_active=ev_gate_active,
+    )
+    broker = BacktestBroker(
+        initial_cash=100_000, commission=0.0001, slippage=0.0, allow_short=True
+    )
+    engine = TradingEngine(strategy=strat, broker=broker, data_stream=_ListStream(bars))
+    engine.run()
+    return sum(1 for t in broker.trades if t["type"] in ("buy", "sell_short"))
+
+
+def _regime_histogram(bars: List[Bar]) -> Dict[str, int]:
+    """Drive bars through the same extractor/structure/regime stack and
+    tally the resulting regime distribution."""
+    from collections import Counter
+
+    from src.brooks.features import BarFeatureExtractor
+    from src.brooks.regime import BrooksRegimeClassifier
+    from src.brooks.structure import MarketStructureTracker
+
+    ext = BarFeatureExtractor(swing_k=2, breakout_lookback=20)
+    tracker = MarketStructureTracker(ext, breakout_lookback=20)
+    cls = BrooksRegimeClassifier()
+    history = []
+    counter: Counter[str] = Counter()
+    for b in bars:
+        ts = int(b.timestamp.timestamp() * 1_000_000_000)
+        feat = ext.on_bar(ts, b.open, b.high, b.low, b.close)
+        struct = tracker.on_features(feat)
+        history.append(feat)
+        snap = cls.classify(history, struct)
+        counter[snap.regime.value] += 1
+    return dict(counter)
+
+
+def _build_chop_only_session(seed: int = 7, n_bars: int = 600) -> List[Bar]:
+    """Pure mean-reverting chop around a fixed level (no trend)."""
+    rng = random.Random(seed)
+    base = datetime(2025, 4, 1, 0, 0)
+    out: List[Bar] = []
+    price = 100.0
+    for i in range(n_bars):
+        o = price
+        c = o + (100.0 - o) * 0.3 + rng.uniform(-0.4, 0.4)
+        h = max(o, c) + rng.uniform(0.05, 0.25)
+        l = min(o, c) - rng.uniform(0.05, 0.25)
+        out.append(_bar(i, o, h, l, c, base=base))
+        price = c
+    return out
+
+
+def _summarize(label: str, bars: List[Bar]) -> None:
+    print(f"\n=== {label} ===")
+    print(f"session bars: {len(bars)}")
+    print(f"regime histogram: {_regime_histogram(bars)}")
+    raw = _run_once(bars, context_filter_enabled=False, ev_gate_active=False)
+    cf_only = _run_once(bars, context_filter_enabled=True, ev_gate_active=False)
+    ev_only = _run_once(bars, context_filter_enabled=False, ev_gate_active=True)
+    cf_plus_ev = _run_once(bars, context_filter_enabled=True, ev_gate_active=True)
+    print(f"entries (no gates):          {raw}")
+    print(f"entries (ContextFilter only): {cf_only}  reduction vs raw = {(1 - cf_only/raw) * 100 if raw else 0:.1f}%")
+    print(f"entries (EV gate only):       {ev_only}  reduction vs raw = {(1 - ev_only/raw) * 100 if raw else 0:.1f}%")
+    print(f"entries (CF + EV):            {cf_plus_ev}  reduction vs raw = {(1 - cf_plus_ev/raw) * 100 if raw else 0:.1f}%")
+    if ev_only:
+        delta = 1 - cf_plus_ev / ev_only
+        print(f"CF effect on top of EV gate:  {delta * 100:.1f}%  (PRs vs legacy live config)")
+
+
+def main() -> None:
+    _summarize("multi-regime", _build_multi_regime_session())
+    _summarize("chop-only", _build_chop_only_session())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/api/schemas/brooks_studio.py
+++ b/src/api/schemas/brooks_studio.py
@@ -69,6 +69,23 @@ class FillView(BaseModel):
     reason: str = ""
 
 
+class BackgroundSummary(BaseModel):
+    """Compact "what is the market doing now" summary attached to BarEvent.
+
+    Populated by :class:`~src.brooks.decision.context_filter.ContextFilter`
+    so the Studio panel can render the regime + structure context that
+    decided whether the bar's signals were allowed through.
+    """
+
+    regime: Optional[str] = None
+    leg_dir: Optional[str] = None
+    in_trading_range: bool = False
+    swing_age_bars: Optional[int] = None
+    pattern_types: List[str] = Field(default_factory=list)
+    allow: bool = True
+    reason: str = ""
+
+
 class BarEvent(BaseModel):
     bar_idx: int
     timestamp_ns: int
@@ -76,11 +93,13 @@ class BarEvent(BaseModel):
     features: Optional[FeaturesView] = None
     structure: Optional[StructureView] = None
     signals: List[Signal] = Field(default_factory=list)
+    failed_signals: List[Signal] = Field(default_factory=list)
     decision: Optional[Decision] = None
     fill: Optional[FillView] = None
     stop_adj: Optional[StopAdj] = None
     pnl_r: Optional[float] = None
     htf: Dict[str, HTFView] = Field(default_factory=dict)
+    background: Optional[BackgroundSummary] = None
 
 
 class PnLPoint(BaseModel):
@@ -169,6 +188,7 @@ class ReplayBarResponse(BaseModel):
 
 __all__ = [
     "Bar",
+    "BackgroundSummary",
     "RegimeView",
     "StructureView",
     "FeaturesView",

--- a/src/brooks/decision/__init__.py
+++ b/src/brooks/decision/__init__.py
@@ -4,12 +4,15 @@ hard threshold.
 """
 
 from src.brooks.decision.aggregator import AggregatedDecision, SignalAggregator
+from src.brooks.decision.context_filter import ContextDecision, ContextFilter
 from src.brooks.decision.ev_gate import EVGate
 from src.brooks.decision.hit_rate import HitRateKey, HitRateTable
 from src.brooks.decision.trader_equation import TraderEquation
 
 __all__ = [
     "AggregatedDecision",
+    "ContextDecision",
+    "ContextFilter",
     "EVGate",
     "HitRateKey",
     "HitRateTable",

--- a/src/brooks/decision/context_filter.py
+++ b/src/brooks/decision/context_filter.py
@@ -1,0 +1,588 @@
+"""Background → signal context filter.
+
+The aggregator and EV gate accept any signal a detector emits. Brooks'
+"background → signal" principle says the **regime / structure** must
+permit a signal before it can be traded; otherwise the same set of
+detectors will fire constantly in chop and the resulting strategy
+trades far too often.
+
+:class:`ContextFilter` sits between the aggregator and the EV gate. It
+inspects the combined ``(side, pattern_type set)``, the current
+:class:`BrooksRegime`, and the :class:`MarketStructure` snapshot and
+returns ``(allow, reason)``. Signals whose background does not permit
+them are dropped before they ever reach the EV gate; the strategy keeps
+them around as ``failed_signals`` for the Studio panel to render.
+
+The rules below intentionally err on the **conservative** side:
+
+* trends only allow with-trend continuation patterns by default;
+  countertrend trades require a strong-reversal package
+  (wedge / double / mtr / final-flag / failed-breakout)
+* tight ranges reject every breakout follow-through; only reversals
+  inside the range are allowed
+* broad ranges allow both edges to fade and trend-internal pullbacks
+* breakout mode allows the freshly-broken side's continuation only
+* climax + unknown reject everything except strong counter-climax
+  reversals (climax) or nothing at all (unknown)
+
+Each rule comes with a short reason string that downstream renderers
+display next to the failed signal.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List, Optional, Set
+
+from src.brooks.regime import BrooksRegime
+from src.brooks.schema import Signal
+from src.brooks.structure import MarketStructure
+
+__all__ = [
+    "ContextDecision",
+    "ContextFilter",
+    "PATTERN_TYPE_MAP",
+    "REVERSAL_TYPES",
+    "CONTINUATION_TYPES",
+    "pattern_type_for",
+]
+
+
+# ---------------------------------------------------------------------------
+# Pattern → category map
+# ---------------------------------------------------------------------------
+
+# Map detector name (``Signal.pattern``) → high-level pattern category.
+# Detectors not listed here fall back to ``"unknown"``.
+PATTERN_TYPE_MAP: dict[str, str] = {
+    # with-trend pullback recoveries (Brooks H1..H4 / L1..L4)
+    "h1": "pullback",
+    "h2": "pullback",
+    "h3": "pullback",
+    "h4": "pullback",
+    "l1": "pullback",
+    "l2": "pullback",
+    "l3": "pullback",
+    "l4": "pullback",
+    # reversal patterns
+    "wedge_long": "wedge",
+    "wedge_short": "wedge",
+    "double_top": "double_top",
+    "double_bottom": "double_bottom",
+    "mtr_long": "mtr",
+    "mtr_short": "mtr",
+    "final_flag": "final_flag",
+    "failed_breakout": "failed_breakout",
+    # breakout continuations
+    "bp_long": "breakout_pullback",
+    "bp_short": "breakout_pullback",
+    "ii_breakout": "breakout",
+    "iii_breakout": "breakout",
+    "measured_move": "measured_move",
+    "micro_channel_long": "micro_channel",
+    "micro_channel_short": "micro_channel",
+}
+
+REVERSAL_TYPES: Set[str] = {
+    "wedge",
+    "double_top",
+    "double_bottom",
+    "mtr",
+    "final_flag",
+    "failed_breakout",
+}
+
+CONTINUATION_TYPES: Set[str] = {
+    "pullback",
+    "breakout",
+    "breakout_pullback",
+    "measured_move",
+    "micro_channel",
+}
+
+
+def pattern_type_for(pattern: str) -> str:
+    """Return the high-level category for a detector's name."""
+    return PATTERN_TYPE_MAP.get(pattern, "unknown")
+
+
+# ---------------------------------------------------------------------------
+# Result + filter
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ContextDecision:
+    """Outcome of a :class:`ContextFilter` evaluation."""
+
+    allow: bool
+    reason: str
+    regime: str = "unknown"
+    leg_dir: str = "flat"
+    in_trading_range: bool = False
+    swing_age_bars: Optional[int] = None
+    pattern_types: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "allow": self.allow,
+            "reason": self.reason,
+            "regime": self.regime,
+            "leg_dir": self.leg_dir,
+            "in_trading_range": self.in_trading_range,
+            "swing_age_bars": self.swing_age_bars,
+            "pattern_types": list(self.pattern_types),
+        }
+
+
+class ContextFilter:
+    """Background → signal gate that runs before the EV gate.
+
+    Parameters
+    ----------
+    allow_strong_reversal_in_trend:
+        When ``True`` (default), strong reversal packages are permitted
+        to take countertrend trades inside trend regimes. Setting to
+        ``False`` forces with-trend-only behaviour.
+    micro_channel_steepness_atr:
+        Reject continuation pullbacks when the leg's micro-channel slope
+        per bar exceeds this many ATR units — a too-steep leg is climax
+        territory and chasing it usually fails. ``None`` disables the
+        check.
+    max_swing_age_bars:
+        Reject any signal when the latest confirmed swing of either kind
+        is older than this many bars (structure is "stale"). ``None``
+        disables the check.
+    require_reversal_package_for_countertrend:
+        Number of distinct reversal-type patterns required for the
+        filter to allow a countertrend signal in a trending regime.
+        Default ``1`` lets a single wedge/double/mtr through; setting to
+        ``2`` enforces confluence on reversal trades.
+    """
+
+    def __init__(
+        self,
+        *,
+        allow_strong_reversal_in_trend: bool = True,
+        micro_channel_steepness_atr: Optional[float] = 1.0,
+        max_swing_age_bars: Optional[int] = 80,
+        require_reversal_package_for_countertrend: int = 1,
+        weak_trend_pullback_needs_confluence: bool = True,
+    ) -> None:
+        if require_reversal_package_for_countertrend < 1:
+            raise ValueError("require_reversal_package_for_countertrend must be >= 1")
+        if micro_channel_steepness_atr is not None and micro_channel_steepness_atr <= 0:
+            raise ValueError("micro_channel_steepness_atr must be > 0 or None")
+        if max_swing_age_bars is not None and max_swing_age_bars <= 0:
+            raise ValueError("max_swing_age_bars must be > 0 or None")
+        self._allow_reversal = allow_strong_reversal_in_trend
+        self._steep_atr = micro_channel_steepness_atr
+        self._max_swing_age = max_swing_age_bars
+        self._reversal_n = int(require_reversal_package_for_countertrend)
+        self._weak_trend_needs_confluence = bool(weak_trend_pullback_needs_confluence)
+
+    # ------------------------------------------------------------------ check
+    def check(
+        self,
+        side: str,
+        signals: Iterable[Signal],
+        regime: BrooksRegime,
+        structure: MarketStructure,
+    ) -> ContextDecision:
+        signals = list(signals)
+        types = sorted({pattern_type_for(s.pattern) for s in signals})
+        type_set = set(types)
+        leg_dir = getattr(structure, "current_leg_dir", "flat") or "flat"
+        swing_age = _swing_age_bars(structure)
+        in_tr = regime in (
+            BrooksRegime.TIGHT_TRADING_RANGE,
+            BrooksRegime.BROAD_TRADING_RANGE,
+        )
+        base = dict(
+            regime=regime.value if hasattr(regime, "value") else str(regime),
+            leg_dir=leg_dir,
+            in_trading_range=in_tr,
+            swing_age_bars=swing_age,
+            pattern_types=types,
+        )
+
+        # ---- structure-level guards (apply to all regimes except unknown) ---
+        if regime != BrooksRegime.UNKNOWN:
+            if (
+                self._max_swing_age is not None
+                and swing_age is not None
+                and swing_age > self._max_swing_age
+            ):
+                return ContextDecision(
+                    allow=False,
+                    reason=f"structure_stale: swing_age={swing_age} > {self._max_swing_age}",
+                    **base,
+                )
+
+        # ---- per-regime rules ----------------------------------------------
+        if regime == BrooksRegime.UNKNOWN:
+            return ContextDecision(
+                allow=False, reason="regime_unknown: insufficient context", **base
+            )
+
+        if regime == BrooksRegime.CLIMAX:
+            return self._check_climax(side, type_set, structure, base)
+
+        if regime == BrooksRegime.BREAKOUT_MODE:
+            return self._check_breakout(side, type_set, structure, base)
+
+        if regime == BrooksRegime.TIGHT_TRADING_RANGE:
+            return self._check_tight_range(side, type_set, base)
+
+        if regime == BrooksRegime.BROAD_TRADING_RANGE:
+            return self._check_broad_range(side, type_set, base)
+
+        if regime in (
+            BrooksRegime.STRONG_BULL_TREND,
+            BrooksRegime.WEAK_BULL_TREND,
+        ):
+            return self._check_trend(
+                side, type_set, regime, structure, trend_side="long", base=base
+            )
+
+        if regime in (
+            BrooksRegime.STRONG_BEAR_TREND,
+            BrooksRegime.WEAK_BEAR_TREND,
+        ):
+            return self._check_trend(
+                side, type_set, regime, structure, trend_side="short", base=base
+            )
+
+        # Defensive default — should be unreachable; reject so we never trade
+        # in a regime we don't recognise.
+        return ContextDecision(
+            allow=False, reason=f"regime_unhandled: {regime}", **base
+        )
+
+    # ------------------------------------------------------------------ trend
+    def _check_trend(
+        self,
+        side: str,
+        types: Set[str],
+        regime: BrooksRegime,
+        structure: MarketStructure,
+        *,
+        trend_side: str,
+        base: dict,
+    ) -> ContextDecision:
+        with_trend = side == trend_side
+        if with_trend:
+            with_trend_reversals = (
+                {"double_bottom"} if trend_side == "long" else {"double_top"}
+            )
+            allowed = (CONTINUATION_TYPES & types) | (with_trend_reversals & types)
+            if not allowed:
+                return ContextDecision(
+                    allow=False,
+                    reason=(
+                        f"with_trend_no_continuation: types={sorted(types)} "
+                        f"regime={regime.value}"
+                    ),
+                    **base,
+                )
+            # Brooks: a with-trend pullback only makes sense when the
+            # current leg is *against* the trend (so price is in a real
+            # pullback). When the leg is extending with the trend, an h2/l2
+            # here is buying the high / selling the low; when the leg is
+            # flat the structure is ambiguous and the pullback signal is
+            # likely chop noise.
+            leg_dir = (base.get("leg_dir") or "flat")
+            in_pullback_leg = (
+                (trend_side == "long" and leg_dir == "down")
+                or (trend_side == "short" and leg_dir == "up")
+            )
+            if (allowed <= {"pullback"}) and not in_pullback_leg:
+                return ContextDecision(
+                    allow=False,
+                    reason=(
+                        "with_trend_pullback_needs_counter_leg: "
+                        f"leg_dir={leg_dir} trend={trend_side}"
+                    ),
+                    **base,
+                )
+            # Weak trends are noisy — a lone with-trend pullback is the
+            # majority of false signals in chop. Require either a
+            # non-pullback continuation pattern (bp_*, measured_move,
+            # micro_channel) or a structurally-aligned reversal
+            # (double_bottom in bull / double_top in bear).
+            if (
+                self._weak_trend_needs_confluence
+                and regime in (
+                    BrooksRegime.WEAK_BULL_TREND,
+                    BrooksRegime.WEAK_BEAR_TREND,
+                )
+                and (allowed <= {"pullback"})
+            ):
+                return ContextDecision(
+                    allow=False,
+                    reason=(
+                        "weak_trend_pullback_needs_confluence: "
+                        f"types={sorted(types)} regime={regime.value}"
+                    ),
+                    **base,
+                )
+            steep = self._micro_channel_too_steep(structure, trend_side)
+            # Steep micro-channels in strong trends → don't chase pure
+            # pullbacks; require breakout-pullback or a reversal package.
+            if (
+                steep
+                and regime == BrooksRegime.STRONG_BULL_TREND
+                and types <= {"pullback"}
+            ):
+                return ContextDecision(
+                    allow=False,
+                    reason="micro_channel_too_steep_for_pullback",
+                    **base,
+                )
+            if (
+                steep
+                and regime == BrooksRegime.STRONG_BEAR_TREND
+                and types <= {"pullback"}
+            ):
+                return ContextDecision(
+                    allow=False,
+                    reason="micro_channel_too_steep_for_pullback",
+                    **base,
+                )
+            return ContextDecision(
+                allow=True, reason="with_trend_continuation", **base
+            )
+
+        # Counter-trend in a trend regime — require a reversal package.
+        if not self._allow_reversal:
+            return ContextDecision(
+                allow=False,
+                reason="counter_trend_blocked: reversals disabled in trend",
+                **base,
+            )
+        reversal_hits = REVERSAL_TYPES & types
+        if regime in (BrooksRegime.STRONG_BULL_TREND, BrooksRegime.STRONG_BEAR_TREND):
+            needed = max(self._reversal_n, 1)
+            # Strong trend needs the full package; a single wedge is not
+            # enough to fight an established trend.
+            if len(reversal_hits) < max(needed, 2):
+                return ContextDecision(
+                    allow=False,
+                    reason=(
+                        f"counter_strong_trend_needs_reversal_package: "
+                        f"reversal_types={sorted(reversal_hits)} "
+                        f"need>={max(needed, 2)}"
+                    ),
+                    **base,
+                )
+            return ContextDecision(
+                allow=True,
+                reason=(
+                    f"counter_strong_trend_with_reversal_package: "
+                    f"{sorted(reversal_hits)}"
+                ),
+                **base,
+            )
+        # Weak trend — single reversal pattern is sufficient.
+        if not reversal_hits:
+            return ContextDecision(
+                allow=False,
+                reason=(
+                    f"counter_weak_trend_needs_reversal: types={sorted(types)}"
+                ),
+                **base,
+            )
+        return ContextDecision(
+            allow=True,
+            reason=f"counter_weak_trend_with_reversal: {sorted(reversal_hits)}",
+            **base,
+        )
+
+    # ------------------------------------------------------------------ ranges
+    def _check_tight_range(
+        self, side: str, types: Set[str], base: dict
+    ) -> ContextDecision:
+        # Tight TRs chop violently — Brooks' guidance is "trade out of a
+        # tight TR, not in it". Only allow strong-reversal *confluence*
+        # (≥ 2 reversal patterns) or an explicit failed-breakout fade.
+        if types & CONTINUATION_TYPES:
+            return ContextDecision(
+                allow=False,
+                reason=(
+                    f"tight_range_blocks_continuation: types={sorted(types)}"
+                ),
+                **base,
+            )
+        reversal_hits = types & REVERSAL_TYPES
+        if "failed_breakout" in reversal_hits:
+            return ContextDecision(
+                allow=True,
+                reason=f"tight_range_failed_breakout: {sorted(reversal_hits)}",
+                **base,
+            )
+        if len(reversal_hits) >= 2:
+            return ContextDecision(
+                allow=True,
+                reason=f"tight_range_reversal_confluence: {sorted(reversal_hits)}",
+                **base,
+            )
+        return ContextDecision(
+            allow=False,
+            reason=f"tight_range_needs_strong_reversal: types={sorted(types)}",
+            **base,
+        )
+
+    def _check_broad_range(
+        self, side: str, types: Set[str], base: dict
+    ) -> ContextDecision:
+        # Broad TRs allow edge fades and breakout-pullback re-entries but
+        # naked breakouts and lone with-range pullbacks usually fail back
+        # into the range.
+        if types & {"breakout"}:
+            return ContextDecision(
+                allow=False,
+                reason="broad_range_blocks_naked_breakout",
+                **base,
+            )
+        if types & REVERSAL_TYPES:
+            return ContextDecision(
+                allow=True,
+                reason=f"broad_range_reversal: {sorted(types & REVERSAL_TYPES)}",
+                **base,
+            )
+        if "breakout_pullback" in types:
+            return ContextDecision(
+                allow=True,
+                reason="broad_range_breakout_pullback",
+                **base,
+            )
+        return ContextDecision(
+            allow=False,
+            reason=f"broad_range_needs_reversal_or_bp: types={sorted(types)}",
+            **base,
+        )
+
+    # ------------------------------------------------------------------ breakout
+    def _check_breakout(
+        self,
+        side: str,
+        types: Set[str],
+        structure: MarketStructure,
+        base: dict,
+    ) -> ContextDecision:
+        always_in = getattr(structure, "always_in", "neutral") or "neutral"
+        # Breakout mode favors continuation in the breakout direction.
+        with_breakout = (
+            (always_in == "long" and side == "long")
+            or (always_in == "short" and side == "short")
+        )
+        if with_breakout:
+            # Brooks: chase the breakout *only* on a confirmed pullback
+            # ("BO + BP"). Naked breakout-on-breakout (ii/iii / measured
+            # move alone) trades the spike, which usually mean-reverts.
+            if "breakout_pullback" in types:
+                return ContextDecision(
+                    allow=True,
+                    reason="breakout_with_direction_bp",
+                    **base,
+                )
+            return ContextDecision(
+                allow=False,
+                reason=(
+                    f"breakout_needs_pullback_re_entry: types={sorted(types)}"
+                ),
+                **base,
+            )
+        # Counter-breakout — allow only the explicit failed-breakout package.
+        if types & {"failed_breakout", "wedge", "double_top", "double_bottom"}:
+            return ContextDecision(
+                allow=True,
+                reason=(
+                    f"breakout_failure_reversal: "
+                    f"{sorted(types & (REVERSAL_TYPES | {'failed_breakout'}))}"
+                ),
+                **base,
+            )
+        return ContextDecision(
+            allow=False,
+            reason=(
+                f"counter_breakout_needs_failure: types={sorted(types)}"
+            ),
+            **base,
+        )
+
+    # ------------------------------------------------------------------ climax
+    def _check_climax(
+        self,
+        side: str,
+        types: Set[str],
+        structure: MarketStructure,
+        base: dict,
+    ) -> ContextDecision:
+        # In climax, with-trend continuation is the worst trade Brooks
+        # describes — momentum is about to reverse. Reject continuations
+        # outright; allow only counter-climax reversal packages.
+        with_trend_continuation = bool(types & CONTINUATION_TYPES)
+        always_in = getattr(structure, "always_in", "neutral") or "neutral"
+        with_trend = (
+            (always_in == "long" and side == "long")
+            or (always_in == "short" and side == "short")
+        )
+        if with_trend and with_trend_continuation:
+            return ContextDecision(
+                allow=False,
+                reason=f"climax_blocks_continuation: types={sorted(types)}",
+                **base,
+            )
+        reversal_hits = types & (REVERSAL_TYPES | {"final_flag"})
+        if reversal_hits:
+            return ContextDecision(
+                allow=True,
+                reason=f"climax_reversal: {sorted(reversal_hits)}",
+                **base,
+            )
+        return ContextDecision(
+            allow=False,
+            reason=f"climax_needs_reversal: types={sorted(types)}",
+            **base,
+        )
+
+    # ------------------------------------------------------------------ helpers
+    def _micro_channel_too_steep(
+        self, structure: MarketStructure, trend_side: str
+    ) -> bool:
+        if self._steep_atr is None:
+            return False
+        atr = float(getattr(structure, "atr14", 0.0) or 0.0)
+        if atr <= 0:
+            return False
+        channel = (
+            getattr(structure, "micro_channel_top", None)
+            if trend_side == "long"
+            else getattr(structure, "micro_channel_bot", None)
+        )
+        if channel is None:
+            return False
+        slope = abs(float(getattr(channel, "slope", 0.0)))
+        return slope >= self._steep_atr * atr
+
+
+def _swing_age_bars(structure: MarketStructure) -> Optional[int]:
+    """Bars between the latest confirmed swing (high or low) and ``current_idx``.
+
+    Returns ``None`` when no swings have been confirmed yet — callers
+    treat that as "unknown" rather than "stale".
+    """
+    current_idx = getattr(structure, "current_idx", -1)
+    if current_idx is None or current_idx < 0:
+        return None
+    highs = getattr(structure, "confirmed_swing_highs", None) or []
+    lows = getattr(structure, "confirmed_swing_lows", None) or []
+    last_idx = -1
+    if highs:
+        last_idx = max(last_idx, highs[-1].bar_idx)
+    if lows:
+        last_idx = max(last_idx, lows[-1].bar_idx)
+    if last_idx < 0:
+        return None
+    return max(0, current_idx - last_idx)

--- a/src/brooks/runtime/core.py
+++ b/src/brooks/runtime/core.py
@@ -36,6 +36,7 @@ from src.brooks.runtime.event_sink import BarEventSink
 from src.brooks.runtime.regime_capture import RegimeCapturingClassifier
 from src.brooks.runtime.throttle import Throttle
 from src.brooks.runtime.views import (
+    background_to_view_dict,
     decision_to_dict,
     decision_to_full_dict,
     features_to_view_dict,
@@ -300,6 +301,19 @@ class BrooksCore:
                     "volume": float(latest.volume),
                 }
 
+        # ContextFilter telemetry — failed signals (rejected this bar) and
+        # the per-bar background summary the filter produced. The Studio
+        # panel uses these to render rejected setups + the regime/structure
+        # context behind the decision.
+        failed_signals_state = getattr(self.strategy, "_last_failed_signals", {}) or {}
+        failed_signals_list: List[Dict[str, Any]] = [
+            s.model_dump() for s in (failed_signals_state.get(symbol) or [])
+        ]
+        ctx_decision = (
+            getattr(self.strategy, "_last_context_decision", {}) or {}
+        ).get(symbol)
+        background_payload = background_to_view_dict(ctx_decision)
+
         return {
             "bar_idx": bar_idx,
             "timestamp_ns": ts_ns,
@@ -315,7 +329,9 @@ class BrooksCore:
             "structure": structure_to_view_dict(struct_obj) if struct_obj is not None else None,
             "regime": regime_to_view_dict(regime_payload),
             "signals": signals_list,
+            "failed_signals": failed_signals_list,
             "decision": decision_dict,
+            "background": background_payload,
             "htf": htf_payload,
             "htf_bars": htf_bars,
             "symbol": symbol,

--- a/src/brooks/runtime/views.py
+++ b/src/brooks/runtime/views.py
@@ -87,7 +87,26 @@ def regime_to_view_dict(
     }
 
 
+def background_to_view_dict(
+    ctx_decision: Any,
+) -> Optional[Dict[str, Any]]:
+    """Project a :class:`~src.brooks.decision.context_filter.ContextDecision`
+    into the BarEvent.background payload."""
+    if ctx_decision is None:
+        return None
+    return {
+        "regime": getattr(ctx_decision, "regime", None),
+        "leg_dir": getattr(ctx_decision, "leg_dir", None),
+        "in_trading_range": bool(getattr(ctx_decision, "in_trading_range", False)),
+        "swing_age_bars": getattr(ctx_decision, "swing_age_bars", None),
+        "pattern_types": list(getattr(ctx_decision, "pattern_types", []) or []),
+        "allow": bool(getattr(ctx_decision, "allow", True)),
+        "reason": getattr(ctx_decision, "reason", "") or "",
+    }
+
+
 __all__ = [
+    "background_to_view_dict",
     "decision_to_dict",
     "decision_to_full_dict",
     "features_to_view_dict",

--- a/src/brooks/schema.py
+++ b/src/brooks/schema.py
@@ -16,6 +16,7 @@ class Signal(BaseModel):
     """A pattern-detection signal produced by a rule/LLM/VLM detector."""
 
     pattern: str
+    pattern_type: Optional[str] = None
     side: Literal["long", "short"]
     signal_bar_idx: int
     entry_px: float = Field(gt=0)
@@ -31,6 +32,14 @@ class Signal(BaseModel):
     def _entry_differs_from_stop(self) -> "Signal":
         if self.entry_px == self.stop_px:
             raise ValueError("entry_px must differ from stop_px")
+        return self
+
+    @model_validator(mode="after")
+    def _populate_pattern_type(self) -> "Signal":
+        if self.pattern_type is None:
+            from src.brooks.decision.context_filter import pattern_type_for
+
+            object.__setattr__(self, "pattern_type", pattern_type_for(self.pattern))
         return self
 
     @property

--- a/src/brooks/strategy.py
+++ b/src/brooks/strategy.py
@@ -35,6 +35,7 @@ from src.brooks.analyst.rule import RuleAnalyst  # noqa: F401 — triggers regis
 from src.brooks.context import AccountSnapshot, BrooksContext, TFSnapshot
 from src.brooks.context import Bar as BrooksBar
 from src.brooks.decision.aggregator import AggregatedDecision, SignalAggregator
+from src.brooks.decision.context_filter import ContextDecision, ContextFilter
 from src.brooks.decision.ev_gate import EVGate
 from src.brooks.decision.hit_rate import HitRateTable
 from src.brooks.decision.trader_equation import TraderEquation
@@ -101,6 +102,11 @@ class BrooksStrategy(Strategy):
         analyst_name: str = self.params["analyst"]
         self._analyst = AnalystRegistry.build(analyst_name, **self.params.get("analyst_params", {}))
         self._aggregator = SignalAggregator(**self.params.get("aggregator_params", {}))
+        self._context_filter = (
+            ContextFilter(**self.params.get("context_filter_params", {}))
+            if self.params.get("context_filter_enabled", True)
+            else None
+        )
         self._te = _build_te(self.params.get("te_params", {}))
         self._ev_gate = EVGate(
             self._te,
@@ -124,6 +130,12 @@ class BrooksStrategy(Strategy):
         self._positions: Dict[str, PositionState] = {}
         self._pending_decisions: Dict[str, Decision] = {}
         self._entry_order_ids: Dict[str, str] = {}
+        # Per-symbol bookkeeping for the most recent ContextFilter pass — read
+        # by the runtime BarEvent builder so the Studio panel can render
+        # ``failed_signals`` and the background summary even when no order
+        # was placed.
+        self._last_failed_signals: Dict[str, List[Any]] = {}
+        self._last_context_decision: Dict[str, ContextDecision] = {}
         # Bar count at which the current pending decision was submitted —
         # used to time out stale stop-entries (see ``pending_entry_max_bars``).
         self._pending_submit_bar: Dict[str, int] = {}
@@ -137,6 +149,8 @@ class BrooksStrategy(Strategy):
             "analyst": "rule",
             "analyst_params": {},
             "aggregator_params": {"confluence_n": 1},
+            "context_filter_enabled": True,
+            "context_filter_params": {},
             "te_params": {},
             "min_expected_r": 0.1,
             "sizer_params": {"kind": "kelly"},
@@ -251,6 +265,12 @@ class BrooksStrategy(Strategy):
     def _process_symbol_bar(self, symbol: str, bar: Bar) -> None:
         ts_ns = int(bar.timestamp.timestamp() * 1_000_000_000)
 
+        # Reset per-bar context-filter bookkeeping. Anything left in here from
+        # the prior bar would otherwise re-render on the Studio chart even
+        # though it relates to a stale evaluation.
+        self._last_failed_signals[symbol] = []
+        self._last_context_decision.pop(symbol, None)
+
         # ---- LTF features/structure/regime for this bar ---------------------
         feat = self._extractors[symbol].on_bar(ts_ns, bar.open, bar.high, bar.low, bar.close)
         struct = self._structures[symbol].on_features(feat)
@@ -290,6 +310,28 @@ class BrooksStrategy(Strategy):
             return
         if symbol in self._positions or symbol in self._pending_decisions:
             return  # don't stack
+
+        # ---- Brooks "background → signal" gate -----------------------------
+        # The aggregated signal is now subjected to a regime/structure check
+        # before any EV math runs. Reject early so the Studio panel can still
+        # render the rejected signals as ``failed_signals`` (they carry
+        # diagnostic value even when we don't trade them).
+        if self._context_filter is not None:
+            ctx_decision = self._context_filter.check(
+                side=combined.side,
+                signals=combined.raw_signals,
+                regime=regime.regime,
+                structure=struct,
+            )
+            self._last_context_decision[symbol] = ctx_decision
+            if not ctx_decision.allow:
+                self._last_failed_signals[symbol] = list(combined.raw_signals)
+                self._log(
+                    f"context_filter rejected {combined.side} {symbol}: "
+                    f"{ctx_decision.reason}",
+                    level="DEBUG",
+                )
+                return
 
         htf_tag = ctx.htf_alignment_for(combined.side)
         decisions = self._ev_gate.filter(

--- a/tests/brooks/test_context_filter.py
+++ b/tests/brooks/test_context_filter.py
@@ -1,0 +1,616 @@
+"""ContextFilter — Brooks "background → signal" gate.
+
+Each regime is exercised at least once with both a passing and a
+rejecting fixture. The structure-stale guard and micro-channel
+steepness check are tested separately.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+import pytest
+
+from src.brooks.decision.context_filter import (
+    CONTINUATION_TYPES,
+    ContextDecision,
+    ContextFilter,
+    PATTERN_TYPE_MAP,
+    REVERSAL_TYPES,
+    pattern_type_for,
+)
+from src.brooks.features import SwingPoint
+from src.brooks.regime import BrooksRegime
+from src.brooks.schema import Signal
+from src.brooks.structure import ChannelFit, MarketStructure
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _signal(pattern: str, side: str, *, idx: int = 10) -> Signal:
+    return Signal(
+        pattern=pattern,
+        side=side,  # type: ignore[arg-type]
+        signal_bar_idx=idx,
+        entry_px=100.0,
+        stop_px=99.0 if side == "long" else 101.0,
+        probability=0.5,
+        quality=0.5,
+        source=f"rule:{pattern}",
+    )
+
+
+def _structure(
+    *,
+    always_in: str = "long",
+    leg_dir: str = "up",
+    current_idx: int = 50,
+    swing_high_at: Optional[int] = 45,
+    swing_low_at: Optional[int] = 40,
+    atr14: float = 1.0,
+    micro_channel_top_slope: Optional[float] = None,
+    micro_channel_bot_slope: Optional[float] = None,
+) -> MarketStructure:
+    s = MarketStructure()
+    s.always_in = always_in  # type: ignore[assignment]
+    s.current_leg_dir = leg_dir  # type: ignore[assignment]
+    s.current_idx = current_idx
+    s.atr14 = atr14
+    if swing_high_at is not None:
+        s.confirmed_swing_highs = [
+            SwingPoint(bar_idx=swing_high_at, price=110.0, kind="high", confirmed_at_idx=swing_high_at + 2)
+        ]
+    if swing_low_at is not None:
+        s.confirmed_swing_lows = [
+            SwingPoint(bar_idx=swing_low_at, price=90.0, kind="low", confirmed_at_idx=swing_low_at + 2)
+        ]
+    if micro_channel_top_slope is not None:
+        s.micro_channel_top = ChannelFit(
+            slope=micro_channel_top_slope,
+            intercept=0.0,
+            start_idx=current_idx - 5,
+            end_idx=current_idx,
+            kind="top",
+        )
+    if micro_channel_bot_slope is not None:
+        s.micro_channel_bot = ChannelFit(
+            slope=micro_channel_bot_slope,
+            intercept=0.0,
+            start_idx=current_idx - 5,
+            end_idx=current_idx,
+            kind="bottom",
+        )
+    return s
+
+
+def _check(
+    cf: ContextFilter,
+    *,
+    side: str,
+    patterns: Iterable[str],
+    regime: BrooksRegime,
+    structure: Optional[MarketStructure] = None,
+) -> ContextDecision:
+    structure = structure or _structure()
+    sigs = [_signal(p, side) for p in patterns]
+    return cf.check(side=side, signals=sigs, regime=regime, structure=structure)
+
+
+# ---------------------------------------------------------------------------
+# pattern_type_for / map
+# ---------------------------------------------------------------------------
+
+
+def test_pattern_type_for_known_and_unknown():
+    assert pattern_type_for("h2") == "pullback"
+    assert pattern_type_for("wedge_long") == "wedge"
+    assert pattern_type_for("ii_breakout") == "breakout"
+    assert pattern_type_for("not_a_real_detector") == "unknown"
+
+
+def test_continuation_and_reversal_disjoint():
+    assert CONTINUATION_TYPES.isdisjoint(REVERSAL_TYPES)
+    # Every value in PATTERN_TYPE_MAP is either continuation, reversal, or
+    # explicitly bridged (failed_breakout is in reversal).
+    classified = CONTINUATION_TYPES | REVERSAL_TYPES
+    for cat in PATTERN_TYPE_MAP.values():
+        assert cat in classified, f"category {cat!r} not classified"
+
+
+# ---------------------------------------------------------------------------
+# constructor guards
+# ---------------------------------------------------------------------------
+
+
+def test_constructor_rejects_invalid_args():
+    with pytest.raises(ValueError):
+        ContextFilter(require_reversal_package_for_countertrend=0)
+    with pytest.raises(ValueError):
+        ContextFilter(micro_channel_steepness_atr=0)
+    with pytest.raises(ValueError):
+        ContextFilter(max_swing_age_bars=0)
+
+
+# ---------------------------------------------------------------------------
+# UNKNOWN — reject everything
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_regime_rejects_all():
+    cf = ContextFilter()
+    res = _check(cf, side="long", patterns=["h2"], regime=BrooksRegime.UNKNOWN)
+    assert res.allow is False
+    assert "regime_unknown" in res.reason
+    assert res.regime == "unknown"
+    assert res.pattern_types == ["pullback"]
+
+
+# ---------------------------------------------------------------------------
+# STRONG_BULL_TREND
+# ---------------------------------------------------------------------------
+
+
+def test_strong_bull_allows_with_trend_pullback():
+    cf = ContextFilter(micro_channel_steepness_atr=None)
+    # Pullback signal is only valid when leg is currently *against* the
+    # trend (i.e. price is in a pullback, not extending).
+    s = _structure(always_in="long", leg_dir="down")
+    res = _check(
+        cf,
+        side="long",
+        patterns=["h2"],
+        regime=BrooksRegime.STRONG_BULL_TREND,
+        structure=s,
+    )
+    assert res.allow, res.reason
+    assert "with_trend_continuation" in res.reason
+
+
+def test_strong_bull_rejects_pullback_during_extending_leg():
+    cf = ContextFilter(micro_channel_steepness_atr=None)
+    s = _structure(always_in="long", leg_dir="up")
+    res = _check(
+        cf,
+        side="long",
+        patterns=["h2"],
+        regime=BrooksRegime.STRONG_BULL_TREND,
+        structure=s,
+    )
+    assert not res.allow
+    assert "with_trend_pullback_needs_counter_leg" in res.reason
+
+
+def test_strong_bull_rejects_pullback_when_leg_flat():
+    cf = ContextFilter(micro_channel_steepness_atr=None)
+    s = _structure(always_in="long", leg_dir="flat")
+    res = _check(
+        cf,
+        side="long",
+        patterns=["h2"],
+        regime=BrooksRegime.STRONG_BULL_TREND,
+        structure=s,
+    )
+    assert not res.allow
+    assert "with_trend_pullback_needs_counter_leg" in res.reason
+
+
+def test_strong_bull_rejects_lone_counter_short():
+    cf = ContextFilter()
+    res = _check(
+        cf,
+        side="short",
+        patterns=["wedge_short"],
+        regime=BrooksRegime.STRONG_BULL_TREND,
+    )
+    assert not res.allow
+    assert "counter_strong_trend_needs_reversal_package" in res.reason
+
+
+def test_strong_bull_allows_counter_with_full_reversal_package():
+    cf = ContextFilter()
+    res = _check(
+        cf,
+        side="short",
+        patterns=["wedge_short", "double_top"],
+        regime=BrooksRegime.STRONG_BULL_TREND,
+    )
+    assert res.allow, res.reason
+    assert "counter_strong_trend_with_reversal_package" in res.reason
+
+
+def test_strong_bull_blocks_pullback_when_micro_channel_too_steep():
+    cf = ContextFilter(micro_channel_steepness_atr=1.0)
+    # slope = 1.5 ATR/bar — too steep. leg_dir=down so the
+    # leg-extending guard does not pre-empt the steepness check.
+    s = _structure(
+        atr14=1.0, micro_channel_top_slope=1.5, leg_dir="down", always_in="long"
+    )
+    res = _check(
+        cf,
+        side="long",
+        patterns=["h2"],
+        regime=BrooksRegime.STRONG_BULL_TREND,
+        structure=s,
+    )
+    assert not res.allow
+    assert "micro_channel_too_steep" in res.reason
+
+
+# ---------------------------------------------------------------------------
+# WEAK_BULL_TREND
+# ---------------------------------------------------------------------------
+
+
+def test_weak_bull_allows_single_reversal_short():
+    cf = ContextFilter()
+    res = _check(
+        cf,
+        side="short",
+        patterns=["wedge_short"],
+        regime=BrooksRegime.WEAK_BULL_TREND,
+    )
+    assert res.allow, res.reason
+    assert "counter_weak_trend_with_reversal" in res.reason
+
+
+def test_weak_bull_rejects_counter_without_reversal():
+    cf = ContextFilter()
+    res = _check(
+        cf,
+        side="short",
+        patterns=["l2"],
+        regime=BrooksRegime.WEAK_BULL_TREND,
+    )
+    assert not res.allow
+    assert "counter_weak_trend_needs_reversal" in res.reason
+
+
+# ---------------------------------------------------------------------------
+# STRONG_BEAR_TREND / WEAK_BEAR_TREND
+# ---------------------------------------------------------------------------
+
+
+def test_strong_bear_allows_with_trend_pullback():
+    cf = ContextFilter(micro_channel_steepness_atr=None)
+    # Pullback in a bear trend = a *bull* leg (against trend), then L2.
+    s = _structure(always_in="short", leg_dir="up")
+    res = _check(
+        cf,
+        side="short",
+        patterns=["l2"],
+        regime=BrooksRegime.STRONG_BEAR_TREND,
+        structure=s,
+    )
+    assert res.allow, res.reason
+
+
+def test_strong_bear_rejects_lone_counter_long():
+    cf = ContextFilter()
+    s = _structure(always_in="short", leg_dir="down")
+    res = _check(
+        cf,
+        side="long",
+        patterns=["wedge_long"],
+        regime=BrooksRegime.STRONG_BEAR_TREND,
+        structure=s,
+    )
+    assert not res.allow
+
+
+def test_weak_bear_allows_single_reversal_long():
+    cf = ContextFilter()
+    s = _structure(always_in="short", leg_dir="down")
+    res = _check(
+        cf,
+        side="long",
+        patterns=["wedge_long"],
+        regime=BrooksRegime.WEAK_BEAR_TREND,
+        structure=s,
+    )
+    assert res.allow, res.reason
+
+
+# ---------------------------------------------------------------------------
+# TIGHT_TRADING_RANGE
+# ---------------------------------------------------------------------------
+
+
+def test_tight_range_blocks_breakout_continuation():
+    cf = ContextFilter()
+    s = _structure(always_in="neutral", leg_dir="flat")
+    res = _check(
+        cf,
+        side="long",
+        patterns=["bp_long"],
+        regime=BrooksRegime.TIGHT_TRADING_RANGE,
+        structure=s,
+    )
+    assert not res.allow
+    assert "tight_range_blocks_continuation" in res.reason
+
+
+def test_tight_range_requires_reversal_confluence():
+    cf = ContextFilter()
+    s = _structure(always_in="neutral", leg_dir="flat")
+    # Single reversal pattern is no longer enough — tight TRs are
+    # "no-trade" regimes by default.
+    lone = _check(
+        cf,
+        side="short",
+        patterns=["double_top"],
+        regime=BrooksRegime.TIGHT_TRADING_RANGE,
+        structure=s,
+    )
+    assert not lone.allow
+    assert "tight_range_needs_strong_reversal" in lone.reason
+
+    confluence = _check(
+        cf,
+        side="short",
+        patterns=["double_top", "wedge_short"],
+        regime=BrooksRegime.TIGHT_TRADING_RANGE,
+        structure=s,
+    )
+    assert confluence.allow
+    assert "tight_range_reversal_confluence" in confluence.reason
+
+
+def test_tight_range_allows_failed_breakout_solo():
+    cf = ContextFilter()
+    s = _structure(always_in="neutral", leg_dir="flat")
+    res = _check(
+        cf,
+        side="short",
+        patterns=["failed_breakout"],
+        regime=BrooksRegime.TIGHT_TRADING_RANGE,
+        structure=s,
+    )
+    assert res.allow
+    assert "tight_range_failed_breakout" in res.reason
+
+
+# ---------------------------------------------------------------------------
+# BROAD_TRADING_RANGE
+# ---------------------------------------------------------------------------
+
+
+def test_broad_range_allows_reversal_and_breakout_pullback():
+    cf = ContextFilter()
+    s = _structure(always_in="neutral", leg_dir="flat")
+    rev = _check(
+        cf,
+        side="short",
+        patterns=["double_top"],
+        regime=BrooksRegime.BROAD_TRADING_RANGE,
+        structure=s,
+    )
+    assert rev.allow
+    assert "broad_range_reversal" in rev.reason
+
+    bp = _check(
+        cf,
+        side="long",
+        patterns=["bp_long"],
+        regime=BrooksRegime.BROAD_TRADING_RANGE,
+        structure=s,
+    )
+    assert bp.allow
+    assert "broad_range_breakout_pullback" in bp.reason
+
+
+def test_broad_range_rejects_lone_pullback():
+    cf = ContextFilter()
+    s = _structure(always_in="neutral", leg_dir="flat")
+    res = _check(
+        cf,
+        side="long",
+        patterns=["h2"],
+        regime=BrooksRegime.BROAD_TRADING_RANGE,
+        structure=s,
+    )
+    assert not res.allow
+    assert "broad_range_needs_reversal_or_bp" in res.reason
+
+
+def test_broad_range_blocks_naked_breakout():
+    cf = ContextFilter()
+    s = _structure(always_in="neutral", leg_dir="flat")
+    res = _check(
+        cf,
+        side="long",
+        patterns=["ii_breakout"],
+        regime=BrooksRegime.BROAD_TRADING_RANGE,
+        structure=s,
+    )
+    assert not res.allow
+    assert "broad_range_blocks_naked_breakout" in res.reason
+
+
+# ---------------------------------------------------------------------------
+# BREAKOUT_MODE
+# ---------------------------------------------------------------------------
+
+
+def test_breakout_requires_pullback_re_entry():
+    cf = ContextFilter()
+    s = _structure(always_in="long", leg_dir="up")
+    bp = _check(
+        cf,
+        side="long",
+        patterns=["bp_long"],
+        regime=BrooksRegime.BREAKOUT_MODE,
+        structure=s,
+    )
+    assert bp.allow
+    assert "breakout_with_direction_bp" in bp.reason
+
+    naked = _check(
+        cf,
+        side="long",
+        patterns=["ii_breakout"],
+        regime=BrooksRegime.BREAKOUT_MODE,
+        structure=s,
+    )
+    assert not naked.allow
+    assert "breakout_needs_pullback_re_entry" in naked.reason
+
+
+def test_breakout_counter_needs_failure_pattern():
+    cf = ContextFilter()
+    s = _structure(always_in="long", leg_dir="up")
+    res = _check(
+        cf,
+        side="short",
+        patterns=["l2"],
+        regime=BrooksRegime.BREAKOUT_MODE,
+        structure=s,
+    )
+    assert not res.allow
+    assert "counter_breakout_needs_failure" in res.reason
+
+
+def test_breakout_counter_failure_allowed():
+    cf = ContextFilter()
+    s = _structure(always_in="long", leg_dir="up")
+    res = _check(
+        cf,
+        side="short",
+        patterns=["failed_breakout"],
+        regime=BrooksRegime.BREAKOUT_MODE,
+        structure=s,
+    )
+    assert res.allow
+    assert "breakout_failure_reversal" in res.reason
+
+
+# ---------------------------------------------------------------------------
+# CLIMAX
+# ---------------------------------------------------------------------------
+
+
+def test_climax_blocks_with_trend_continuation():
+    cf = ContextFilter()
+    s = _structure(always_in="long", leg_dir="up")
+    res = _check(
+        cf,
+        side="long",
+        patterns=["h2"],
+        regime=BrooksRegime.CLIMAX,
+        structure=s,
+    )
+    assert not res.allow
+    assert "climax_blocks_continuation" in res.reason
+
+
+def test_climax_allows_counter_reversal():
+    cf = ContextFilter()
+    s = _structure(always_in="long", leg_dir="up")
+    res = _check(
+        cf,
+        side="short",
+        patterns=["final_flag"],
+        regime=BrooksRegime.CLIMAX,
+        structure=s,
+    )
+    assert res.allow
+    assert "climax_reversal" in res.reason
+
+
+# ---------------------------------------------------------------------------
+# Structure guards
+# ---------------------------------------------------------------------------
+
+
+def test_stale_swing_age_blocks_signal():
+    cf = ContextFilter(max_swing_age_bars=20)
+    # current_idx=200, last swing at 50 → age=150 ≫ 20
+    s = _structure(current_idx=200, swing_high_at=50, swing_low_at=50)
+    res = _check(
+        cf,
+        side="long",
+        patterns=["h2"],
+        regime=BrooksRegime.STRONG_BULL_TREND,
+        structure=s,
+    )
+    assert not res.allow
+    assert "structure_stale" in res.reason
+
+
+def test_swing_age_unknown_does_not_block():
+    cf = ContextFilter(max_swing_age_bars=20)
+    # leg_dir="down" so the with-trend pullback is permitted on its own;
+    # otherwise the leg-extending guard would mask the swing-age check.
+    s = _structure(
+        current_idx=200, swing_high_at=None, swing_low_at=None, leg_dir="down"
+    )
+    res = _check(
+        cf,
+        side="long",
+        patterns=["h2"],
+        regime=BrooksRegime.STRONG_BULL_TREND,
+        structure=s,
+    )
+    # swing_age=None → guard skipped
+    assert res.allow
+    assert res.swing_age_bars is None
+
+
+# ---------------------------------------------------------------------------
+# 9-regime coverage matrix sanity check
+# ---------------------------------------------------------------------------
+
+
+def test_filter_handles_every_brooks_regime():
+    """Ensure no regime crashes the filter and every value of
+    :class:`BrooksRegime` is reachable end-to-end. Coverage of the
+    actual rule output is validated by the regime-specific tests
+    above; this one is a smoke-test for the dispatch itself."""
+    cf = ContextFilter()
+    # leg_dir="down" so the "with-trend pullback in a real pullback leg"
+    # path is exercised; the trend regimes need that to allow the signal.
+    s = _structure(leg_dir="down")
+    seen: dict[BrooksRegime, ContextDecision] = {}
+    for regime in BrooksRegime:
+        res = cf.check(
+            side="long",
+            signals=[_signal("h2", "long"), _signal("bp_long", "long")],
+            regime=regime,
+            structure=s,
+        )
+        assert isinstance(res, ContextDecision)
+        seen[regime] = res
+    assert set(seen.keys()) == set(BrooksRegime)
+    # Sanity: at least one regime allows the with-trend pullback and at
+    # least one rejects it — proves the dispatch isn't a no-op.
+    assert any(r.allow for r in seen.values())
+    assert any(not r.allow for r in seen.values())
+
+
+# ---------------------------------------------------------------------------
+# ContextDecision serialization
+# ---------------------------------------------------------------------------
+
+
+def test_context_decision_to_dict_roundtrip():
+    cf = ContextFilter()
+    res = _check(cf, side="long", patterns=["h2"], regime=BrooksRegime.STRONG_BULL_TREND)
+    blob = res.to_dict()
+    assert blob["allow"] is res.allow
+    assert blob["reason"] == res.reason
+    assert blob["regime"] == "strong_bull_trend"
+    assert blob["pattern_types"] == ["pullback"]
+
+
+# ---------------------------------------------------------------------------
+# Signal.pattern_type auto-population
+# ---------------------------------------------------------------------------
+
+
+def test_signal_pattern_type_auto_populated():
+    sig = _signal("wedge_long", "long")
+    assert sig.pattern_type == "wedge"
+    sig2 = _signal("not_a_known_detector", "long")
+    assert sig2.pattern_type == "unknown"

--- a/tests/brooks/test_strategy_e2e.py
+++ b/tests/brooks/test_strategy_e2e.py
@@ -120,6 +120,11 @@ def _make_strategy() -> BrooksStrategy:
         te_params={"cost_r": 0.0},
         min_expected_r=-100.0,
         sizer_params={"kind": "fixed", "risk_pct": 0.01},
+        # The legacy v2 contract pins the analyst+aggregator output and
+        # predates the QUA-68 ContextFilter. Disable the filter here so
+        # this test still measures only the signal-level path it was
+        # designed to lock down.
+        context_filter_enabled=False,
     )
 
 


### PR DESCRIPTION
## Summary
- New `ContextFilter` (`src/brooks/decision/context_filter.py`) sits between the SignalAggregator and the EV gate in `BrooksStrategy`. It enforces Brooks' "background → signal" principle: a signal must be permitted by the current regime + structure before it can be traded.
- Schema extensions: `Signal.pattern_type` (auto-populated from a detector→category map), `BarEvent.failed_signals`, `BarEvent.background` (`BackgroundSummary` with `regime / leg_dir / in_trading_range / swing_age_bars / pattern_types / allow / reason`).
- Strategy wiring: per-bar reset of `_last_failed_signals` / `_last_context_decision`; runtime BarEvent builder now emits `failed_signals` + `background`. New `context_filter_enabled` / `context_filter_params` strategy params (default-on).

## Filter rules (defaults, all parametric)
- **Trends:** with-trend continuation only when `leg_dir` is the pullback leg; weak trends require non-pullback confluence; counter-trend in strong trends needs ≥2 reversal patterns; counter-trend in weak trends needs ≥1 reversal pattern.
- **Tight TR:** only failed-breakout fades or ≥2-pattern reversal confluence.
- **Broad TR:** reversals or breakout-pullback re-entries; naked breakouts blocked.
- **Breakout mode:** only `bp_*` re-entries with the breakout direction; counter-side needs an explicit failure pattern.
- **Climax:** continuation blocked, counter-climax reversal allowed.
- **Unknown:** reject all.
- **Structural guards:** stale-swing rejection (default >80 bars) and a micro-channel steepness check (default ≥1 ATR/bar) for steep-leg pullback chases.

## Measured trade-count reduction
Reproducible via `scripts/measure_context_filter_reduction.py`:
- 705-bar synthetic multi-regime: **24.2%** (91 → 69 entries).
- 600-bar pure-chop: **14.1%** (99 → 85 entries).

The ≥50% target from the issue is **not** met on these synthetic fixtures because the rule analyst frequently emits multi-pattern signals that satisfy the filter's "not pullback-only" requirement; further reduction would require raising the aggregator's `confluence_n`, which is out of scope for this task. Live sessions with sparser signal mixes are expected to see proportionally larger reductions.

## Backward compatibility
- `BarEvent` fields are Optional / default-empty; old timeline rows deserialize unchanged.
- `context_filter_enabled` defaults to True; the legacy v2 e2e test pins signal-level behavior and now opts out via `context_filter_enabled=False`.

## Test plan
- [x] `pytest tests/brooks/` — 464 passed (1 pre-existing failure unrelated to this PR is deselected: `test_factory_vlm_without_registration_raises`).
- [x] 31 new ContextFilter unit tests covering all 9 `BrooksRegime` states, leg-direction guards, micro-channel steepness, stale-swing rejection, dispatch coverage, `ContextDecision` serialization, and `Signal.pattern_type` auto-population.
- [x] `tests/brooks/test_strategy_e2e.py` — legacy v2 entry contract still pins (with `context_filter_enabled=False`).
- [x] Runtime BarEvent serialization smoke-tested via `tests/brooks/runtime/`.
- [ ] (Out of scope, tracked in QUA-68 sub-tasks B + C) Studio frontend rendering of `failed_signals` / `background`; full historical replay comparison report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)