### PR TITLE
fix(brooks): relax ContextFilter BREAKOUT_MODE gate (QUA-71)

### DIFF
--- a/src/brooks/decision/context_filter.py
+++ b/src/brooks/decision/context_filter.py
@@ -21,7 +21,10 @@ The rules below intentionally err on the **conservative** side:
 * tight ranges reject every breakout follow-through; only reversals
   inside the range are allowed
 * broad ranges allow both edges to fade and trend-internal pullbacks
-* breakout mode allows the freshly-broken side's continuation only
+* breakout mode allows any with-breakout continuation pattern
+  (pullback / breakout / bp / measured_move / micro_channel) plus an
+  aligned reversal entry; counter-breakout signals require a reversal
+  package (failed_breakout / wedge / double / mtr / final_flag)
 * climax + unknown reject everything except strong counter-climax
   reversals (climax) or nothing at all (unknown)
 
@@ -477,30 +480,47 @@ class ContextFilter:
             or (always_in == "short" and side == "short")
         )
         if with_breakout:
-            # Brooks: chase the breakout *only* on a confirmed pullback
-            # ("BO + BP"). Naked breakout-on-breakout (ii/iii / measured
-            # move alone) trades the spike, which usually mean-reverts.
-            if "breakout_pullback" in types:
+            # Brooks: a fresh breakout's first leg is exactly the move we
+            # want to ride. Accept any with-breakout continuation pattern
+            # — H1/H2/H3 (or L1/L2/L3) pullbacks, ii/iii breakouts,
+            # bp_long / bp_short, measured_move, micro_channel — plus a
+            # structurally-aligned reversal entry (double_bottom on a
+            # long-side breakout / double_top on a short-side one). A
+            # narrower "BO + BP only" gate dropped the entire first-leg
+            # run-up that drives strong-breakout days.
+            with_breakout_reversals = (
+                {"double_bottom"} if always_in == "long" else {"double_top"}
+            )
+            allowed = (CONTINUATION_TYPES & types) | (with_breakout_reversals & types)
+            if allowed:
                 return ContextDecision(
                     allow=True,
-                    reason="breakout_with_direction_bp",
+                    reason=f"breakout_with_direction_continuation: {sorted(allowed)}",
                     **base,
                 )
             return ContextDecision(
                 allow=False,
                 reason=(
-                    f"breakout_needs_pullback_re_entry: types={sorted(types)}"
+                    f"breakout_with_direction_no_continuation: types={sorted(types)}"
                 ),
                 **base,
             )
