### PR TITLE
feat(studio): Brooks-style annotations + pattern shapes (QUA-69)

### DIFF
--- a/ui/src/features/studio/__tests__/annotationsLayer.test.ts
+++ b/ui/src/features/studio/__tests__/annotationsLayer.test.ts
@@ -20,60 +20,67 @@ import {
   brooksShorthand,
   buildAnnotationMarkers,
   buildAnnotations,
+  categoryOf,
+  strongPatternSignal,
 } from '../layers/annotations';
 import { makeLayerCtx } from './mockChart';
-import { makeDecision, makeSignal, makeTimeline } from './fixtures';
+import { makeSignal, makeTimeline } from './fixtures';
 
-describe('annotations layer', () => {
-  it('maps known patterns to Brooks shorthand', () => {
+describe('annotations layer (Brooks-style sparse markers)', () => {
+  it('keeps the brooks shorthand helper for tooltips / sidebar', () => {
     expect(brooksShorthand('high_2')).toBe('H2');
-    expect(brooksShorthand('low_1')).toBe('L1');
-    expect(brooksShorthand('major_trend_reversal')).toBe('MTR');
-    expect(brooksShorthand('failed_breakout')).toBe('FF');
     expect(brooksShorthand('Wedge')).toBe('Wdg');
-  });
-
-  it('falls back to first-letter compaction for unknown patterns', () => {
     expect(brooksShorthand('flag_pole_rally')).toBe('FPR');
     expect(brooksShorthand(null)).toBe('?');
   });
 
-  it('emits at most one annotation per bar — fill > decision > signal', () => {
-    const tl = makeTimeline(4);
-    // bar 0: signal only → signal
-    tl.events[0].signals = [makeSignal({ id: 's0', pattern: 'h2', side: 'long' })];
-    // bar 1: decision + signal → decision wins
-    tl.events[1].decision = makeDecision({ pattern: 'BO', side: 'long' });
-    tl.events[1].signals = [makeSignal({ id: 's1', pattern: 'h1', side: 'long' })];
-    // bar 2: fill + decision → fill wins
-    tl.events[2].decision = makeDecision({ pattern: 'L2', side: 'short' });
-    tl.events[2].fill = { side: 'buy', qty: 1, price: 101.5, reason: 'entry' };
+  it('reads pattern_type from signals, falling back to detector name', () => {
+    expect(categoryOf(makeSignal({ id: 'a', pattern_type: 'wedge' }))).toBe('wedge');
+    expect(categoryOf(makeSignal({ id: 'b', pattern: 'wedge_long' }))).toBe('wedge');
+    expect(categoryOf(makeSignal({ id: 'c', pattern: 'h2' }))).toBe('');
+    expect(categoryOf(null)).toBe('');
+  });
 
-    const out = buildAnnotations(tl, 3);
+  it('only surfaces strong reversal patterns on the chart', () => {
+    expect(strongPatternSignal([makeSignal({ id: 'a', pattern: 'h2' })])).toBeNull();
+    expect(
+      strongPatternSignal([
+        makeSignal({ id: 'a', pattern: 'h2' }),
+        makeSignal({ id: 'b', pattern_type: 'double_top', side: 'short' }),
+      ]),
+    ).toMatchObject({ id: 'b' });
+  });
+
+  it('emits one annotation per bar — fill > pattern label > failed signal', () => {
+    const tl = makeTimeline(5);
+    // bar 0: fill wins everything
+    tl.events[0].fill = { side: 'buy', qty: 1, price: 101.5, reason: 'entry' };
+    tl.events[0].signals = [makeSignal({ id: 'sw', pattern_type: 'wedge', side: 'long' })];
+    tl.events[0].failed_signals = [makeSignal({ id: 'fs', pattern: 'h2' })];
+    // bar 1: strong pattern (double_top), no fill
+    tl.events[1].signals = [
+      makeSignal({ id: 's1', pattern_type: 'double_top', side: 'short' }),
+    ];
+    // bar 2: failed signal only — red dot
+    tl.events[2].failed_signals = [makeSignal({ id: 's2', pattern: 'h2', side: 'long' })];
+    tl.events[2].background = { in_trading_range: false, allow: false, reason: 'tight TR' };
+    // bar 3: only weak signals (h1) → nothing on chart
+    tl.events[3].signals = [makeSignal({ id: 's3', pattern: 'h1', side: 'long' })];
+    // bar 4: no events at all → nothing
+
+    const out = buildAnnotations(tl, 4);
     expect(out.length).toBe(3);
-    expect(out[0]).toMatchObject({ bar_idx: 0, kind: 'signal', text: 'H2' });
-    expect(out[1]).toMatchObject({ bar_idx: 1, kind: 'decision', text: 'BO' });
-    expect(out[2]).toMatchObject({ bar_idx: 2, kind: 'fill' });
-    expect(out[2].text).toContain('101.50');
+    expect(out[0]).toMatchObject({ bar_idx: 0, kind: 'fill', text: '' });
+    expect(out[1]).toMatchObject({ bar_idx: 1, kind: 'pattern', text: 'Double top' });
+    expect(out[2]).toMatchObject({ bar_idx: 2, kind: 'failed_signal', text: '' });
+    expect(out[2].title).toContain('tight TR');
   });
 
   it('hides annotations from future bars (no info leak)', () => {
     const tl = makeTimeline(5);
-    tl.events[3].decision = makeDecision({ pattern: 'BO' });
+    tl.events[3].signals = [makeSignal({ id: 'a', pattern_type: 'wedge', side: 'long' })];
     expect(buildAnnotations(tl, 2).length).toBe(0);
     expect(buildAnnotations(tl, 3).length).toBe(1);
-  });
-
-  it('picks the strongest signal when a bar has many', () => {
-    const tl = makeTimeline(2);
-    tl.events[1].signals = [
-      makeSignal({ id: 'a', pattern: 'h1', side: 'long' }),
-      makeSignal({ id: 'b', pattern: 'mtr', side: 'long' }),
-      makeSignal({ id: 'c', pattern: 'h2', side: 'long' }),
-    ];
-    const out = buildAnnotations(tl, 1);
-    expect(out.length).toBe(1);
-    expect(out[0].text).toBe('MTR');
   });
 
   it('positions long fills below the bar and shorts/sells above', () => {
@@ -87,14 +94,28 @@ describe('annotations layer', () => {
     expect(out[1].shape).toBe('arrowDown');
   });
 
+  it('drops H1/L2 shorthand spam — only fills, strong patterns, failed dots', () => {
+    const tl = makeTimeline(2);
+    tl.events[0].signals = [
+      makeSignal({ id: 'a', pattern: 'h1', side: 'long' }),
+      makeSignal({ id: 'b', pattern: 'h2', side: 'long' }),
+      makeSignal({ id: 'c', pattern: 'l2', side: 'short' }),
+    ];
+    expect(buildAnnotations(tl, 1).length).toBe(0);
+  });
+
   it('builds chart markers with stable IDs and sorted time', () => {
     const tl = makeTimeline(3);
-    tl.events[2].decision = makeDecision({ pattern: 'BO' });
-    tl.events[1].decision = makeDecision({ pattern: 'L2', side: 'short' });
+    tl.events[2].signals = [
+      makeSignal({ id: 'a', pattern_type: 'wedge', side: 'long' }),
+    ];
+    tl.events[1].signals = [
+      makeSignal({ id: 'b', pattern_type: 'double_bottom', side: 'long' }),
+    ];
     const markers = buildAnnotationMarkers(tl, 2);
     expect(markers.length).toBe(2);
-    expect(markers[0].id).toBe('ann-1-decision');
-    expect(markers[1].id).toBe('ann-2-decision');
+    expect(markers[0].id).toBe('ann-1-pattern');
+    expect(markers[1].id).toBe('ann-2-pattern');
     expect(markers[0].time).toBeLessThan(markers[1].time as number);
   });
 
@@ -102,7 +123,7 @@ describe('annotations layer', () => {
     const { ctx } = makeLayerCtx();
     const handle = annotationsLayer.mount(ctx);
     const tl = makeTimeline(2);
-    tl.events[1].decision = makeDecision({ pattern: 'BO' });
+    tl.events[1].signals = [makeSignal({ id: 'a', pattern_type: 'wedge', side: 'long' })];
     handle.update(tl, 1);
     const lastMarkers = [...markersByPlugin.values()].pop() as unknown[];
     expect(lastMarkers.length).toBe(1);

--- a/ui/src/features/studio/__tests__/patternShapesLayer.test.ts
+++ b/ui/src/features/studio/__tests__/patternShapesLayer.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const markersByPlugin = new Map<unknown, unknown[]>();
+const detached: unknown[] = [];
+
+vi.mock('lightweight-charts', () => ({
+  LineSeries: { type: 'Line' },
+  LineStyle: { Solid: 0, Dotted: 1, Dashed: 2 },
+  createSeriesMarkers: vi.fn((series: unknown, initial: unknown[] = []) => {
+    const handle = {
+      _series: series,
+      setMarkers: vi.fn((m: unknown[]) => markersByPlugin.set(handle, m)),
+      detach: vi.fn(() => detached.push(handle)),
+    };
+    markersByPlugin.set(handle, initial);
+    return handle;
+  }),
+}));
+
+import {
+  buildPatternShapeMarkers,
+  buildTradingRangeBoundaries,
+  buildWedgeLine,
+  computeTradingRangeRegions,
+  computeWedgeRegions,
+  patternShapesLayer,
+} from '../layers/pattern_shapes';
+import { makeLayerCtx } from './mockChart';
+import { makeSignal, makeTimeline } from './fixtures';
+
+describe('pattern_shapes layer — trading range', () => {
+  it('groups consecutive in_trading_range bars into a single region', () => {
+    const tl = makeTimeline(6);
+    for (let i = 1; i <= 4; i++) {
+      tl.events[i].background = { in_trading_range: true };
+    }
+    const regions = computeTradingRangeRegions(tl, 5);
+    expect(regions.length).toBe(1);
+    expect(regions[0]).toMatchObject({ from_bar: 1, to_bar: 4 });
+    // top = max(high) over bars 1..4 = bars[i].high = 102..105 → 105
+    expect(regions[0].top).toBe(105);
+    // bottom = min(low) over bars 1..4 = 100..103 → 100
+    expect(regions[0].bottom).toBe(100);
+  });
+
+  it('splits non-contiguous trading-range runs into multiple regions', () => {
+    const tl = makeTimeline(8);
+    tl.events[1].background = { in_trading_range: true };
+    tl.events[2].background = { in_trading_range: true };
+    tl.events[5].background = { in_trading_range: true };
+    tl.events[6].background = { in_trading_range: true };
+    const regions = computeTradingRangeRegions(tl, 7);
+    expect(regions.map((r) => [r.from_bar, r.to_bar])).toEqual([
+      [1, 2],
+      [5, 6],
+    ]);
+  });
+
+  it('clamps the trailing region to currentBarIdx', () => {
+    const tl = makeTimeline(6);
+    for (let i = 1; i <= 5; i++) tl.events[i].background = { in_trading_range: true };
+    const regions = computeTradingRangeRegions(tl, 3);
+    expect(regions.length).toBe(1);
+    expect(regions[0].to_bar).toBe(3);
+  });
+
+  it('builds 2-point line data per region for top / bottom boundaries', () => {
+    const tl = makeTimeline(5);
+    tl.events[1].background = { in_trading_range: true };
+    tl.events[2].background = { in_trading_range: true };
+    tl.events[3].background = { in_trading_range: true };
+    const regions = computeTradingRangeRegions(tl, 4);
+    const top = buildTradingRangeBoundaries(tl, regions, 'top');
+    const bot = buildTradingRangeBoundaries(tl, regions, 'bottom');
+    expect(top.length).toBe(2);
+    expect(bot.length).toBe(2);
+    expect(top[0].value).toBe(top[1].value);
+    expect(bot[0].value).toBe(bot[1].value);
+    expect(top[0].value).toBeGreaterThan(bot[0].value);
+  });
+});
+
+describe('pattern_shapes layer — wedge', () => {
+  it('extracts wedge regions from signals carrying p1_idx metadata', () => {
+    const tl = makeTimeline(12);
+    tl.events[10].signals = [
+      makeSignal({
+        id: 'w',
+        pattern: 'wedge_long',
+        pattern_type: 'wedge',
+        side: 'long',
+        meta: { p1_idx: 2, p2_idx: 5, p3_idx: 8 },
+      }),
+    ];
+    const regions = computeWedgeRegions(tl, 11);
+    expect(regions.length).toBe(1);
+    expect(regions[0]).toMatchObject({
+      signal_bar: 10,
+      start_bar: 2,
+      side: 'long',
+    });
+    expect(regions[0].top_start).toBeGreaterThanOrEqual(regions[0].bottom_start);
+    expect(regions[0].top_end).toBeGreaterThanOrEqual(regions[0].bottom_end);
+  });
+
+  it('falls back to a 12-bar lookback when p1_idx is missing', () => {
+    const tl = makeTimeline(20);
+    tl.events[15].signals = [
+      makeSignal({ id: 'w', pattern_type: 'wedge', side: 'short' }),
+    ];
+    const regions = computeWedgeRegions(tl, 19);
+    expect(regions.length).toBe(1);
+    expect(regions[0].start_bar).toBe(3);
+    expect(regions[0].side).toBe('short');
+  });
+
+  it('skips wedge signals whose bar is past currentBarIdx', () => {
+    const tl = makeTimeline(20);
+    tl.events[18].signals = [
+      makeSignal({
+        id: 'w',
+        pattern_type: 'wedge',
+        side: 'long',
+        meta: { p1_idx: 8 },
+      }),
+    ];
+    expect(computeWedgeRegions(tl, 12).length).toBe(0);
+    expect(computeWedgeRegions(tl, 18).length).toBe(1);
+  });
+
+  it('skips non-wedge signals', () => {
+    const tl = makeTimeline(10);
+    tl.events[5].signals = [
+      makeSignal({ id: 's', pattern_type: 'pullback', side: 'long' }),
+    ];
+    expect(computeWedgeRegions(tl, 9).length).toBe(0);
+  });
+
+  it('buildWedgeLine emits 2 points per region for top / bottom', () => {
+    const tl = makeTimeline(20);
+    tl.events[15].signals = [
+      makeSignal({
+        id: 'w',
+        pattern_type: 'wedge',
+        side: 'long',
+        meta: { p1_idx: 5 },
+      }),
+    ];
+    const regions = computeWedgeRegions(tl, 19);
+    const top = buildWedgeLine(tl, regions, 'top');
+    const bot = buildWedgeLine(tl, regions, 'bottom');
+    expect(top.length).toBe(2);
+    expect(bot.length).toBe(2);
+    expect((top[1].time as number) > (top[0].time as number)).toBe(true);
+  });
+});
+
+describe('pattern_shapes layer — markers + lifecycle', () => {
+  it('builds one TR / Wedge label marker per region', () => {
+    const tl = makeTimeline(10);
+    tl.events[1].background = { in_trading_range: true };
+    tl.events[2].background = { in_trading_range: true };
+    tl.events[5].signals = [
+      makeSignal({
+        id: 'w',
+        pattern_type: 'wedge',
+        side: 'long',
+        meta: { p1_idx: 0 },
+      }),
+    ];
+    const ranges = computeTradingRangeRegions(tl, 9);
+    const wedges = computeWedgeRegions(tl, 9);
+    const markers = buildPatternShapeMarkers(tl, ranges, wedges);
+    expect(markers.length).toBe(2);
+    const texts = markers.map((m) => m.text);
+    expect(texts).toContain('Trading range');
+    expect(texts).toContain('Wedge');
+  });
+
+  it('mounts series + marker plugin and pushes data on update', () => {
+    const { ctx, chart } = makeLayerCtx();
+    const handle = patternShapesLayer.mount(ctx);
+    // 6 LineSeries — TR top/bot + 4 wedge sides (long top/bot + short top/bot)
+    expect(chart.added.length).toBe(6);
+
+    const tl = makeTimeline(10);
+    tl.events[2].background = { in_trading_range: true };
+    tl.events[3].background = { in_trading_range: true };
+    tl.events[8].signals = [
+      makeSignal({
+        id: 'w',
+        pattern_type: 'wedge',
+        side: 'long',
+        meta: { p1_idx: 4 },
+      }),
+    ];
+    handle.update(tl, 9);
+    expect(chart.added[0].data.length).toBe(2); // TR top
+    expect(chart.added[1].data.length).toBe(2); // TR bot
+    expect(chart.added[2].data.length).toBe(2); // wedge long top
+    expect(chart.added[3].data.length).toBe(2); // wedge long bot
+    // No short wedges in this fixture.
+    expect(chart.added[4].data.length).toBe(0);
+    expect(chart.added[5].data.length).toBe(0);
+
+    handle.unmount();
+    expect(chart.removed.length).toBe(6);
+    expect(detached.length).toBeGreaterThan(0);
+  });
+});

--- a/ui/src/features/studio/__tests__/registry.test.ts
+++ b/ui/src/features/studio/__tests__/registry.test.ts
@@ -20,6 +20,7 @@ describe('layer registry', () => {
       'ema20',
       'ema200',
       'annotations',
+      'pattern_shapes',
       'trades',
       'signals',
       'decisions',
@@ -33,6 +34,7 @@ describe('layer registry', () => {
 
   it('default-visible favours the aggregated annotations layer over raw fills', () => {
     expect(DEFAULT_VISIBLE.has('annotations')).toBe(true);
+    expect(DEFAULT_VISIBLE.has('pattern_shapes')).toBe(true);
     expect(DEFAULT_VISIBLE.has('trades')).toBe(true);
     expect(DEFAULT_VISIBLE.has('fills')).toBe(false);
     expect(DEFAULT_VISIBLE.has('ema200')).toBe(false);

--- a/ui/src/features/studio/layers/annotations.ts
+++ b/ui/src/features/studio/layers/annotations.ts
@@ -1,20 +1,21 @@
 /**
- * Annotations layer — Al Brooks-style sparse labels, one per bar.
+ * Annotations layer — Al Brooks-style sparse markers, one per bar.
  *
- * The legacy stack of layers (signals + decisions + fills + reasoning) each
- * pushed their own marker on the same bar, producing a wall of overlapping
- * text. This layer collapses every event into at most one short, bar-anchored
- * label using Brooks shorthand (H1/H2/L1/L2/MTR/BO/ii/FF/M2B/MM/…).
+ * Driven by the backend schema introduced in QUA-68:
+ *   - `BarEvent.fill`             → entry arrow (green ↑ / red ↓)
+ *   - `BarEvent.signals[].pattern_type` → strong-pattern text label
+ *                                  ("Wedge", "Double top", …)
+ *   - `BarEvent.failed_signals`   → red dot (signal that ContextFilter
+ *                                  rejected; never traded)
  *
- * Priority when a single bar carries multiple kinds of event:
- *   fill > decision > top-priority signal
+ * Priority when several apply on the same bar: **fill > pattern label >
+ * failed-signal dot**. Anything not in that priority list (every H1/L2/MTR
+ * shorthand the legacy layer used to spam) is intentionally dropped from
+ * the chart — those still show up in the tooltip / SignalSidebar so the
+ * structure is recoverable on demand.
  *
- * The full per-bar detail (all signals, full reasoning) is still available in
- * the side panel; here we deliberately keep the chart sparse so the user can
- * read structure at a glance, then drill in.
- *
- * Future-info safety: bars with `bar_idx > currentBarIdx` are dropped before
- * label construction, so scrubbing back hides them.
+ * Future-info safety: bars with `bar_idx > currentBarIdx` are skipped, so
+ * scrubbing back hides them.
  */
 
 import {
@@ -38,13 +39,50 @@ import type { BarEvent, FillView, SessionTimeline, Signal } from '../types';
 
 const LONG_COLOR = '#26A69A';
 const SHORT_COLOR = '#EF5350';
-const SIGNAL_NEUTRAL = '#90A4AE';
+const FAILED_DOT_COLOR = '#EF5350';
 const FILL_BUY_COLOR = '#26A69A';
 const FILL_SELL_COLOR = '#EF5350';
 
 /**
- * Brooks shorthand — keep these short (≤4 chars) so they don't crowd the
- * chart. Anything missing falls through to the raw `pattern` text.
+ * Pattern categories worth a verbose chart label. Anything not listed here
+ * (pullbacks, breakouts, micro-channels, generic "unknown") stays out of
+ * the chart text — Brooks notes only foreground the strong reversals /
+ * failed breakouts that mark a structural turn.
+ */
+const PATTERN_LABEL: Record<string, string> = {
+  wedge: 'Wedge',
+  double_top: 'Double top',
+  double_bottom: 'Double bottom',
+  mtr: 'MTR',
+  final_flag: 'Final flag',
+  failed_breakout: 'Failed BO',
+};
+
+/**
+ * Detector-name → category fallback for older replays that pre-date the
+ * server-side ``pattern_type`` field. Keeping this list narrow; legacy
+ * shorthand (h2/l1/mtr_long…) maps onto the same six categories the Brooks
+ * `PATTERN_TYPE_MAP` uses.
+ */
+const PATTERN_NAME_FALLBACK: Record<string, string> = {
+  wedge: 'wedge',
+  wedge_long: 'wedge',
+  wedge_short: 'wedge',
+  double_top: 'double_top',
+  double_bottom: 'double_bottom',
+  mtr: 'mtr',
+  mtr_long: 'mtr',
+  mtr_short: 'mtr',
+  major_trend_reversal: 'mtr',
+  final_flag: 'final_flag',
+  failed_breakout: 'failed_breakout',
+  ff: 'failed_breakout',
+};
+
+/**
+ * Brooks shorthand — kept exported for tooltips / SidePanel use; the chart
+ * itself no longer uses these as default text. Anything missing falls back
+ * to the first-letter compaction of the raw pattern name.
  */
 const BROOKS_SHORTHAND: Record<string, string> = {
   high_1: 'H1',
@@ -82,43 +120,10 @@ const BROOKS_SHORTHAND: Record<string, string> = {
   pullback: 'PB',
 };
 
-/**
- * Built-in priority ordering when a bar has multiple raw signals — Brooks
- * traders care about MTR/BO over H1/L1, so we surface the strongest one and
- * drop the rest into the inspector.
- */
-const SIGNAL_PRIORITY = new Map<string, number>([
-  ['mtr', 100],
-  ['major_trend_reversal', 100],
-  ['bo', 90],
-  ['breakout', 90],
-  ['failed_breakout', 85],
-  ['ff', 85],
-  ['m2b', 80],
-  ['m2t', 80],
-  ['micro_double_bottom', 80],
-  ['micro_double_top', 80],
-  ['mm', 75],
-  ['measured_move', 75],
-  ['wedge', 70],
-  ['ii', 60],
-  ['ioi', 60],
-  ['inside_inside', 60],
-  ['h2', 50],
-  ['l2', 50],
-  ['high_2', 50],
-  ['low_2', 50],
-  ['h1', 30],
-  ['l1', 30],
-  ['high_1', 30],
-  ['low_1', 30],
-]);
-
 export function brooksShorthand(pattern: string | undefined | null): string {
   if (!pattern) return '?';
   const key = pattern.toLowerCase().replace(/[\s-]+/g, '_');
   if (BROOKS_SHORTHAND[key]) return BROOKS_SHORTHAND[key];
-  // Fallback: take the first letter of each `_`-separated chunk, uppercased.
   const compact = key
     .split('_')
     .map((chunk) => chunk.charAt(0).toUpperCase())
@@ -126,19 +131,29 @@ export function brooksShorthand(pattern: string | undefined | null): string {
   return compact.slice(0, 4) || pattern.slice(0, 4);
 }
 
-function topSignal(signals: Signal[] | undefined): Signal | null {
+/**
+ * Resolve a signal's category. Prefers the server-provided
+ * `pattern_type` (populated since QUA-68) and falls back to the detector
+ * name for older replays.
+ */
+export function categoryOf(sig: Signal | undefined | null): string {
+  if (!sig) return '';
+  const explicit = (sig.pattern_type ?? '').toString().toLowerCase();
+  if (explicit) return explicit;
+  const name = (sig.pattern ?? '').toLowerCase().replace(/[\s-]+/g, '_');
+  return PATTERN_NAME_FALLBACK[name] ?? '';
+}
+
+/**
+ * Pick the strong-reversal signal worth foregrounding. The detector list
+ * is small, so a linear scan is fine even on the busiest bars.
+ */
+export function strongPatternSignal(signals: Signal[] | undefined): Signal | null {
   if (!signals || signals.length === 0) return null;
-  let best: Signal | null = null;
-  let bestScore = -1;
   for (const s of signals) {
-    const key = (s.pattern ?? '').toLowerCase().replace(/[\s-]+/g, '_');
-    const score = SIGNAL_PRIORITY.get(key) ?? 10;
-    if (score > bestScore) {
-      bestScore = score;
-      best = s;
-    }
+    if (PATTERN_LABEL[categoryOf(s)]) return s;
   }
-  return best;
+  return null;
 }
 
 function fillSideColor(side: FillView['side']): string {
@@ -150,14 +165,16 @@ function isBuySide(side: FillView['side']): boolean {
   return side === 'buy' || side === 'buy_to_cover';
 }
 
+export type AnnotationKind = 'fill' | 'pattern' | 'failed_signal';
+
 export interface BarAnnotation {
   bar_idx: number;
   text: string;
   color: string;
   position: BarMarkerPosition;
   shape: SeriesMarkerShape;
-  /** Coarse classification for the inspector. */
-  kind: 'fill' | 'decision' | 'signal';
+  size: number;
+  kind: AnnotationKind;
   /** Title — full pattern name for the marker tooltip / a11y. */
   title: string;
 }
@@ -169,8 +186,10 @@ function timeForBar(timeline: SessionTimeline, idx: number): UTCTimestamp | null
 }
 
 /**
- * Build at most one annotation per bar. Priority: fill > decision > top
- * signal. Fills get a ▲/▼ arrow; decisions a smaller arrow; signals a circle.
+ * Build at most one annotation per bar. Priority:
+ *   1. fill           — entry arrow, no text
+ *   2. pattern label  — strong-pattern text (Wedge / Double top / …)
+ *   3. failed signal  — red dot
  */
 export function buildAnnotations(
   timeline: SessionTimeline,
@@ -185,48 +204,54 @@ export function buildAnnotations(
   return out;
 }
 
-function annotationForEvent(ev: BarEvent): BarAnnotation | null {
+export function annotationForEvent(ev: BarEvent): BarAnnotation | null {
   if (ev.fill) {
     const buy = isBuySide(ev.fill.side);
-    const tag = ev.fill.reason ? ev.fill.reason.toUpperCase().slice(0, 4) : (buy ? 'BUY' : 'SLL');
     return {
       bar_idx: ev.bar_idx,
-      text: `${tag} ${ev.fill.price.toFixed(2)}`,
+      text: '',
       color: fillSideColor(ev.fill.side),
       position: buy ? 'belowBar' : 'aboveBar',
       shape: buy ? 'arrowUp' : 'arrowDown',
+      size: 2,
       kind: 'fill',
       title: `${ev.fill.side} @${ev.fill.price.toFixed(2)} (${ev.fill.reason || 'fill'})`,
     };
   }
-  if (ev.decision) {
-    const tag = brooksShorthand(ev.decision.pattern);
-    const arrow = ev.decision.side === 'long' ? 'arrowUp' : 'arrowDown';
+
+  const strong = strongPatternSignal(ev.signals);
+  if (strong) {
+    const cat = categoryOf(strong);
+    const label = PATTERN_LABEL[cat] ?? brooksShorthand(strong.pattern);
+    const long = strong.side === 'long';
     return {
       bar_idx: ev.bar_idx,
-      text: tag,
-      color: ev.decision.side === 'long' ? LONG_COLOR : SHORT_COLOR,
-      position: ev.decision.side === 'long' ? 'belowBar' : 'aboveBar',
-      shape: arrow,
-      kind: 'decision',
-      title: `${ev.decision.side} ${ev.decision.pattern} → ${ev.decision.entry_px}`,
+      text: label,
+      color: long ? LONG_COLOR : SHORT_COLOR,
+      position: long ? 'belowBar' : 'aboveBar',
+      shape: long ? 'arrowUp' : 'arrowDown',
+      size: 1,
+      kind: 'pattern',
+      title: `${label}${strong.side ? ` (${strong.side})` : ''}`,
     };
   }
-  const sig = topSignal(ev.signals);
-  if (sig) {
-    const tag = brooksShorthand(sig.pattern);
-    const color =
-      sig.side === 'long' ? LONG_COLOR : sig.side === 'short' ? SHORT_COLOR : SIGNAL_NEUTRAL;
+
+  const failed = ev.failed_signals && ev.failed_signals[0];
+  if (failed) {
+    const reason = ev.background?.reason ?? '';
+    const labelTitle = failed.pattern ?? 'signal';
     return {
       bar_idx: ev.bar_idx,
-      text: tag,
-      color,
-      position: sig.side === 'short' ? 'aboveBar' : 'belowBar',
+      text: '',
+      color: FAILED_DOT_COLOR,
+      position: failed.side === 'short' ? 'aboveBar' : 'belowBar',
       shape: 'circle',
-      kind: 'signal',
-      title: `${sig.pattern ?? 'signal'}${sig.side ? ` (${sig.side})` : ''}`,
+      size: 0,
+      kind: 'failed_signal',
+      title: reason ? `Failed: ${labelTitle} — ${reason}` : `Failed: ${labelTitle}`,
     };
   }
+
   return null;
 }
 
@@ -244,9 +269,7 @@ export function buildAnnotationMarkers(
       shape: ann.shape,
       color: ann.color,
       text: ann.text,
-      // Decisions/fills are size 1; signals are slightly smaller so the eye is
-      // drawn to actual entries first.
-      size: ann.kind === 'signal' ? 0 : 1,
+      size: ann.size,
       id: `ann-${ann.bar_idx}-${ann.kind}`,
     });
   }

--- a/ui/src/features/studio/layers/pattern_shapes.ts
+++ b/ui/src/features/studio/layers/pattern_shapes.ts
@@ -1,0 +1,432 @@
+/**
+ * Pattern shapes layer — multi-bar Brooks structures: ``Trading Range``
+ * rectangles and ``Wedge`` converging trendlines.
+ *
+ * Two shape kinds, each driven by data the backend already attaches to
+ * the timeline (no extra HTTP calls):
+ *
+ * Trading Range
+ *   Contiguous runs of bars where ``BarEvent.background.in_trading_range``
+ *   is ``true`` form one rectangle. Top / bottom are the running max-high
+ *   and min-low across the run, so the rectangle hugs the actual price
+ *   action. The rectangle is rendered as two solid boundary
+ *   ``LineSeries`` lines plus a small "TR" marker at its start — the
+ *   lightweight-charts v5 line API can paint a translucent boundary, and
+ *   leaving the interior unfilled keeps the candles legible.
+ *
+ * Wedge
+ *   Each ``Signal`` whose ``pattern_type === 'wedge'`` carries
+ *   ``meta.p1_idx`` / ``p2_idx`` / ``p3_idx`` — the three pivot bar
+ *   indices the detector found. We draw two converging trendlines from
+ *   ``p1_idx`` to the signal bar by connecting endpoint highs and lows.
+ *   That's not a perfect geometric fit but it puts the wedge in the
+ *   right place and lets the user see "the lines are squeezing toward
+ *   the breakout bar", which is the important Brooks read.
+ *
+ * Future-info safety: every helper clamps to ``currentBarIdx`` so a
+ * scrub-back hides shapes that haven't formed yet.
+ */
+
+import {
+  LineSeries,
+  LineStyle,
+  createSeriesMarkers,
+  type ISeriesApi,
+  type ISeriesMarkersPluginApi,
+  type LineData,
+  type SeriesMarker,
+  type Time,
+  type UTCTimestamp,
+} from 'lightweight-charts';
+import type { ChartLayer, LayerCtx, LayerHandle } from './types';
+import type { BarEvent, SessionTimeline, Signal } from '../types';
+
+const RANGE_TOP_COLOR = 'rgba(180, 180, 180, 0.9)';
+const RANGE_BOT_COLOR = 'rgba(180, 180, 180, 0.9)';
+const RANGE_LABEL_COLOR = '#9CA3AF';
+const WEDGE_LONG_COLOR = 'rgba(38, 166, 154, 0.9)';
+const WEDGE_SHORT_COLOR = 'rgba(239, 83, 80, 0.9)';
+const WEDGE_LABEL_COLOR_LONG = '#26A69A';
+const WEDGE_LABEL_COLOR_SHORT = '#EF5350';
+
+export interface TradingRangeRegion {
+  from_bar: number;
+  to_bar: number;
+  top: number;
+  bottom: number;
+}
+
+export interface WedgeRegion {
+  signal_bar: number;
+  start_bar: number;
+  side: 'long' | 'short';
+  top_start: number;
+  top_end: number;
+  bottom_start: number;
+  bottom_end: number;
+}
+
+function timeForBar(timeline: SessionTimeline, idx: number): UTCTimestamp | null {
+  const bar = timeline.bars[idx];
+  if (!bar) return null;
+  return Math.floor(bar.timestamp_ns / 1_000_000_000) as UTCTimestamp;
+}
+
+function clampedEnd(timeline: SessionTimeline, currentBarIdx: number): number {
+  return Math.min(currentBarIdx, timeline.bars.length - 1);
+}
+
+/**
+ * Walk events in-order. A trading-range region is a maximal run of
+ * consecutive events flagged ``in_trading_range``. Bars without an event
+ * (e.g. the warm-up window) break the run.
+ */
+export function computeTradingRangeRegions(
+  timeline: SessionTimeline,
+  currentBarIdx: number,
+): TradingRangeRegion[] {
+  const out: TradingRangeRegion[] = [];
+  const end = clampedEnd(timeline, currentBarIdx);
+  if (end < 0) return out;
+
+  let runStart: number | null = null;
+  let runEnd = -1;
+
+  const closeRun = () => {
+    if (runStart === null) return;
+    const region = bandFromBars(timeline, runStart, runEnd);
+    if (region) out.push(region);
+    runStart = null;
+    runEnd = -1;
+  };
+
+  for (const ev of timeline.events) {
+    if (ev.bar_idx > end) break;
+    const inTR = ev.background?.in_trading_range === true;
+    if (inTR) {
+      if (runStart === null) {
+        runStart = ev.bar_idx;
+      } else if (ev.bar_idx !== runEnd + 1) {
+        // Gap in events — close the prior run, start a new one.
+        closeRun();
+        runStart = ev.bar_idx;
+      }
+      runEnd = ev.bar_idx;
+    } else {
+      closeRun();
+    }
+  }
+  closeRun();
+  return out;
+}
+
+function bandFromBars(
+  timeline: SessionTimeline,
+  from: number,
+  to: number,
+): TradingRangeRegion | null {
+  if (to < from) return null;
+  let top = -Infinity;
+  let bottom = Infinity;
+  for (let i = from; i <= to; i++) {
+    const bar = timeline.bars[i];
+    if (!bar) continue;
+    if (bar.high > top) top = bar.high;
+    if (bar.low < bottom) bottom = bar.low;
+  }
+  if (!Number.isFinite(top) || !Number.isFinite(bottom)) return null;
+  return { from_bar: from, to_bar: to, top, bottom };
+}
+
+function readMetaInt(sig: Signal, key: string): number | null {
+  const meta = (sig as { meta?: Record<string, unknown> }).meta;
+  if (!meta) return null;
+  const v = meta[key];
+  return typeof v === 'number' && Number.isFinite(v) ? Math.floor(v) : null;
+}
+
+/**
+ * Pull every wedge signal off the timeline and resolve its converging
+ * trendline endpoints. Signals that lack pivot metadata fall back to a
+ * fixed 12-bar lookback so the user still sees something.
+ */
+export function computeWedgeRegions(
+  timeline: SessionTimeline,
+  currentBarIdx: number,
+): WedgeRegion[] {
+  const end = clampedEnd(timeline, currentBarIdx);
+  if (end < 0) return [];
+  const out: WedgeRegion[] = [];
+  for (const ev of timeline.events) {
+    if (ev.bar_idx > end) break;
+    const sigs = ev.signals ?? [];
+    for (const sig of sigs) {
+      const ptype = (sig.pattern_type ?? '').toString().toLowerCase();
+      if (ptype !== 'wedge') continue;
+      const region = wedgeRegionFromSignal(timeline, ev, sig, end);
+      if (region) out.push(region);
+    }
+  }
+  return out;
+}
+
+function wedgeRegionFromSignal(
+  timeline: SessionTimeline,
+  ev: BarEvent,
+  sig: Signal,
+  end: number,
+): WedgeRegion | null {
+  const sigBar = Math.min(ev.bar_idx, end);
+  if (sigBar < 0 || sigBar >= timeline.bars.length) return null;
+
+  const p1 = readMetaInt(sig, 'p1_idx');
+  const fallbackStart = Math.max(0, sigBar - 12);
+  const start = p1 !== null && p1 >= 0 && p1 < sigBar ? p1 : fallbackStart;
+  if (start >= sigBar) return null;
+
+  const startBar = timeline.bars[start];
+  const endBar = timeline.bars[sigBar];
+  if (!startBar || !endBar) return null;
+
+  // Endpoint highs/lows = the sweep extremes within the early- and
+  // late-half of the wedge window. Splitting at the midpoint gives the
+  // converging-lines effect; using whole-window extremes would flatten
+  // both lines into horizontals.
+  const mid = Math.floor((start + sigBar) / 2);
+  const earlyHi = maxHighIn(timeline, start, mid);
+  const earlyLo = minLowIn(timeline, start, mid);
+  const lateHi = maxHighIn(timeline, mid + 1, sigBar);
+  const lateLo = minLowIn(timeline, mid + 1, sigBar);
+
+  return {
+    signal_bar: sigBar,
+    start_bar: start,
+    side: sig.side === 'short' ? 'short' : 'long',
+    top_start: earlyHi ?? startBar.high,
+    top_end: lateHi ?? endBar.high,
+    bottom_start: earlyLo ?? startBar.low,
+    bottom_end: lateLo ?? endBar.low,
+  };
+}
+
+function maxHighIn(timeline: SessionTimeline, from: number, to: number): number | null {
+  let v = -Infinity;
+  for (let i = from; i <= to; i++) {
+    const b = timeline.bars[i];
+    if (b && b.high > v) v = b.high;
+  }
+  return Number.isFinite(v) ? v : null;
+}
+
+function minLowIn(timeline: SessionTimeline, from: number, to: number): number | null {
+  let v = Infinity;
+  for (let i = from; i <= to; i++) {
+    const b = timeline.bars[i];
+    if (b && b.low < v) v = b.low;
+  }
+  return Number.isFinite(v) ? v : null;
+}
+
+export function buildTradingRangeBoundaries(
+  timeline: SessionTimeline,
+  regions: TradingRangeRegion[],
+  which: 'top' | 'bottom',
+): LineData<UTCTimestamp>[] {
+  const out: LineData<UTCTimestamp>[] = [];
+  for (const region of regions) {
+    const startT = timeForBar(timeline, region.from_bar);
+    const endT = timeForBar(timeline, region.to_bar);
+    if (startT === null || endT === null) continue;
+    const value = which === 'top' ? region.top : region.bottom;
+    out.push({ time: startT, value });
+    out.push({ time: endT, value });
+  }
+  // lightweight-charts requires strictly ascending time inside one
+  // LineSeries; if two regions touch at the same timestamp, drop the
+  // duplicate point.
+  out.sort((a, b) => (a.time as number) - (b.time as number));
+  return dedupeMonotonic(out);
+}
+
+export function buildWedgeLine(
+  timeline: SessionTimeline,
+  regions: WedgeRegion[],
+  which: 'top' | 'bottom',
+): LineData<UTCTimestamp>[] {
+  const out: LineData<UTCTimestamp>[] = [];
+  for (const region of regions) {
+    const startT = timeForBar(timeline, region.start_bar);
+    const endT = timeForBar(timeline, region.signal_bar);
+    if (startT === null || endT === null) continue;
+    const startVal = which === 'top' ? region.top_start : region.bottom_start;
+    const endVal = which === 'top' ? region.top_end : region.bottom_end;
+    out.push({ time: startT, value: startVal });
+    out.push({ time: endT, value: endVal });
+  }
+  out.sort((a, b) => (a.time as number) - (b.time as number));
+  return dedupeMonotonic(out);
+}
+
+function dedupeMonotonic(
+  data: LineData<UTCTimestamp>[],
+): LineData<UTCTimestamp>[] {
+  const out: LineData<UTCTimestamp>[] = [];
+  let lastT: number | null = null;
+  for (const point of data) {
+    const t = point.time as number;
+    if (lastT !== null && t === lastT) {
+      out[out.length - 1] = point;
+      continue;
+    }
+    out.push(point);
+    lastT = t;
+  }
+  return out;
+}
+
+export function buildPatternShapeMarkers(
+  timeline: SessionTimeline,
+  ranges: TradingRangeRegion[],
+  wedges: WedgeRegion[],
+): SeriesMarker<Time>[] {
+  const markers: SeriesMarker<Time>[] = [];
+
+  for (const region of ranges) {
+    const t = timeForBar(timeline, region.from_bar);
+    if (t === null) continue;
+    markers.push({
+      time: t as Time,
+      position: 'aboveBar',
+      shape: 'square',
+      color: RANGE_LABEL_COLOR,
+      text: 'Trading range',
+      size: 0,
+      id: `tr-${region.from_bar}-${region.to_bar}`,
+    });
+  }
+
+  for (const region of wedges) {
+    const t = timeForBar(timeline, region.signal_bar);
+    if (t === null) continue;
+    const long = region.side === 'long';
+    markers.push({
+      time: t as Time,
+      position: long ? 'belowBar' : 'aboveBar',
+      shape: 'square',
+      color: long ? WEDGE_LABEL_COLOR_LONG : WEDGE_LABEL_COLOR_SHORT,
+      text: 'Wedge',
+      size: 0,
+      id: `wedge-${region.signal_bar}-${region.start_bar}`,
+    });
+  }
+
+  markers.sort((a, b) => (a.time as number) - (b.time as number));
+  return markers;
+}
+
+export const patternShapesLayer: ChartLayer = {
+  id: 'pattern_shapes',
+  name: 'Pattern shapes',
+  swatch: RANGE_TOP_COLOR,
+  defaultVisible: true,
+
+  mount(ctx: LayerCtx): LayerHandle {
+    const { chart } = ctx;
+    const baseOpts = {
+      priceLineVisible: false,
+      lastValueVisible: false,
+      crosshairMarkerVisible: false,
+    } as const;
+
+    let rangeTop: ISeriesApi<'Line'> | null = chart.addSeries(LineSeries, {
+      ...baseOpts,
+      color: RANGE_TOP_COLOR,
+      lineWidth: 2,
+      lineStyle: LineStyle.Dashed,
+    });
+    let rangeBot: ISeriesApi<'Line'> | null = chart.addSeries(LineSeries, {
+      ...baseOpts,
+      color: RANGE_BOT_COLOR,
+      lineWidth: 2,
+      lineStyle: LineStyle.Dashed,
+    });
+    let wedgeTopLong: ISeriesApi<'Line'> | null = chart.addSeries(LineSeries, {
+      ...baseOpts,
+      color: WEDGE_LONG_COLOR,
+      lineWidth: 2,
+      lineStyle: LineStyle.Solid,
+    });
+    let wedgeBotLong: ISeriesApi<'Line'> | null = chart.addSeries(LineSeries, {
+      ...baseOpts,
+      color: WEDGE_LONG_COLOR,
+      lineWidth: 2,
+      lineStyle: LineStyle.Solid,
+    });
+    let wedgeTopShort: ISeriesApi<'Line'> | null = chart.addSeries(LineSeries, {
+      ...baseOpts,
+      color: WEDGE_SHORT_COLOR,
+      lineWidth: 2,
+      lineStyle: LineStyle.Solid,
+    });
+    let wedgeBotShort: ISeriesApi<'Line'> | null = chart.addSeries(LineSeries, {
+      ...baseOpts,
+      color: WEDGE_SHORT_COLOR,
+      lineWidth: 2,
+      lineStyle: LineStyle.Solid,
+    });
+    let labelPlugin: ISeriesMarkersPluginApi<Time> | null = createSeriesMarkers(
+      ctx.primarySeries,
+      [],
+    );
+
+    return {
+      update(timeline, currentBarIdx) {
+        if (
+          !rangeTop ||
+          !rangeBot ||
+          !wedgeTopLong ||
+          !wedgeBotLong ||
+          !wedgeTopShort ||
+          !wedgeBotShort
+        )
+          return;
+        const ranges = computeTradingRangeRegions(timeline, currentBarIdx);
+        const wedges = computeWedgeRegions(timeline, currentBarIdx);
+
+        rangeTop.setData(buildTradingRangeBoundaries(timeline, ranges, 'top'));
+        rangeBot.setData(buildTradingRangeBoundaries(timeline, ranges, 'bottom'));
+
+        const longWedges = wedges.filter((w) => w.side === 'long');
+        const shortWedges = wedges.filter((w) => w.side === 'short');
+        wedgeTopLong.setData(buildWedgeLine(timeline, longWedges, 'top'));
+        wedgeBotLong.setData(buildWedgeLine(timeline, longWedges, 'bottom'));
+        wedgeTopShort.setData(buildWedgeLine(timeline, shortWedges, 'top'));
+        wedgeBotShort.setData(buildWedgeLine(timeline, shortWedges, 'bottom'));
+
+        if (labelPlugin) {
+          labelPlugin.setMarkers(buildPatternShapeMarkers(timeline, ranges, wedges));
+        }
+      },
+      unmount() {
+        try {
+          if (rangeTop) chart.removeSeries(rangeTop);
+          if (rangeBot) chart.removeSeries(rangeBot);
+          if (wedgeTopLong) chart.removeSeries(wedgeTopLong);
+          if (wedgeBotLong) chart.removeSeries(wedgeBotLong);
+          if (wedgeTopShort) chart.removeSeries(wedgeTopShort);
+          if (wedgeBotShort) chart.removeSeries(wedgeBotShort);
+          labelPlugin?.detach();
+        } catch {
+          // chart already disposed
+        }
+        rangeTop = null;
+        rangeBot = null;
+        wedgeTopLong = null;
+        wedgeBotLong = null;
+        wedgeTopShort = null;
+        wedgeBotShort = null;
+        labelPlugin = null;
+      },
+    };
+  },
+};

--- a/ui/src/features/studio/layers/registry.ts
+++ b/ui/src/features/studio/layers/registry.ts
@@ -18,6 +18,7 @@ import { stopAdjLayer } from './stop_adj';
 import { htfOverlayLayer } from './htf_overlay';
 import { reasoningLayer } from './reasoning';
 import { annotationsLayer } from './annotations';
+import { patternShapesLayer } from './pattern_shapes';
 import { tradesLayer } from './trades';
 
 export const LAYERS: readonly ChartLayer[] = [
@@ -26,6 +27,7 @@ export const LAYERS: readonly ChartLayer[] = [
   ema20Layer,
   ema200Layer,
   annotationsLayer,
+  patternShapesLayer,
   tradesLayer,
   signalsLayer,
   decisionsLayer,

--- a/ui/src/features/studio/types.ts
+++ b/ui/src/features/studio/types.ts
@@ -57,11 +57,17 @@ export interface StructureView {
 /**
  * Loose mirror of `src.brooks.schema.Signal` — frontend treats it as
  * mostly opaque metadata for hover/inspector panels.
+ *
+ * `pattern_type` is the high-level Brooks category (`wedge`,
+ * `double_top`, `pullback`, …) populated server-side via
+ * `PATTERN_TYPE_MAP`. The chart picks visual treatment off this category
+ * rather than the raw detector name (`h2`, `wedge_long`, …).
  */
 export interface Signal {
   id?: string;
   bar_idx?: number;
   pattern?: string;
+  pattern_type?: string | null;
   side?: 'long' | 'short';
   source?: string;
   [key: string]: unknown;
@@ -102,6 +108,21 @@ export interface HTFView {
   last_swing_idx?: number | null;
 }
 
+/**
+ * Compact "what is the market doing now" summary attached to BarEvent —
+ * mirror of `src.api.schemas.brooks_studio.BackgroundSummary`. Produced
+ * by the ContextFilter when it accepts/rejects a bar's signals.
+ */
+export interface BackgroundSummary {
+  regime?: string | null;
+  leg_dir?: string | null;
+  in_trading_range?: boolean;
+  swing_age_bars?: number | null;
+  pattern_types?: string[];
+  allow?: boolean;
+  reason?: string;
+}
+
 export interface BarEvent {
   bar_idx: number;
   timestamp_ns: number;
@@ -109,11 +130,15 @@ export interface BarEvent {
   features?: FeaturesView | null;
   structure?: StructureView | null;
   signals?: Signal[];
+  /** Signals that the ContextFilter rejected — never traded but rendered
+   * on the chart as red dots for visual diagnosis. */
+  failed_signals?: Signal[];
   decision?: Decision | null;
   fill?: FillView | null;
   stop_adj?: StopAdj | null;
   pnl_r?: number | null;
   htf?: Record<string, HTFView>;
+  background?: BackgroundSummary | null;
 }
 
 export interface PnLPoint {


### PR DESCRIPTION
## Summary
- Rewrite `annotations.ts` priority to `fill > pattern label > failed signal dot`. Strong reversals (Wedge / Double top / Double bottom / MTR / Final flag / Failed BO) get text labels; H1/L2/MTR shorthand no longer clutters the chart (still in tooltip + SignalSidebar).
- New `pattern_shapes.ts` layer rendering multi-bar `Trading range` rectangles (boundary lines from contiguous `background.in_trading_range` runs) and `Wedge` converging trendlines anchored on the detector's `p1_idx` metadata.
- Extend `types.ts` to mirror the QUA-68 backend payload (`Signal.pattern_type`, `BarEvent.failed_signals`, `BarEvent.background` / `BackgroundSummary`).

## Test plan
- [x] `bun run test` — 153/153 pass (incl. 9 annotations + 11 new pattern_shapes cases)
- [x] `bunx eslint` clean for touched files
- [x] `tsc -b` clean for studio files (the 16 pre-existing errors are unrelated to this PR)
- [ ] Visual smoke test in `/studio` — verify wedge trendlines + TR rectangles render and toggle on/off via `LayerToggle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)