-        # Counter-breakout — allow only the explicit failed-breakout package.
-        if types & {"failed_breakout", "wedge", "double_top", "double_bottom"}:
+        # Counter-breakout — pure counter-direction continuation patterns
+        # (e.g. an H/L pullback against a fresh breakout) are rejected by
+        # default; allow only when a reversal package is present
+        # (failed_breakout / wedge / double / mtr / final_flag — any of
+        # the climax-exhaustion-style markers in REVERSAL_TYPES).
+        reversal_hits = types & REVERSAL_TYPES
+        if "failed_breakout" in reversal_hits:
             return ContextDecision(
                 allow=True,
-                reason=(
-                    f"breakout_failure_reversal: "
-                    f"{sorted(types & (REVERSAL_TYPES | {'failed_breakout'}))}"
-                ),
+                reason=f"breakout_failure_reversal: {sorted(reversal_hits)}",
+                **base,
+            )
+        if reversal_hits:
+            return ContextDecision(
+                allow=True,
+                reason=f"counter_breakout_reversal_package: {sorted(reversal_hits)}",
                 **base,
             )
         return ContextDecision(

--- a/tests/brooks/test_context_filter.py
+++ b/tests/brooks/test_context_filter.py
@@ -434,9 +434,19 @@ def test_broad_range_blocks_naked_breakout():
 # ---------------------------------------------------------------------------
 
 
-def test_breakout_requires_pullback_re_entry():
+def test_breakout_with_direction_allows_bp_and_continuation():
+    """First-leg follow-through patterns ride a fresh breakout.
+
+    The earlier "BO + BP only" gate dropped same-direction H1/H2/H3 and
+    ii/iii_breakout signals on real strong-breakout sessions (QUA-71:
+    2025-01-20 lost the 8k spike). With the relaxed rule any
+    with-breakout continuation pattern passes, while structurally-
+    aligned reversals (double_bottom in a long breakout) also go
+    through.
+    """
     cf = ContextFilter()
     s = _structure(always_in="long", leg_dir="up")
+
     bp = _check(
         cf,
         side="long",
@@ -444,8 +454,19 @@ def test_breakout_requires_pullback_re_entry():
         regime=BrooksRegime.BREAKOUT_MODE,
         structure=s,
     )
-    assert bp.allow
-    assert "breakout_with_direction_bp" in bp.reason
+    assert bp.allow, bp.reason
+    assert "breakout_with_direction_continuation" in bp.reason
+
+    h2 = _check(
+        cf,
+        side="long",
+        patterns=["h2"],
+        regime=BrooksRegime.BREAKOUT_MODE,
+        structure=s,
+    )
+    assert h2.allow, h2.reason
+    assert "breakout_with_direction_continuation" in h2.reason
+    assert "pullback" in h2.reason
 
     naked = _check(
         cf,
@@ -454,11 +475,55 @@ def test_breakout_requires_pullback_re_entry():
         regime=BrooksRegime.BREAKOUT_MODE,
         structure=s,
     )
-    assert not naked.allow
-    assert "breakout_needs_pullback_re_entry" in naked.reason
+    assert naked.allow, naked.reason
+    assert "breakout_with_direction_continuation" in naked.reason
+    assert "breakout" in naked.reason
+
+    aligned_reversal = _check(
+        cf,
+        side="long",
+        patterns=["double_bottom"],
+        regime=BrooksRegime.BREAKOUT_MODE,
+        structure=s,
+    )
+    assert aligned_reversal.allow, aligned_reversal.reason
+    assert "double_bottom" in aligned_reversal.reason
 
 
-def test_breakout_counter_needs_failure_pattern():
+def test_breakout_with_direction_short_continuation():
+    """Mirror of the long-side check: bear breakout + L2 short rides."""
+    cf = ContextFilter()
+    s = _structure(always_in="short", leg_dir="down")
+    res = _check(
+        cf,
+        side="short",
+        patterns=["l2"],
+        regime=BrooksRegime.BREAKOUT_MODE,
+        structure=s,
+    )
+    assert res.allow, res.reason
+    assert "breakout_with_direction_continuation" in res.reason
+
+
+def test_breakout_with_direction_unknown_pattern_rejected():
+    """Same-direction signal whose pattern_type is neither continuation
+    nor an aligned reversal still fails — we should not paper over an
+    unknown detector by treating breakout mode as a free pass."""
+    cf = ContextFilter()
+    s = _structure(always_in="long", leg_dir="up")
+    res = cf.check(
+        side="long",
+        signals=[_signal("not_a_real_detector", "long")],
+        regime=BrooksRegime.BREAKOUT_MODE,
+        structure=s,
+    )
+    assert not res.allow
+    assert "breakout_with_direction_no_continuation" in res.reason
+
+
+def test_breakout_counter_pure_pullback_rejected():
+    """Counter-direction L2 against a fresh long breakout — no reversal
+    package present, so default-reject."""
     cf = ContextFilter()
     s = _structure(always_in="long", leg_dir="up")
     res = _check(
@@ -470,6 +535,37 @@ def test_breakout_counter_needs_failure_pattern():
     )
     assert not res.allow
     assert "counter_breakout_needs_failure" in res.reason
+
+
+def test_breakout_counter_with_climax_exhaustion_allowed():
+    """Counter-direction signal stacked with a climax-exhaustion marker
+    (final_flag / mtr) is allowed — it's the failed-breakout-style fade
+    that reversed QUA-70's 2025-01-20 morning spike. Without this carve-
+    out the ``REVERSAL_TYPES`` final_flag / mtr would still be dropped
+    by the old ``{failed_breakout, wedge, double_*}`` allow-list."""
+    cf = ContextFilter()
+    s = _structure(always_in="long", leg_dir="up")
+
+    final_flag_combo = _check(
+        cf,
+        side="short",
+        patterns=["l2", "final_flag"],
+        regime=BrooksRegime.BREAKOUT_MODE,
+        structure=s,
+    )
+    assert final_flag_combo.allow, final_flag_combo.reason
+    assert "counter_breakout_reversal_package" in final_flag_combo.reason
+    assert "final_flag" in final_flag_combo.reason
+
+    mtr_combo = _check(
+        cf,
+        side="short",
+        patterns=["l2", "mtr_short"],
+        regime=BrooksRegime.BREAKOUT_MODE,
+        structure=s,
+    )
+    assert mtr_combo.allow, mtr_combo.reason
+    assert "counter_breakout_reversal_package" in mtr_combo.reason
 
 
 def test_breakout_counter_failure_allowed():


### PR DESCRIPTION
## Summary

- BREAKOUT_MODE rule previously allowed only `bp_long`/`bp_short` on the with-breakout side, rejecting `H1/H2/H3` pullbacks and `ii/iii_breakout` follow-throughs that fire on the breakout's first leg. QUA-70's 2025-01-20 BTCUSDT 5m session lost the entire 8k spike PnL (+10,986 → -37) because of this.
- `_check_breakout` now allows any with-breakout `CONTINUATION_TYPES` pattern plus the structurally-aligned reversal entry (`double_bottom` on long breakout, `double_top` on short).
- Counter-breakout signals still default-reject; `failed_breakout` keeps its own allow path, and any other reversal type (`wedge` / `double` / `mtr` / `final_flag`) now also lets a counter-direction stack through (climax-exhaustion fade).
- Other 8 regime rules untouched per QUA-71 scope.

## Replay numbers (BTCUSDT 5m, scripts/brooks_context_filter_replay_compare.py @ e8f22f6)

| Session | Indicator | Old (no CF) | NEW (QUA-71 fix) |
|---|---|---|---|
| Trend 2025-01-15 | Trades filled | 34 | 21 |
| | Win rate | 55.2% | 55.6% |
| | Realised PnL | -2192.32 | **+1394.64** |
| Tight-range 2025-01-04 | Trades filled | 31 | 25 |
| | Win rate | 55.6% | **66.7%** |
| | Realised PnL | +853.30 | +967.15 |
| Breakout 2025-01-20 | Trades filled | 23 | 14 |
| | Win rate | 66.7% | 50.0% |
| | Realised PnL | +10,986.19 | -1,400.20 |

Trend day ≥ +1,000 ✅, range win-rate ≥ 65% ✅, three-session net positive (+961). Breakout day **does not hit the +5,000 acceptance bar** — see test plan note.

## Test plan
- [x] `pytest tests/brooks/test_context_filter.py` — 34/34 pass (5 new BREAKOUT_MODE cases: same-direction h2 / ii_breakout / l2_short, counter l2 + final_flag, counter l2 + mtr_short, aligned double_bottom)
- [x] `pytest tests/brooks/` (excluding env-specific failures: tiktoken / pyarrow / talib unrelated to this PR) — 427 passing
- [ ] **Heads-up**: regime instrumentation on 2025-01-20 shows `BREAKOUT_MODE` only fires on 10/289 bars (02:15-02:35 long, 12:10-12:30 short). The morning 8k spike (06:30-08:30) is classified `weak_bull_trend` for the entire pump and `climax` for 2 bars at the peak. Loosening BREAKOUT_MODE alone therefore can't recover the +10,986 OLD PnL — that's why this PR delivers the spec'd BREAKOUT_MODE fix but breakout-day PnL only moves from -37 (QUA-70 baseline) to -1,400 (one extra `breakout_with_direction_continuation` short took a loss). The remaining gap is a regime-classifier or weak-trend-rule problem that's out of QUA-71's stated scope (`其他 8 种 regime 规则完全保留`); follow-up issue recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)